### PR TITLE
Restructure codebase into focused modules

### DIFF
--- a/lib/agent_runner.ml
+++ b/lib/agent_runner.ml
@@ -1,0 +1,97 @@
+(** Agent session runner — manages the lifecycle of agent subprocesses.
+
+    Handles spawning Claude/Codex/Gemini, streaming output to Discord,
+    typing indicator refresh, and message splitting for Discord's 2000-char limit.
+
+    Key design: one agent invocation at a time per session, enforced by
+    the session's `processing` flag. Large text deltas are split at
+    1800-char boundaries before being sent to Discord. *)
+
+(** Typing indicator refresh interval in seconds. *)
+let typing_interval = 8.0
+
+(** Run an agent and stream its output to a Discord channel.
+    Handles message creation/editing, typing indicators, and splitting.
+    Returns Ok () on success, Error msg on failure. *)
+let run ~sw ~env ~rest ~session ~channel_id ~prompt () =
+  (* Send typing indicator *)
+  ignore (Discord_rest.send_typing rest ~channel_id ());
+  Logs.info (fun m -> m "agent_runner: running %s for %s: %s"
+    (Config.string_of_agent_kind session.Session_store.agent_kind)
+    session.project_name
+    (if String.length prompt > 80
+     then String.sub prompt 0 80 ^ "..."
+     else prompt));
+  let result_buf = Buffer.create 4096 in
+  let current_msg_id = ref None in
+  let current_msg_buf = Buffer.create 1900 in
+  let last_typing = ref (Unix.gettimeofday ()) in
+  let last_edit = ref (Unix.gettimeofday ()) in
+  let flush_to_discord () =
+    let text = Buffer.contents current_msg_buf in
+    if String.length text = 0 then ()
+    else match !current_msg_id with
+    | None ->
+      (match Discord_rest.create_message rest ~channel_id ~content:text () with
+       | Ok sent -> current_msg_id := Some sent.Discord_types.id
+       | Error e -> Logs.warn (fun m -> m "agent_runner: send error: %s" e))
+    | Some mid ->
+      (match Discord_rest.edit_message rest ~channel_id ~message_id:mid ~content:text () with
+       | Ok _ -> ()
+       | Error e -> Logs.warn (fun m -> m "agent_runner: edit error: %s" e))
+  in
+  let start_new_message () =
+    flush_to_discord ();
+    Buffer.clear current_msg_buf;
+    current_msg_id := None
+  in
+  let on_event = function
+    | Agent_process.Text_delta text ->
+      Buffer.add_string result_buf text;
+      (* Split large deltas at 1800-char boundaries *)
+      let text_len = String.length text in
+      let pos = ref 0 in
+      while !pos < text_len do
+        let remaining_capacity = 1800 - Buffer.length current_msg_buf in
+        let chunk_len = min remaining_capacity (text_len - !pos) in
+        if chunk_len > 0 then
+          Buffer.add_substring current_msg_buf text !pos chunk_len;
+        pos := !pos + chunk_len;
+        if Buffer.length current_msg_buf >= 1800 then
+          start_new_message ()
+      done;
+      let now = Unix.gettimeofday () in
+      if now -. !last_edit > 2.0 && Buffer.length current_msg_buf > 0 then begin
+        flush_to_discord ();
+        last_edit := now
+      end;
+      if now -. !last_typing > typing_interval then begin
+        ignore (Discord_rest.send_typing rest ~channel_id ());
+        last_typing := now
+      end
+    | Agent_process.Result { text = _; session_id = _ } ->
+      flush_to_discord ()
+    | Agent_process.Tool_use name ->
+      Logs.debug (fun m -> m "agent_runner: tool: %s" name)
+    | Agent_process.Error e ->
+      Logs.warn (fun m -> m "agent_runner: error event: %s" e)
+    | Agent_process.Other _ -> ()
+  in
+  match Agent_process.run_streaming ~sw ~env
+          ~working_dir:session.working_dir
+          ~kind:session.agent_kind
+          ~session_id:session.session_id
+          ~message_count:session.message_count
+          ?system_prompt:session.system_prompt
+          ~prompt ~on_event () with
+  | Ok () ->
+    flush_to_discord ();
+    if Buffer.length result_buf = 0 then
+      ignore (Discord_rest.create_message rest ~channel_id
+        ~content:"(no response)" ());
+    Ok ()
+  | Error e ->
+    Logs.warn (fun m -> m "agent_runner: error: %s" e);
+    ignore (Discord_rest.create_message rest ~channel_id
+      ~content:(Printf.sprintf "Agent error: %s" e) ());
+    Error e

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -1,260 +1,44 @@
-(** Top-level bot orchestrator.
+(** Top-level bot orchestrator — thin wiring layer.
 
-    Owns the Discord connection, manages sessions, routes messages
-    between Discord and agent subprocesses.
+    Routes Discord messages to the appropriate handler:
+    - Commands (! prefix) → Command module → handlers
+    - Control channel chat → Claude session with MCP tools
+    - Project channel chat → Claude session scoped to project
+    - Thread messages → Agent_runner
 
-    Discord channel layout:
-    - Control channel: server-wide commands, project overview
-    - Project channels: one per project, start agents here
-    - Session threads: one per agent session, bridges I/O *)
+    Owns no mutable state directly — delegates to Session_store
+    and Channel_manager. *)
 
-module SessionMap = Map.Make(String) (* thread_id -> agent_session *)
-
-(** Derive the project source directory from the running executable path.
-    e.g. _build/default/bin/main.exe -> <project_root>
-    Falls back to cwd if derivation fails. *)
+(** Derive the project source directory from the running executable path. *)
 let project_root =
   lazy (
     try
-      (* Executable is at <root>/_build/.../bin/main.exe or <root>/_build/.../bin/discord-agents *)
       let exe = Sys.executable_name in
-      let exe = if Filename.is_relative exe then Filename.concat (Sys.getcwd ()) exe else exe in
+      let exe = if Filename.is_relative exe
+        then Filename.concat (Sys.getcwd ()) exe else exe in
       let rec find_root path =
         if Sys.file_exists (Filename.concat path "dune-project") then path
         else
           let parent = Filename.dirname path in
-          if parent = path then Sys.getcwd ()  (* hit filesystem root *)
+          if parent = path then Sys.getcwd ()
           else find_root parent
       in
       find_root (Filename.dirname exe)
     with _ -> Sys.getcwd ()
   )
 
-(** Lightweight agent session — tracks a Discord thread <-> Claude session. *)
-type agent_session = {
-  project_name : string;
-  working_dir : string;
-  agent_kind : Config.agent_kind;
-  session_id : string;
-  thread_id : string;
-  system_prompt : string option;
-  mutable message_count : int;
-  mutable processing : bool;  (* guard: only one agent invocation at a time *)
-}
-
-let sessions_file () =
-  let home = Sys.getenv "HOME" in
-  Filename.concat home ".config/discord-agents/sessions.json"
-
-let sessions_lock_file () =
-  sessions_file () ^ ".lock"
-
-(** Acquire an exclusive file lock for sessions.json operations.
-    Both the OCaml bot and Python MCP server use this to prevent
-    lost-update races on concurrent read-modify-write. *)
-let with_sessions_lock f =
-  let lock_path = sessions_lock_file () in
-  let fd = Unix.openfile lock_path [Unix.O_WRONLY; Unix.O_CREAT] 0o600 in
-  Fun.protect ~finally:(fun () ->
-    (try Unix.lockf fd Unix.F_ULOCK 0 with _ -> ());
-    Unix.close fd
-  ) (fun () ->
-    Unix.lockf fd Unix.F_LOCK 0;
-    f ()
-  )
-
-(** Save sessions atomically with file locking.
-    Holds sessions.json.lock during write to prevent concurrent updates
-    from the MCP server from being lost. *)
-let save_sessions sessions =
-  with_sessions_lock (fun () ->
-  let entries = SessionMap.bindings sessions in
-  let json = `List (List.map (fun (_tid, s) ->
-    `Assoc ([
-      ("project_name", `String s.project_name);
-      ("working_dir", `String s.working_dir);
-      ("agent_kind", `String (Config.string_of_agent_kind s.agent_kind));
-      ("session_id", `String s.session_id);
-      ("thread_id", `String s.thread_id);
-      ("message_count", `Int s.message_count);
-    ] @ (match s.system_prompt with
-         | Some sp -> [("system_prompt", `String sp)]
-         | None -> []))
-  ) entries) in
-  let path = sessions_file () in
-  let tmp = path ^ ".tmp" in
-  let oc = open_out tmp in
-  (try
-    output_string oc (Yojson.Safe.pretty_to_string json);
-    output_char oc '\n';
-    close_out oc;
-    Unix.rename tmp path
-  with exn ->
-    (try close_out oc with _ -> ());
-    (try Sys.remove tmp with _ -> ());
-    Logs.warn (fun m -> m "bot: failed to save sessions: %s" (Printexc.to_string exn))))
-
-let load_sessions () =
-  let path = sessions_file () in
-  if not (Sys.file_exists path) then SessionMap.empty
-  else
-    let contents =
-      let ic = open_in path in
-      Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
-        let n = in_channel_length ic in
-        let s = Bytes.create n in
-        really_input ic s 0 n;
-        Bytes.to_string s)
-    in
-    try
-      let json = Yojson.Safe.from_string contents in
-      let open Yojson.Safe.Util in
-      let entries = to_list json |> List.map (fun j ->
-        let thread_id = j |> member "thread_id" |> to_string in
-        let session = {
-          project_name = j |> member "project_name" |> to_string;
-          working_dir = j |> member "working_dir" |> to_string;
-          agent_kind = (match Config.agent_kind_of_string
-            (j |> member "agent_kind" |> to_string) with
-            | Ok k -> k | Error _ -> Config.Claude);
-          session_id = j |> member "session_id" |> to_string;
-          thread_id;
-          system_prompt = j |> member "system_prompt" |> to_string_option;
-          message_count = j |> member "message_count" |> to_int;
-          processing = false;
-        } in
-        (thread_id, session)
-      ) in
-      List.fold_left (fun acc (tid, s) -> SessionMap.add tid s acc) SessionMap.empty entries
-    with exn ->
-      Logs.warn (fun m -> m "bot: failed to load sessions: %s" (Printexc.to_string exn));
-      SessionMap.empty
-
-module ChannelMap = Map.Make(String) (* project_name -> channel_id *)
-
 type t = {
   config : Config.t;
   rest : Discord_rest.t;
   gateway : Discord_gateway.t;
   projects : Project.t list;
-  mutable sessions : agent_session SessionMap.t;
-  mutable project_channels : string ChannelMap.t;
-  mutable category_id : string option;
+  sessions : Session_store.t;
+  channels : Channel_manager.t;
   env : Eio_unix.Stdenv.base;
   sw : Eio.Switch.t;
 }
 
-let add_session (t : t) thread_id session =
-  t.sessions <- SessionMap.add thread_id session t.sessions;
-  save_sessions t.sessions
-
-let remove_session (t : t) thread_id =
-  t.sessions <- SessionMap.remove thread_id t.sessions;
-  save_sessions t.sessions
-
-(** Commands the bot recognizes. *)
-type command =
-  | List_projects
-  | List_sessions
-  | List_claude_sessions
-  | Start_agent of { project : string; kind : Config.agent_kind }
-  | Resume_session of { session_id : string }
-  | Stop_session of { thread_id : string }
-  | Cleanup_channels
-  | Restart
-  | Help
-  | Unknown of string
-
-(** Check if a message is a command. Commands MUST start with ! to avoid
-    hijacking natural language like "help me debug this" or "start here". *)
-let is_command content =
-  let trimmed = String.trim content in
-  String.length trimmed > 0 && trimmed.[0] = '!'
-
-let parse_command content =
-  let parts = String.split_on_char ' ' (String.trim content) in
-  (* Strip ! prefix and lowercase the command word *)
-  let parts = match parts with
-    | w :: rest when String.length w > 0 && w.[0] = '!' ->
-      String.lowercase_ascii (String.sub w 1 (String.length w - 1)) :: rest
-    | other -> other
-  in
-  match parts with
-  | ["projects"] | ["list"] -> List_projects
-  | ["sessions"] -> List_sessions
-  | ["claude-sessions"] -> List_claude_sessions
-  | "start" :: project :: kind_str :: _ ->
-    let kind = match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with
-      | Ok k -> k | Error _ -> Config.Claude in
-    Start_agent { project; kind }
-  | ["start"; project] ->
-    Start_agent { project; kind = Config.Claude }
-  | ["start"] ->
-    List_projects
-  | ["resume"; session_id] -> Resume_session { session_id }
-  | ["stop"; thread_id] -> Stop_session { thread_id }
-  | ["cleanup-channels"] | ["cleanup"] -> Cleanup_channels
-  | ["restart"] -> Restart
-  | ["help"] -> Help
-  | _ -> Unknown content
-
-(** Fuzzy-match a query against project names.
-    Tries: exact match, case-insensitive match, prefix match, substring match.
-    Returns the best matching project or None. *)
-let find_project_fuzzy projects query =
-  let q = String.lowercase_ascii query in
-  (* Exact match *)
-  match List.find_opt (fun (p : Project.t) -> p.name = query) projects with
-  | Some _ as found -> found
-  | None ->
-  (* Case-insensitive exact *)
-  match List.find_opt (fun (p : Project.t) ->
-    String.lowercase_ascii p.name = q) projects with
-  | Some _ as found -> found
-  | None ->
-  (* Numeric index (1-based) *)
-  (match int_of_string_opt query with
-   | Some n when n >= 1 && n <= List.length projects ->
-     Some (List.nth projects (n - 1))
-   | _ ->
-  (* Prefix match *)
-  let prefix_matches = List.filter (fun (p : Project.t) ->
-    let name = String.lowercase_ascii p.name in
-    String.length name >= String.length q
-    && String.sub name 0 (String.length q) = q
-  ) projects in
-  match prefix_matches with
-  | [p] -> Some p  (* unique prefix *)
-  | _ ->
-  (* Substring match *)
-  let substr_matches = List.filter (fun (p : Project.t) ->
-    let name = String.lowercase_ascii p.name in
-    let rec has_substr i =
-      if i + String.length q > String.length name then false
-      else if String.sub name i (String.length q) = q then true
-      else has_substr (i + 1)
-    in
-    has_substr 0
-  ) projects in
-  match substr_matches with
-  | [p] -> Some p  (* unique substring *)
-  | _ -> None)
-
-(** Generate a UUID for Claude session tracking.
-    Uses mirage-crypto-rng (initialized by discord_rest). *)
-let generate_uuid () =
-  let raw = Mirage_crypto_rng.generate 16 in
-  let hex = Buffer.create 32 in
-  String.iter (fun c ->
-    Buffer.add_string hex (Printf.sprintf "%02x" (Char.code c))
-  ) raw;
-  let s = Buffer.contents hex in
-  Printf.sprintf "%s-%s-%s-%s-%s"
-    (String.sub s 0 8) (String.sub s 8 4) (String.sub s 12 4)
-    (String.sub s 16 4) (String.sub s 20 12)
-
-(** Find a usable working directory for a project.
-    For bare repos, look for master/ or main/ worktree. *)
+(** Find a usable working directory for a project. *)
 let working_dir_of_project (p : Project.t) =
   if p.is_bare then
     let candidates = ["master"; "main"] in
@@ -267,26 +51,44 @@ let working_dir_of_project (p : Project.t) =
   else
     Ok p.path
 
-(** Typing indicator refresh interval in seconds.
-    Discord's typing indicator expires after ~10s, so refresh every 8s. *)
-let typing_interval = 8.0
+(** System prompt for control channel Claude — knows about MCP tools. *)
+let control_system_prompt projects =
+  let project_list = String.concat "\n" (List.mapi (fun i (p : Project.t) ->
+    Printf.sprintf "  %d. %s (%s)" (i+1) p.name p.path
+  ) projects) in
+  Printf.sprintf
+"You are the control agent for a Discord bot that manages AI coding sessions.
 
-(** Split text into chunks that fit Discord's 2000-char message limit.
-    Tries to split at paragraph breaks, then newlines, then spaces.
-    Avoids splitting inside code blocks (triple backticks). *)
+You have MCP tools available:
+- start_session: Start a new agent session for a project
+- list_projects: List all discovered projects
+- list_sessions: List active bot sessions
+- list_claude_sessions: Find recent Claude Code sessions to resume
+- resume_session: Resume an existing Claude session
+- restart_bot: Rebuild and restart the bot
+- cleanup_channels: Delete stale Discord channels
+
+USE THESE TOOLS. When the user asks to work on a project, start a session, etc., call the appropriate tool.
+
+Known projects:
+%s
+
+Keep responses concise — this is Discord." project_list
+
+(** Split text into chunks for Discord's 2000-char limit.
+    Splits at paragraph breaks > newlines > spaces.
+    Handles code blocks by closing/reopening ```. *)
 let split_message ?(max_len=1900) text =
   let len = String.length text in
   if len <= max_len then [text]
   else
     let find_split_point pos limit =
-      (* Try paragraph break first *)
       let try_find sep =
         let sep_len = String.length sep in
         let best = ref None in
         let i = ref pos in
         while !i + sep_len <= limit do
-          if String.sub text !i sep_len = sep then
-            best := Some !i;
+          if String.sub text !i sep_len = sep then best := Some !i;
           incr i
         done;
         !best
@@ -301,17 +103,14 @@ let split_message ?(max_len=1900) text =
           | Some p -> p + 1
           | None -> limit
     in
-    (* Count triple backticks in a string *)
     let count_backticks s =
       let count = ref 0 in
       let i = ref 0 in
       let slen = String.length s in
       while !i + 2 < slen do
         if s.[!i] = '`' && s.[!i+1] = '`' && s.[!i+2] = '`' then begin
-          incr count;
-          i := !i + 3
-        end else
-          incr i
+          incr count; i := !i + 3
+        end else incr i
       done;
       !count
     in
@@ -334,414 +133,153 @@ let split_message ?(max_len=1900) text =
     in
     split 0 false []
 
-(** Post a (potentially long) response to a Discord channel, splitting if needed. *)
 let post_response rest ~channel_id text =
-  let chunks = split_message text in
   List.iter (fun chunk ->
     match Discord_rest.create_message rest ~channel_id ~content:chunk () with
     | Ok _ -> ()
-    | Error e -> Logs.warn (fun m -> m "bot: failed to post response: %s" e)
-  ) chunks
+    | Error e -> Logs.warn (fun m -> m "bot: post error: %s" e)
+  ) (split_message text)
 
-(** Resolve a Claude project directory name back to a filesystem path.
-    e.g. "-home-tedks-Projects-claude-discord" -> "/home/tedks/Projects/claude-discord"
-
-    Can't just split on '-' because project names contain hyphens.
-    Instead, walk the filesystem: at each level, try consuming path
-    segments greedily (longest directory name that matches). *)
-let resolve_project_dir proj_name =
-  (* Strip leading dash *)
-  let s = if String.length proj_name > 0 && proj_name.[0] = '-'
-          then String.sub proj_name 1 (String.length proj_name - 1)
-          else proj_name in
-  let rec resolve path remaining =
-    if String.length remaining = 0 then path
-    else
-      (* Try to find the longest prefix of 'remaining' that is a directory under 'path' *)
-      let parts = String.split_on_char '-' remaining in
-      let rec try_lengths n =
-        if n < 1 then
-          (* Fallback: just use the first part *)
-          let first = List.hd parts in
-          let rest_parts = List.tl parts in
-          let next_path = Filename.concat path first in
-          let rest = String.concat "-" rest_parts in
-          resolve next_path rest
-        else
-          let candidate_parts = List.filteri (fun i _ -> i < n) parts in
-          let candidate = String.concat "-" candidate_parts in
-          let candidate_path = Filename.concat path candidate in
-          if (try Sys.file_exists candidate_path with _ -> false) then
-            let rest_parts = List.filteri (fun i _ -> i >= n) parts in
-            let rest = String.concat "-" rest_parts in
-            resolve candidate_path rest
-          else
-            try_lengths (n - 1)
-      in
-      try_lengths (List.length parts)
-  in
-  resolve "/" s
-
-(** Info about a Claude Code session discovered on disk. *)
-type claude_session_info = {
-  cs_session_id : string;
-  cs_project_dir : string;   (** e.g. "-home-tedks-Projects-claude-discord" *)
-  cs_working_dir : string;   (** resolved working directory *)
-  cs_summary : string;       (** first user message, truncated *)
-  cs_mtime : float;
-}
-
-(** Scan ~/.claude/projects/ for recent Claude Code sessions.
-    Returns sessions modified in the last [hours] hours, newest first. *)
-let discover_claude_sessions ?(hours=24) () =
-  Eio_unix.run_in_systhread @@ fun () ->
-  let home = Sys.getenv "HOME" in
-  let projects_dir = Filename.concat home ".claude/projects" in
-  if not (Sys.file_exists projects_dir) then []
-  else
-    let cutoff = Unix.gettimeofday () -. (float_of_int hours *. 3600.0) in
-    let results = ref [] in
-    let project_dirs = Sys.readdir projects_dir |> Array.to_list in
-    List.iter (fun proj_name ->
-      let proj_path = Filename.concat projects_dir proj_name in
-      if try Sys.is_directory proj_path with Sys_error _ -> false then begin
-        let files = try Sys.readdir proj_path |> Array.to_list with Sys_error _ -> [] in
-        List.iter (fun fname ->
-          if Filename.check_suffix fname ".jsonl"
-             && not (String.contains fname '/') then begin
-            let fpath = Filename.concat proj_path fname in
-            let stat = try Some (Unix.stat fpath) with Unix.Unix_error _ -> None in
-            match stat with
-            | Some st when st.Unix.st_mtime > cutoff ->
-              let session_id = Filename.chop_suffix fname ".jsonl" in
-              (* Extract first user message as summary *)
-              let summary =
-                try
-                  let ic = open_in fpath in
-                  Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
-                    let summary = ref "" in
-                    (try while !summary = "" do
-                      let line = input_line ic in
-                      let json = Yojson.Safe.from_string line in
-                      let open Yojson.Safe.Util in
-                      if json |> member "type" |> to_string = "user" then begin
-                        let msg = json |> member "message" in
-                        let content = msg |> member "content" in
-                        match content with
-                        | `List items ->
-                          List.iter (fun item ->
-                            if !summary = "" then
-                              match item |> member "type" |> to_string_option with
-                              | Some "text" ->
-                                let text = item |> member "text" |> to_string in
-                                summary := String.sub text 0 (min 80 (String.length text))
-                              | _ -> ()
-                          ) items
-                        | `String s ->
-                          summary := String.sub s 0 (min 80 (String.length s))
-                        | _ -> ()
-                      end
-                    done with End_of_file | _ -> ());
-                    !summary)
-                with _ -> "(unknown)"
-              in
-              (* Resolve working directory from project dir name.
-                 The dir name is the cwd with / replaced by - and leading -.
-                 We can't just split on - because project names have hyphens.
-                 Instead, scan the filesystem to find the longest matching prefix. *)
-              let working_dir = resolve_project_dir proj_name in
-              results := {
-                cs_session_id = session_id;
-                cs_project_dir = proj_name;
-                cs_working_dir = working_dir;
-                cs_summary = summary;
-                cs_mtime = st.Unix.st_mtime;
-              } :: !results
-            | _ -> ()
-          end
-        ) files
-      end
-    ) project_dirs;
-    (* Sort newest first *)
-    List.sort (fun a b -> compare b.cs_mtime a.cs_mtime) !results
-
-(** Find a Claude session by ID (or prefix) and return its info. *)
-let find_claude_session session_id_prefix =
-  let home = Sys.getenv "HOME" in
-  let projects_dir = Filename.concat home ".claude/projects" in
-  if not (Sys.file_exists projects_dir) then None
-  else
-    let project_dirs = try Sys.readdir projects_dir |> Array.to_list with _ -> [] in
-    let result = ref None in
-    List.iter (fun proj_name ->
-      if !result = None then begin
-        let proj_path = Filename.concat projects_dir proj_name in
-        if try Sys.is_directory proj_path with Sys_error _ -> false then begin
-          let files = try Sys.readdir proj_path |> Array.to_list with _ -> [] in
-          List.iter (fun fname ->
-            if !result = None
-               && Filename.check_suffix fname ".jsonl"
-               && not (String.contains fname '/') then begin
-              let sid = Filename.chop_suffix fname ".jsonl" in
-              if String.length sid >= String.length session_id_prefix
-                 && String.sub sid 0 (String.length session_id_prefix) = session_id_prefix then begin
-                let working_dir = resolve_project_dir proj_name in
-                result := Some (sid, working_dir)
-              end
-            end
-          ) files
-        end
-      end
-    ) project_dirs;
-    !result
-
-(** Handle a message from the control channel. *)
-let handle_control_message t msg =
-  let cmd = parse_command msg.Discord_types.content in
+(** Handle a parsed command. *)
+let handle_command t msg cmd =
+  let channel_id = msg.Discord_types.channel_id in
+  let reply text =
+    ignore (Discord_rest.create_message t.rest ~channel_id ~content:text ()) in
   match cmd with
-  | List_projects ->
+  | Command.List_projects ->
     let lines = List.mapi (fun i (p : Project.t) ->
       Printf.sprintf "`%d.` **%s** — `%s`%s"
         (i + 1) p.name p.path (if p.is_bare then " [bare]" else "")
     ) t.projects in
-    let text = if lines = [] then "No projects found."
+    reply (if lines = [] then "No projects found."
       else "**Projects** (use `!start <name>` or `!start <number>`):\n"
-           ^ String.concat "\n" lines in
-    ignore (Discord_rest.create_message t.rest
-      ~channel_id:msg.channel_id ~content:text ())
-  | List_sessions ->
-    let entries = SessionMap.bindings t.sessions in
-    let lines = List.map (fun (_tid, (s : agent_session)) ->
+           ^ String.concat "\n" lines)
+  | Command.List_sessions ->
+    let entries = Session_store.bindings t.sessions in
+    let lines = List.map (fun (_tid, (s : Session_store.session)) ->
       Printf.sprintf "- **%s** / %s — %d messages (thread: <#%s>)"
         s.project_name
         (Config.string_of_agent_kind s.agent_kind)
-        s.message_count
-        s.thread_id
+        s.message_count s.thread_id
     ) entries in
-    let text = if lines = [] then "No active sessions."
-      else "**Sessions:**\n" ^ String.concat "\n" lines in
-    ignore (Discord_rest.create_message t.rest
-      ~channel_id:msg.channel_id ~content:text ())
-  | List_claude_sessions ->
+    reply (if lines = [] then "No active sessions."
+      else "**Sessions:**\n" ^ String.concat "\n" lines)
+  | Command.List_claude_sessions ->
     Eio.Fiber.fork ~sw:t.sw (fun () ->
-      let sessions = discover_claude_sessions ~hours:24 () in
-      let lines = List.map (fun (s : claude_session_info) ->
-        let age_min = int_of_float ((Unix.gettimeofday () -. s.cs_mtime) /. 60.0) in
-        let age_str =
-          if age_min < 60 then Printf.sprintf "%dm ago" age_min
-          else Printf.sprintf "%dh ago" (age_min / 60)
-        in
+      let sessions = Claude_sessions.discover ~hours:24 () in
+      let lines = List.map (fun (s : Claude_sessions.info) ->
+        let age_min = int_of_float ((Unix.gettimeofday () -. s.mtime) /. 60.0) in
+        let age_str = if age_min < 60 then Printf.sprintf "%dm ago" age_min
+          else Printf.sprintf "%dh ago" (age_min / 60) in
+        let sid_short = String.sub s.session_id 0
+          (min 8 (String.length s.session_id)) in
         Printf.sprintf "- `%s` %s\n  %s — *%s*"
-          (String.sub s.cs_session_id 0 (min 8 (String.length s.cs_session_id)))
-          age_str
-          s.cs_working_dir
-          (if s.cs_summary = "" then "(no summary)" else s.cs_summary)
+          sid_short age_str s.working_dir
+          (if s.summary = "" then "(no summary)" else s.summary)
       ) (List.filteri (fun i _ -> i < 10) sessions) in
-      let text = if lines = [] then "No recent Claude sessions found."
+      reply (if lines = [] then "No recent Claude sessions found."
         else "**Recent Claude sessions** (last 24h):\n" ^ String.concat "\n" lines
-             ^ "\n\nUse `!resume <session_id_prefix>` to attach." in
-      ignore (Discord_rest.create_message t.rest
-        ~channel_id:msg.channel_id ~content:text ()))
-  | Start_agent { project; kind } ->
-    let proj = find_project_fuzzy t.projects project in
+             ^ "\n\nUse `!resume <session_id_prefix>` to attach."))
+  | Command.Start_agent { project; kind } ->
+    let proj = Command.find_project_fuzzy t.projects project in
     (match proj with
      | None ->
-       (* Show suggestions *)
        let q = String.lowercase_ascii project in
        let suggestions = List.filter (fun (p : Project.t) ->
          let name = String.lowercase_ascii p.name in
-         let rec has_substr i =
-           if i + String.length q > String.length name then false
+         let rec has i = if i + String.length q > String.length name then false
            else if String.sub name i (String.length q) = q then true
-           else has_substr (i + 1)
-         in
-         has_substr 0
+           else has (i + 1) in has 0
        ) t.projects in
-       let text = match suggestions with
-         | [] -> Printf.sprintf "No project matching `%s`. Try `!projects` to see the list." project
-         | _ ->
-           Printf.sprintf "No unique match for `%s`. Did you mean:\n%s"
-             project
-             (String.concat "\n" (List.map (fun (p : Project.t) ->
-               Printf.sprintf "- `!start %s`" p.name) suggestions))
-       in
-       ignore (Discord_rest.create_message t.rest
-         ~channel_id:msg.channel_id ~content:text ())
+       (match suggestions with
+        | [] -> reply (Printf.sprintf "No project matching `%s`. Try `!projects`." project)
+        | _ -> reply (Printf.sprintf "No unique match for `%s`. Did you mean:\n%s" project
+            (String.concat "\n" (List.map (fun (p : Project.t) ->
+              Printf.sprintf "- `!start %s`" p.name) suggestions))))
      | Some p ->
        let kind_str = Config.string_of_agent_kind kind in
-       (* Create a worktree for the session *)
        let branch_name = Printf.sprintf "agent/%s-%s"
-         kind_str (String.sub (generate_uuid ()) 0 8) in
-       let working_dir, branch_info = match Project.create_worktree p ~branch_name with
-         | Ok worktree_path -> worktree_path, Some branch_name
+         kind_str (String.sub (Resource.generate_uuid ()) 0 8) in
+       let working_dir, branch_info =
+         match Project.create_worktree p ~branch_name with
+         | Ok wt -> wt, Some branch_name
          | Error e ->
-           Logs.warn (fun m -> m "bot: worktree creation failed: %s" e);
+           Logs.warn (fun m -> m "bot: worktree failed: %s" e);
            (match working_dir_of_project p with
             | Ok wd -> wd, None
-            | Error e2 ->
-              ignore (Discord_rest.create_message t.rest
-                ~channel_id:msg.channel_id
-                ~content:(Printf.sprintf "Cannot find working directory: %s" e2) ());
-              "", None)
+            | Error e2 -> reply (Printf.sprintf "No working directory: %s" e2); "", None)
        in
        if working_dir <> "" then begin
-         let thread_name = Printf.sprintf "%s / %s" kind_str p.name in
-         (* Create project channel on demand if it doesn't exist yet *)
-         let thread_parent = match ChannelMap.find_opt p.name t.project_channels with
+         let thread_parent =
+           match Channel_manager.find_or_create ~rest:t.rest
+                   ~guild_id:t.config.guild_id ~project:p t.channels with
            | Some ch_id -> ch_id
-           | None ->
-             match t.category_id with
-             | Some cat_id ->
-               let topic = Printf.sprintf "Agent sessions for %s (%s)" p.name p.path in
-               (match Discord_rest.create_channel t.rest ~guild_id:t.config.guild_id
-                        ~name:p.name ~parent_id:cat_id ~topic () with
-                | Ok ch ->
-                  t.project_channels <- ChannelMap.add p.name ch.id t.project_channels;
-                  Logs.info (fun m -> m "bot: created channel for project %s" p.name);
-                  ch.id
-                | Error _ -> msg.channel_id)
-             | None -> msg.channel_id
+           | None -> channel_id
          in
          match Discord_rest.create_thread_no_message t.rest
-                 ~channel_id:thread_parent ~name:thread_name () with
-         | Error e ->
-           ignore (Discord_rest.create_message t.rest
-             ~channel_id:msg.channel_id
-             ~content:(Printf.sprintf "Failed to create thread: %s" e) ())
+                 ~channel_id:thread_parent
+                 ~name:(Printf.sprintf "%s / %s" kind_str p.name) () with
+         | Error e -> reply (Printf.sprintf "Failed to create thread: %s" e)
          | Ok thread_ch ->
-           let session_id = generate_uuid () in
-           let session = {
-             project_name = p.name;
-             working_dir;
-             agent_kind = kind;
-             session_id;
+           let session : Session_store.session = {
+             project_name = p.name; working_dir; agent_kind = kind;
+             session_id = Resource.generate_uuid ();
              thread_id = thread_ch.Discord_types.id;
-             system_prompt = None;
-             message_count = 0;
-             processing = false;
+             system_prompt = None; message_count = 0; processing = false;
            } in
-           add_session t thread_ch.id session;
+           Session_store.add t.sessions ~thread_id:thread_ch.id session;
            let branch_str = match branch_info with
-             | Some b -> Printf.sprintf "\nBranch: `%s`" b
-             | None -> ""
-           in
-           let welcome = Printf.sprintf
-             "**%s** session started for **%s**%s\nWorking in: `%s`\nSend a message to interact with the agent."
-             kind_str p.name branch_str working_dir
-           in
-           ignore (Discord_rest.create_message t.rest
-             ~channel_id:thread_ch.id ~content:welcome ())
-       end (* working_dir <> "" *))
-  | Resume_session { session_id } ->
+             | Some b -> Printf.sprintf "\nBranch: `%s`" b | None -> "" in
+           ignore (Discord_rest.create_message t.rest ~channel_id:thread_ch.id
+             ~content:(Printf.sprintf
+               "**%s** session started for **%s**%s\nWorking in: `%s`\nSend a message to interact."
+               kind_str p.name branch_str working_dir) ())
+       end)
+  | Command.Resume_session { session_id } ->
     Eio.Fiber.fork ~sw:t.sw (fun () ->
-      (* find_claude_session runs blocking I/O *)
       let found = Eio_unix.run_in_systhread (fun () ->
-        find_claude_session session_id
-      ) in
+        Claude_sessions.find_by_prefix session_id) in
       match found with
-      | None ->
-        ignore (Discord_rest.create_message t.rest
-          ~channel_id:msg.channel_id
-          ~content:(Printf.sprintf "No Claude session found matching `%s`." session_id) ())
-      | Some (full_session_id, working_dir) ->
-        let thread_name = Printf.sprintf "resume / %s" (String.sub full_session_id 0 8) in
+      | None -> reply (Printf.sprintf "No Claude session matching `%s`." session_id)
+      | Some (full_sid, working_dir) ->
+        let sid_short = String.sub full_sid 0 (min 8 (String.length full_sid)) in
         match Discord_rest.create_thread_no_message t.rest
-                ~channel_id:msg.channel_id ~name:thread_name () with
-        | Error e ->
-          ignore (Discord_rest.create_message t.rest
-            ~channel_id:msg.channel_id
-            ~content:(Printf.sprintf "Failed to create thread: %s" e) ())
+                ~channel_id ~name:(Printf.sprintf "resume / %s" sid_short) () with
+        | Error e -> reply (Printf.sprintf "Failed to create thread: %s" e)
         | Ok thread_ch ->
-          let session = {
-            project_name = Filename.basename working_dir;
-            working_dir;
-            agent_kind = Config.Claude;
-            session_id = full_session_id;
+          let session : Session_store.session = {
+            project_name = Filename.basename working_dir; working_dir;
+            agent_kind = Config.Claude; session_id = full_sid;
             thread_id = thread_ch.Discord_types.id;
-            system_prompt = None;
-            message_count = 1; (* >0 so we use --resume *)
-            processing = false;
+            system_prompt = None; message_count = 1; processing = false;
           } in
-          add_session t thread_ch.id session;
-          let sid_short = if String.length full_session_id >= 8
-            then String.sub full_session_id 0 8 else full_session_id in
-          let welcome = Printf.sprintf
-            "**Resumed** Claude session `%s`\nWorking in: `%s`\nSend a message to continue."
-            sid_short working_dir
-          in
-          ignore (Discord_rest.create_message t.rest
-            ~channel_id:thread_ch.id ~content:welcome ()))
-  | Stop_session { thread_id } ->
-    (match SessionMap.find_opt thread_id t.sessions with
-     | None ->
-       ignore (Discord_rest.create_message t.rest
-         ~channel_id:msg.channel_id
-         ~content:"Session not found." ())
+          Session_store.add t.sessions ~thread_id:thread_ch.id session;
+          ignore (Discord_rest.create_message t.rest ~channel_id:thread_ch.id
+            ~content:(Printf.sprintf
+              "**Resumed** Claude session `%s`\nWorking in: `%s`\nSend a message to continue."
+              sid_short working_dir) ()))
+  | Command.Stop_session { thread_id } ->
+    (match Session_store.find_opt t.sessions ~thread_id with
+     | None -> reply "Session not found."
      | Some session ->
-       remove_session t thread_id;
-       ignore (Discord_rest.create_message t.rest
-         ~channel_id:msg.channel_id
-         ~content:(Printf.sprintf "Stopped session for **%s**." session.project_name) ()))
-  | Cleanup_channels ->
+       Session_store.remove t.sessions ~thread_id;
+       reply (Printf.sprintf "Stopped session for **%s**." session.project_name))
+  | Command.Cleanup_channels ->
     Eio.Fiber.fork ~sw:t.sw (fun () ->
-      if t.config.guild_id = "" then
-        ignore (Discord_rest.create_message t.rest ~channel_id:msg.channel_id
-          ~content:"No guild_id configured." ())
-      else begin
-        match Discord_rest.get_guild_channels t.rest ~guild_id:t.config.guild_id () with
-        | Error e ->
-          ignore (Discord_rest.create_message t.rest ~channel_id:msg.channel_id
-            ~content:(Printf.sprintf "Failed to get channels: %s" e) ())
-        | Ok channels ->
-          (* Discord lowercases channel names, so compare case-insensitively *)
-          let project_names = List.map (fun (p : Project.t) ->
-            String.lowercase_ascii p.name) t.projects in
-          (* Find channels under Agent Projects that don't match any project,
-             plus duplicates (keep only the first channel per name) *)
-          let seen_names = Hashtbl.create 32 in
-          let to_delete = List.filter (fun (ch : Discord_types.channel) ->
-            match ch.parent_id, ch.name, t.category_id with
-            | Some pid, Some name, Some cat_id when pid = cat_id ->
-              let lname = String.lowercase_ascii name in
-              if Hashtbl.mem seen_names lname then
-                true (* duplicate — delete *)
-              else begin
-                Hashtbl.add seen_names lname true;
-                not (List.mem lname project_names) (* stale — delete *)
-              end
-            | _ -> false
-          ) channels in
-          if to_delete = [] then
-            ignore (Discord_rest.create_message t.rest ~channel_id:msg.channel_id
-              ~content:"No stale channels to clean up." ())
-          else begin
-            let clock = Eio.Stdenv.clock t.env in
-            let deleted = ref 0 in
-            List.iter (fun (ch : Discord_types.channel) ->
-              let name = Option.value ~default:"?" ch.name in
-              match Discord_rest.delete_channel t.rest ~channel_id:ch.id () with
-              | Ok () ->
-                Logs.info (fun m -> m "bot: deleted stale channel %s (%s)" name ch.id);
-                incr deleted;
-                Eio.Time.sleep clock 0.5
-              | Error e ->
-                Logs.warn (fun m -> m "bot: failed to delete channel %s: %s" name e)
-            ) to_delete;
-            ignore (Discord_rest.create_message t.rest ~channel_id:msg.channel_id
-              ~content:(Printf.sprintf "Cleaned up %d stale channels." !deleted) ())
-          end
-      end)
-  | Restart ->
-    ignore (Discord_rest.create_message t.rest
-      ~channel_id:msg.channel_id ~content:"Rebuilding and restarting..." ());
+      match Channel_manager.cleanup ~rest:t.rest
+              ~guild_id:t.config.guild_id ~projects:t.projects t.channels with
+      | Error e -> reply (Printf.sprintf "Cleanup failed: %s" e)
+      | Ok 0 -> reply "No stale channels to clean up."
+      | Ok n -> reply (Printf.sprintf "Cleaned up %d stale channels." n))
+  | Command.Restart ->
+    reply "Rebuilding and restarting...";
     Eio.Fiber.fork ~sw:t.sw (fun () ->
-      let build_and_restart () =
+      match Eio_unix.run_in_systhread (fun () ->
         let root = Lazy.force project_root in
-        let build_exit = Sys.command
+        let exit_code = Sys.command
           (Printf.sprintf "cd %s && nix develop --command dune build 2>&1"
             (Filename.quote root)) in
-        if build_exit <> 0 then
-          `Build_failed
+        if exit_code <> 0 then `Build_failed
         else begin
           let _pid = Unix.create_process "/bin/sh"
             [| "/bin/sh"; "-c";
@@ -749,374 +287,123 @@ let handle_control_message t msg =
                  (Filename.quote root) |]
             Unix.stdin Unix.stdout Unix.stderr in
           `Restarting
-        end
-      in
-      match Eio_unix.run_in_systhread build_and_restart with
-      | `Build_failed ->
-        ignore (Discord_rest.create_message t.rest
-          ~channel_id:msg.channel_id ~content:"Build failed, not restarting." ())
+        end) with
+      | `Build_failed -> reply "Build failed, not restarting."
       | `Restarting ->
-        ignore (Discord_rest.create_message t.rest
-          ~channel_id:msg.channel_id ~content:"Build succeeded. New instance starting (will kill this one via pidfile)." ());
-        (* Give the new instance time to start and kill us *)
-        let clock = Eio.Stdenv.clock t.env in
-        Eio.Time.sleep clock 30.0)
-  | Help ->
-    let text = String.concat "\n" [
+        reply "Build succeeded. New instance starting.";
+        Eio.Time.sleep (Eio.Stdenv.clock t.env) 30.0)
+  | Command.Help ->
+    reply (String.concat "\n" [
       "**Commands:**";
       "`!projects` — list discovered projects";
       "`!sessions` — list active bot sessions";
-      "`!claude-sessions` — list recent Claude Code sessions on this machine";
-      "`!start <project> <claude|codex|gemini>` — start a new agent session";
-      "`!resume <session_id>` — resume an existing Claude session in a new thread";
+      "`!claude-sessions` — list recent Claude sessions";
+      "`!start <project> [agent]` — start a session (defaults to claude)";
+      "`!resume <session_id>` — resume a Claude session";
       "`!stop <thread_id>` — stop a session";
-      "`!cleanup-channels` — delete stale project channels from before dedup";
-      "`!restart` — rebuild and restart the bot";
+      "`!cleanup` — delete stale channels";
+      "`!restart` — rebuild and restart";
       "`!help` — this message";
-    ] in
-    ignore (Discord_rest.create_message t.rest
-      ~channel_id:msg.channel_id ~content:text ())
-  | Unknown _ -> ()
+    ])
+  | Command.Unknown _ -> ()
 
-(** Move a project's channel to the top of the category (position 0).
-    Called on session activity so recently-used projects float up. *)
-let bump_project_channel t project_name =
-  match ChannelMap.find_opt project_name t.project_channels with
-  | None -> ()
-  | Some ch_id ->
-    if t.config.guild_id <> "" then
-      ignore (Discord_rest.modify_channel_position t.rest
-        ~guild_id:t.config.guild_id ~channel_id:ch_id ~position:0 ())
-
-(** Handle a message in a session thread — run the agent and stream the response. *)
+(** Handle a message in a session thread. *)
 let handle_thread_message t msg =
-  match SessionMap.find_opt msg.Discord_types.channel_id t.sessions with
+  match Session_store.find_opt t.sessions ~thread_id:msg.Discord_types.channel_id with
   | None -> ()
   | Some session ->
-    (* Only one agent invocation at a time per session *)
-    if session.processing then begin
+    if session.processing then
       ignore (Discord_rest.create_message t.rest
-        ~channel_id:msg.Discord_types.channel_id
-        ~content:"Still processing previous message..." ());
-    end else begin
-    session.processing <- true;
-    (* Fork a fiber so we don't block the gateway recv loop *)
-    Eio.Fiber.fork ~sw:t.sw (fun () ->
-      Fun.protect ~finally:(fun () -> session.processing <- false) (fun () ->
-      let channel_id = msg.Discord_types.channel_id in
-      (* Ack with eyes reaction, send typing, bump channel to top *)
-      ignore (Discord_rest.create_reaction t.rest ~channel_id
-        ~message_id:msg.id ~emoji:"\xF0\x9F\x91\x80" ());
-      ignore (Discord_rest.send_typing t.rest ~channel_id ());
-      bump_project_channel t session.project_name;
-      let prompt = msg.content in
-      Logs.info (fun m -> m "bot: running %s for %s: %s"
-        (Config.string_of_agent_kind session.agent_kind)
-        session.project_name
-        (if String.length prompt > 80
-         then String.sub prompt 0 80 ^ "..."
-         else prompt));
-      (* Accumulate text and post/edit a Discord message as chunks arrive *)
-      let result_buf = Buffer.create 4096 in
-      let current_msg_id = ref None in
-      let current_msg_buf = Buffer.create 1900 in
-      let last_typing = ref (Unix.gettimeofday ()) in
-      let last_edit = ref (Unix.gettimeofday ()) in
-      (* Flush current buffer to Discord — create or edit message *)
-      let flush_to_discord () =
-        let text = Buffer.contents current_msg_buf in
-        if String.length text = 0 then ()
-        else match !current_msg_id with
-        | None ->
-          (match Discord_rest.create_message t.rest ~channel_id ~content:text () with
-           | Ok sent -> current_msg_id := Some sent.Discord_types.id
-           | Error e -> Logs.warn (fun m -> m "bot: send error: %s" e))
-        | Some mid ->
-          (match Discord_rest.edit_message t.rest ~channel_id ~message_id:mid ~content:text () with
-           | Ok _ -> ()
-           | Error e -> Logs.warn (fun m -> m "bot: edit error: %s" e))
-      in
-      (* Start a new message (when current one is getting long) *)
-      let start_new_message () =
-        flush_to_discord ();
-        Buffer.clear current_msg_buf;
-        current_msg_id := None
-      in
-      let on_event = function
-        | Agent_process.Text_delta text ->
-          Buffer.add_string result_buf text;
-          (* Append to current message buf, flushing when it gets long.
-             Handles large deltas by splitting at 1800 char boundaries. *)
-          let text_len = String.length text in
-          let pos = ref 0 in
-          while !pos < text_len do
-            let remaining_capacity = 1800 - Buffer.length current_msg_buf in
-            let chunk_len = min remaining_capacity (text_len - !pos) in
-            if chunk_len > 0 then
-              Buffer.add_substring current_msg_buf text !pos chunk_len;
-            pos := !pos + chunk_len;
-            if Buffer.length current_msg_buf >= 1800 then
-              start_new_message ()
-          done;
-          (* Periodically flush edits and refresh typing *)
-          let now = Unix.gettimeofday () in
-          if now -. !last_edit > 2.0 && Buffer.length current_msg_buf > 0 then begin
-            flush_to_discord ();
-            last_edit := now
-          end;
-          if now -. !last_typing > typing_interval then begin
-            ignore (Discord_rest.send_typing t.rest ~channel_id ());
-            last_typing := now
-          end
-        | Agent_process.Result { text = _; session_id = _ } ->
-          (* Final flush *)
-          flush_to_discord ()
-        | Agent_process.Tool_use name ->
-          Logs.debug (fun m -> m "bot: agent using tool: %s" name)
-        | Agent_process.Error e ->
-          Logs.warn (fun m -> m "bot: agent error event: %s" e)
-        | Agent_process.Other _ -> ()
-      in
-      (match Agent_process.run_streaming ~sw:t.sw ~env:t.env
-               ~working_dir:session.working_dir
-               ~kind:session.agent_kind
-               ~session_id:session.session_id
-               ~message_count:session.message_count
-               ?system_prompt:session.system_prompt
-               ~prompt ~on_event () with
-       | Ok () ->
-         session.message_count <- session.message_count + 1;
-         save_sessions t.sessions;
-         (* Final flush if not already done *)
-         flush_to_discord ();
-         if Buffer.length result_buf = 0 then
-           ignore (Discord_rest.create_message t.rest
-             ~channel_id ~content:"(no response)" ())
-       | Error e ->
-         Logs.warn (fun m -> m "bot: agent error: %s" e);
-         ignore (Discord_rest.create_message t.rest
-           ~channel_id
-           ~content:(Printf.sprintf "Agent error: %s" e) ()))))
-    end (* processing guard *)
+        ~channel_id:msg.channel_id ~content:"Still processing previous message..." ())
+    else begin
+      session.processing <- true;
+      Eio.Fiber.fork ~sw:t.sw (fun () ->
+        Fun.protect ~finally:(fun () -> session.processing <- false) (fun () ->
+          let channel_id = msg.Discord_types.channel_id in
+          ignore (Discord_rest.create_reaction t.rest ~channel_id
+            ~message_id:msg.id ~emoji:"\xF0\x9F\x91\x80" ());
+          Channel_manager.bump ~rest:t.rest ~guild_id:t.config.guild_id
+            ~project_name:session.project_name t.channels;
+          match Agent_runner.run ~sw:t.sw ~env:t.env ~rest:t.rest
+                  ~session ~channel_id ~prompt:msg.content () with
+          | Ok () ->
+            Session_store.increment_message_count t.sessions session
+          | Error _ -> ()))
+    end
 
-(** Ensure a session exists for a channel, creating one if needed.
-    Used for the control channel and project channels so users can
-    just chat naturally without explicit !start. *)
-let control_system_prompt t =
-  let project_list = String.concat "\n" (List.mapi (fun i (p : Project.t) ->
-    Printf.sprintf "  %d. %s (%s)" (i+1) p.name p.path
-  ) t.projects) in
-  Printf.sprintf
-"You are the control agent for a Discord bot that manages AI coding sessions.
-
-You are chatting in a Discord channel. You have MCP tools available to manage the bot:
-- start_session: Start a new agent session for a project (creates thread + worktree)
-- list_projects: List all discovered projects
-- list_sessions: List active bot sessions
-- list_claude_sessions: Find recent Claude Code sessions to resume
-- resume_session: Resume an existing Claude session in a new thread
-- restart_bot: Rebuild and restart the bot after code changes
-- cleanup_channels: Delete stale Discord channels
-
-USE THESE TOOLS. When the user asks to work on a project, start a session, see what's running, etc., call the appropriate tool. Don't tell them to type commands — just do it.
-
-Project names support fuzzy matching — prefixes and substrings work.
-
-Known projects:
-%s
-
-Keep responses concise — this is Discord, not a document." project_list
-
+(** Ensure a session exists for a channel (control/project auto-sessions). *)
 let ensure_channel_session t ~channel_id ~project_name ~working_dir ~system_prompt =
-  match SessionMap.find_opt channel_id t.sessions with
+  match Session_store.find_opt t.sessions ~thread_id:channel_id with
   | Some _ -> ()
   | None ->
-    let session = {
-      project_name;
-      working_dir;
-      agent_kind = Config.Claude;
-      session_id = generate_uuid ();
-      thread_id = channel_id;
-      system_prompt;
-      message_count = 0;
-      processing = false;
+    let session : Session_store.session = {
+      project_name; working_dir; agent_kind = Config.Claude;
+      session_id = Resource.generate_uuid (); thread_id = channel_id;
+      system_prompt; message_count = 0; processing = false;
     } in
-    add_session t channel_id session;
-    Logs.info (fun m -> m "bot: auto-created session for channel %s (%s)"
-      channel_id project_name)
-
-(** Reload sessions from disk if the file has changed.
-    Rate-limited to once per 5 seconds to avoid blocking Eio with
-    frequent Unix.stat calls on every message. *)
-let sessions_mtime = ref 0.0
-let last_reload_check = ref 0.0
-
-let maybe_reload_sessions (t : t) =
-  let now = Unix.gettimeofday () in
-  if now -. !last_reload_check < 5.0 then ()
-  else begin
-    last_reload_check := now;
-    let path = sessions_file () in
-    if Sys.file_exists path then begin
-      let stat = Unix.stat path in
-      if stat.Unix.st_mtime > !sessions_mtime then begin
-        sessions_mtime := stat.Unix.st_mtime;
-      let loaded = load_sessions () in
-      (* Merge: keep in-memory sessions that aren't in the file,
-         add file sessions that aren't in memory *)
-      SessionMap.iter (fun tid session ->
-        if not (SessionMap.mem tid t.sessions) then
-          t.sessions <- SessionMap.add tid session t.sessions
-      ) loaded;
-      Logs.debug (fun m -> m "bot: reloaded sessions from disk (%d total)"
-        (SessionMap.cardinal t.sessions))
-    end
-  end
-  end (* rate limit *)
+    Session_store.add t.sessions ~thread_id:channel_id session;
+    Logs.info (fun m -> m "bot: auto-created session for %s" project_name)
 
 (** Route an incoming Discord message. *)
 let handle_message t (msg : Discord_types.message) =
-  maybe_reload_sessions t;
-  (* Ignore bot messages *)
+  Session_store.maybe_reload t.sessions;
   match msg.author.bot with Some true -> () | _ ->
-  (* Commands (messages starting with !) are handled regardless of channel *)
-  if is_command msg.content then
-    handle_control_message t msg
+  if Command.is_command msg.content then
+    handle_command t msg (Command.parse msg.content)
   else begin
-    (* Check if this is in the control channel or a project channel —
-       auto-create a session for natural language chat *)
     let is_control = match t.config.control_channel_id with
-      | Some ctl_id -> msg.channel_id = ctl_id
-      | None -> false
-    in
+      | Some ctl_id -> msg.channel_id = ctl_id | None -> false in
     let project_for_channel =
-      ChannelMap.bindings t.project_channels
-      |> List.find_opt (fun (_, ch_id) -> ch_id = msg.channel_id)
-      |> Option.map fst
-    in
+      Channel_manager.project_for_channel t.channels ~channel_id:msg.channel_id in
     if is_control then begin
-      (* Control channel: global session with system prompt describing capabilities *)
-      let working_dir = Sys.getcwd () in
       ensure_channel_session t ~channel_id:msg.channel_id
-        ~project_name:"control" ~working_dir
-        ~system_prompt:(Some (control_system_prompt t));
+        ~project_name:"control" ~working_dir:(Sys.getcwd ())
+        ~system_prompt:(Some (control_system_prompt t.projects));
       handle_thread_message t msg
     end else match project_for_channel with
     | Some proj_name ->
-      (* Project channel: auto-create a session for that project *)
       let proj = List.find_opt (fun (p : Project.t) -> p.name = proj_name) t.projects in
       (match proj with
        | Some p ->
-         let working_dir = match working_dir_of_project p with
-           | Ok d -> d | Error _ -> p.path in
+         let wd = match working_dir_of_project p with Ok d -> d | Error _ -> p.path in
          ensure_channel_session t ~channel_id:msg.channel_id
-           ~project_name:p.name ~working_dir ~system_prompt:None;
+           ~project_name:p.name ~working_dir:wd ~system_prompt:None;
          handle_thread_message t msg
        | None -> handle_thread_message t msg)
-    | None ->
-      (* Thread or unknown channel — check existing sessions *)
-      handle_thread_message t msg
-  end
-
-(** Set up project channels under an "Agent Projects" category.
-    Finds or creates the category, then creates a channel per project. *)
-let setup_project_channels t =
-  let guild_id = t.config.guild_id in
-  if guild_id = "" then
-    Logs.info (fun m -> m "bot: no guild_id configured, skipping channel setup")
-  else begin
-    match Discord_rest.get_guild_channels t.rest ~guild_id () with
-    | Error e ->
-      Logs.warn (fun m -> m "bot: failed to get guild channels: %s" e)
-    | Ok channels ->
-      (* Find or create "Agent Projects" category (type 4) *)
-      let category = List.find_opt (fun (ch : Discord_types.channel) ->
-        ch.type_ = Guild_category
-        && ch.name = Some "Agent Projects"
-      ) channels in
-      let cat_id = match category with
-        | Some ch ->
-          Logs.info (fun m -> m "bot: found Agent Projects category: %s" ch.id);
-          ch.id
-        | None ->
-          Logs.info (fun m -> m "bot: creating Agent Projects category");
-          match Discord_rest.create_channel t.rest ~guild_id
-                  ~name:"Agent Projects" ~channel_type:4 () with
-          | Ok ch -> ch.id
-          | Error e ->
-            Logs.warn (fun m -> m "bot: failed to create category: %s" e);
-            ""
-      in
-      if cat_id <> "" then begin
-        t.category_id <- Some cat_id;
-        (* Map existing text channels under this category to projects *)
-        List.iter (fun (ch : Discord_types.channel) ->
-          match ch.parent_id, ch.name with
-          | Some pid, Some name when pid = cat_id ->
-            let matching_project = List.find_opt (fun (p : Project.t) ->
-              String.lowercase_ascii p.name = String.lowercase_ascii name
-            ) t.projects in
-            (match matching_project with
-             | Some p ->
-               t.project_channels <- ChannelMap.add p.name ch.id t.project_channels;
-               Logs.info (fun m -> m "bot: mapped channel %s -> project %s" ch.id p.name)
-             | None -> ())
-          | _ -> ()
-        ) channels;
-        (* Channels created on demand via !start. Log mapping status. *)
-        let mapped = ChannelMap.cardinal t.project_channels in
-        let total = List.length t.projects in
-        Logs.info (fun m -> m "bot: %d/%d projects have channels (others created on demand)"
-          mapped total)
-      end
+    | None -> handle_thread_message t msg
   end
 
 let create ~sw ~(env : Eio_unix.Stdenv.base) config =
   let rest = Discord_rest.create ~sw ~env ~token:config.Config.discord_token in
   let projects = Project.discover ~base_directories:config.base_directories in
+  let sessions = Session_store.create () in
+  let channels = Channel_manager.create () in
   let gateway = Discord_gateway.create
     ~token:config.discord_token
     ~intents:Discord_gateway.default_intents
     ~handler:(fun _event -> ())
   in
-  let bot = {
-    config;
-    rest;
-    gateway;
-    projects;
-    sessions = load_sessions ();
-    project_channels = ChannelMap.empty;
-    category_id = None;
-    env;
-    sw;
-  } in
+  let bot = { config; rest; gateway; projects; sessions; channels; env; sw } in
   bot.gateway.handler <- (fun event ->
     match event with
     | Discord_gateway.Connected user ->
       Logs.info (fun m -> m "bot: connected as %s" user.Discord_types.username);
-      (* Set up project channels only on first connect, not on resume/reconnect *)
-      if bot.category_id = None then
+      if bot.channels.category_id = None then
         Eio.Fiber.fork ~sw (fun () ->
-          setup_project_channels bot;
-          (* Post startup announcement *)
-          match bot.config.control_channel_id with
+          Channel_manager.setup ~rest ~guild_id:config.guild_id ~projects bot.channels;
+          match config.control_channel_id with
           | Some ch_id ->
-            let n_projects = List.length bot.projects in
-            let n_sessions = SessionMap.cardinal bot.sessions in
-            let n_channels = ChannelMap.cardinal bot.project_channels in
-            let text = Printf.sprintf
-              "Bot online. %d projects, %d channels, %d active sessions."
-              n_projects n_channels n_sessions in
-            ignore (Discord_rest.create_message bot.rest
-              ~channel_id:ch_id ~content:text ())
+            let text = Printf.sprintf "Bot online. %d projects, %d channels, %d sessions."
+              (List.length projects) (Channel_manager.count bot.channels)
+              (Session_store.count bot.sessions) in
+            ignore (Discord_rest.create_message rest ~channel_id:ch_id ~content:text ())
           | None -> ())
     | Discord_gateway.Message_received msg -> handle_message bot msg
     | Discord_gateway.Thread_created ch ->
       Logs.info (fun m -> m "bot: thread created: %s"
         (Option.value ~default:"(unnamed)" ch.Discord_types.name))
     | Discord_gateway.Disconnected reason ->
-      Logs.warn (fun m -> m "bot: disconnected: %s" reason)
-  );
+      Logs.warn (fun m -> m "bot: disconnected: %s" reason));
   bot
 
 let run ~sw:_ ~(env : Eio_unix.Stdenv.base) bot =

--- a/lib/channel_manager.ml
+++ b/lib/channel_manager.ml
@@ -1,0 +1,136 @@
+(** Discord channel management for project channels.
+
+    Owns the project→channel mapping. Handles case-insensitive matching
+    (Discord lowercases channel names), on-demand channel creation,
+    channel position bumping, and cleanup of stale channels. *)
+
+module ChannelMap = Map.Make(String) (* project name (original case) -> channel_id *)
+
+type t = {
+  mutable channels : string ChannelMap.t;
+  mutable category_id : string option;
+}
+
+let create () = { channels = ChannelMap.empty; category_id = None }
+
+(** Find a project's channel ID. *)
+let find t ~project_name =
+  ChannelMap.find_opt project_name t.channels
+
+(** Number of mapped channels. *)
+let count t = ChannelMap.cardinal t.channels
+
+(** All channel bindings as (project_name, channel_id) pairs. *)
+let bindings t = ChannelMap.bindings t.channels
+
+(** Set up the "Agent Projects" category and map existing channels
+    to projects (case-insensitive match on names). *)
+let setup ~rest ~guild_id ~projects t =
+  if guild_id = "" then
+    Logs.info (fun m -> m "channel_manager: no guild_id, skipping")
+  else begin
+    match Discord_rest.get_guild_channels rest ~guild_id () with
+    | Error e ->
+      Logs.warn (fun m -> m "channel_manager: failed to get channels: %s" e)
+    | Ok channels ->
+      let category = List.find_opt (fun (ch : Discord_types.channel) ->
+        ch.type_ = Guild_category
+        && ch.name = Some "Agent Projects"
+      ) channels in
+      let cat_id = match category with
+        | Some ch ->
+          Logs.info (fun m -> m "channel_manager: found category %s" ch.id);
+          ch.id
+        | None ->
+          Logs.info (fun m -> m "channel_manager: creating Agent Projects category");
+          match Discord_rest.create_channel rest ~guild_id
+                  ~name:"Agent Projects" ~channel_type:4 () with
+          | Ok ch -> ch.id
+          | Error e ->
+            Logs.warn (fun m -> m "channel_manager: failed to create category: %s" e);
+            ""
+      in
+      if cat_id <> "" then begin
+        t.category_id <- Some cat_id;
+        List.iter (fun (ch : Discord_types.channel) ->
+          match ch.parent_id, ch.name with
+          | Some pid, Some name when pid = cat_id ->
+            (* Case-insensitive match against project names *)
+            let matching = List.find_opt (fun (p : Project.t) ->
+              String.lowercase_ascii p.name = String.lowercase_ascii name
+            ) projects in
+            (match matching with
+             | Some p ->
+               t.channels <- ChannelMap.add p.name ch.id t.channels;
+               Logs.info (fun m -> m "channel_manager: mapped %s -> %s" ch.id p.name)
+             | None -> ())
+          | _ -> ()
+        ) channels;
+        Logs.info (fun m -> m "channel_manager: %d/%d projects have channels"
+          (ChannelMap.cardinal t.channels) (List.length projects))
+      end
+  end
+
+(** Find or create a channel for a project. Returns the channel ID. *)
+let find_or_create ~rest ~guild_id ~project t =
+  match find t ~project_name:project.Project.name with
+  | Some ch_id -> Some ch_id
+  | None ->
+    match t.category_id with
+    | Some cat_id ->
+      let topic = Printf.sprintf "Agent sessions for %s (%s)"
+        project.Project.name project.Project.path in
+      (match Discord_rest.create_channel rest ~guild_id
+               ~name:project.name ~parent_id:cat_id ~topic () with
+       | Ok ch ->
+         t.channels <- ChannelMap.add project.name ch.id t.channels;
+         Logs.info (fun m -> m "channel_manager: created channel for %s" project.name);
+         Some ch.id
+       | Error e ->
+         Logs.warn (fun m -> m "channel_manager: create failed for %s: %s" project.name e);
+         None)
+    | None -> None
+
+(** Move a project's channel to position 0 (top of category). *)
+let bump ~rest ~guild_id ~project_name t =
+  match find t ~project_name with
+  | None -> ()
+  | Some ch_id ->
+    if guild_id <> "" then
+      ignore (Discord_rest.modify_channel_position rest
+        ~guild_id ~channel_id:ch_id ~position:0 ())
+
+(** Delete channels that don't match any current project name.
+    Also removes duplicates (keeps first per name). *)
+let cleanup ~rest ~guild_id ~projects t =
+  if guild_id = "" then Error "no guild_id"
+  else
+    match Discord_rest.get_guild_channels rest ~guild_id () with
+    | Error e -> Error e
+    | Ok channels ->
+      let project_names = List.map (fun (p : Project.t) ->
+        String.lowercase_ascii p.name) projects in
+      let seen = Hashtbl.create 32 in
+      let to_delete = List.filter (fun (ch : Discord_types.channel) ->
+        match ch.parent_id, ch.name, t.category_id with
+        | Some pid, Some name, Some cat_id when pid = cat_id ->
+          let lname = String.lowercase_ascii name in
+          if Hashtbl.mem seen lname then true
+          else begin
+            Hashtbl.add seen lname true;
+            not (List.mem lname project_names)
+          end
+        | _ -> false
+      ) channels in
+      let deleted = List.fold_left (fun acc (ch : Discord_types.channel) ->
+        match Discord_rest.delete_channel rest ~channel_id:ch.id () with
+        | Ok () -> acc + 1
+        | Error _ -> acc
+      ) 0 to_delete in
+      Ok deleted
+
+(** Check if a channel ID belongs to a project channel, return the project name. *)
+let project_for_channel t ~channel_id =
+  ChannelMap.bindings t.channels
+  |> List.find_opt (fun (_, ch_id) -> ch_id = channel_id)
+  |> Option.map fst

--- a/lib/claude_sessions.ml
+++ b/lib/claude_sessions.ml
@@ -1,0 +1,142 @@
+(** Discovery of Claude Code sessions on disk.
+
+    Scans ~/.claude/projects/ for recent session files (JSONL),
+    extracts metadata (first user message, project directory),
+    and resolves project directory names back to filesystem paths. *)
+
+type info = {
+  session_id : string;
+  project_dir : string;
+  working_dir : string;
+  summary : string;
+  mtime : float;
+}
+
+(** Resolve a Claude project directory name back to a filesystem path.
+    e.g. "-home-tedks-Projects-claude-discord" -> "/home/tedks/Projects/claude-discord"
+
+    Walks the filesystem greedily: at each level, tries the longest
+    hyphenated segment that exists as a directory. *)
+let resolve_project_dir proj_name =
+  let s = if String.length proj_name > 0 && proj_name.[0] = '-'
+          then String.sub proj_name 1 (String.length proj_name - 1)
+          else proj_name in
+  let rec resolve path remaining =
+    if String.length remaining = 0 then path
+    else
+      let parts = String.split_on_char '-' remaining in
+      let rec try_lengths n =
+        if n < 1 then
+          let first = List.hd parts in
+          let rest_parts = List.tl parts in
+          resolve (Filename.concat path first) (String.concat "-" rest_parts)
+        else
+          let candidate_parts = List.filteri (fun i _ -> i < n) parts in
+          let candidate = String.concat "-" candidate_parts in
+          let candidate_path = Filename.concat path candidate in
+          if (try Sys.file_exists candidate_path with _ -> false) then
+            let rest_parts = List.filteri (fun i _ -> i >= n) parts in
+            resolve candidate_path (String.concat "-" rest_parts)
+          else
+            try_lengths (n - 1)
+      in
+      try_lengths (List.length parts)
+  in
+  resolve "/" s
+
+(** Extract the first user message from a Claude session JSONL file. *)
+let extract_summary fpath =
+  try
+    Resource.with_file_in fpath (fun ic ->
+      let summary = ref "" in
+      (try while !summary = "" do
+        let line = input_line ic in
+        let json = Yojson.Safe.from_string line in
+        let open Yojson.Safe.Util in
+        if json |> member "type" |> to_string = "user" then begin
+          let msg = json |> member "message" in
+          let content = msg |> member "content" in
+          match content with
+          | `List items ->
+            List.iter (fun item ->
+              if !summary = "" then
+                match item |> member "type" |> to_string_option with
+                | Some "text" ->
+                  let text = item |> member "text" |> to_string in
+                  summary := String.sub text 0 (min 80 (String.length text))
+                | _ -> ()
+            ) items
+          | `String s ->
+            summary := String.sub s 0 (min 80 (String.length s))
+          | _ -> ()
+        end
+      done with End_of_file | _ -> ());
+      !summary)
+  with _ -> "(unknown)"
+
+(** Scan for recent Claude sessions. Returns newest first. *)
+let discover ?(hours=24) () =
+  Eio_unix.run_in_systhread @@ fun () ->
+  let home = Sys.getenv "HOME" in
+  let projects_dir = Filename.concat home ".claude/projects" in
+  if not (Sys.file_exists projects_dir) then []
+  else
+    let cutoff = Unix.gettimeofday () -. (float_of_int hours *. 3600.0) in
+    let results = ref [] in
+    let project_dirs =
+      try Sys.readdir projects_dir |> Array.to_list with _ -> [] in
+    List.iter (fun proj_name ->
+      let proj_path = Filename.concat projects_dir proj_name in
+      if (try Sys.is_directory proj_path with Sys_error _ -> false) then begin
+        let files =
+          try Sys.readdir proj_path |> Array.to_list with Sys_error _ -> [] in
+        List.iter (fun fname ->
+          if Filename.check_suffix fname ".jsonl"
+             && not (String.contains fname '/') then begin
+            let fpath = Filename.concat proj_path fname in
+            match (try Some (Unix.stat fpath) with Unix.Unix_error _ -> None) with
+            | Some st when st.Unix.st_mtime > cutoff ->
+              results := {
+                session_id = Filename.chop_suffix fname ".jsonl";
+                project_dir = proj_name;
+                working_dir = resolve_project_dir proj_name;
+                summary = extract_summary fpath;
+                mtime = st.Unix.st_mtime;
+              } :: !results
+            | _ -> ()
+          end
+        ) files
+      end
+    ) project_dirs;
+    List.sort (fun a b -> compare b.mtime a.mtime) !results
+
+(** Find a session by ID prefix. *)
+let find_by_prefix session_id_prefix =
+  let home = Sys.getenv "HOME" in
+  let projects_dir = Filename.concat home ".claude/projects" in
+  if not (Sys.file_exists projects_dir) then None
+  else
+    let project_dirs =
+      try Sys.readdir projects_dir |> Array.to_list with _ -> [] in
+    let result = ref None in
+    List.iter (fun proj_name ->
+      if !result = None then begin
+        let proj_path = Filename.concat projects_dir proj_name in
+        if (try Sys.is_directory proj_path with Sys_error _ -> false) then begin
+          let files =
+            try Sys.readdir proj_path |> Array.to_list with _ -> [] in
+          List.iter (fun fname ->
+            if !result = None
+               && Filename.check_suffix fname ".jsonl"
+               && not (String.contains fname '/') then begin
+              let sid = Filename.chop_suffix fname ".jsonl" in
+              if String.length sid >= String.length session_id_prefix
+                 && String.sub sid 0 (String.length session_id_prefix)
+                    = session_id_prefix then
+                result := Some (sid, resolve_project_dir proj_name)
+            end
+          ) files
+        end
+      end
+    ) project_dirs;
+    !result

--- a/lib/command.ml
+++ b/lib/command.ml
@@ -1,0 +1,84 @@
+(** Pure command parsing — no I/O, no mutable state.
+
+    Commands require a ! prefix to avoid hijacking natural language
+    like "help me debug this" or "start here". *)
+
+type t =
+  | List_projects
+  | List_sessions
+  | List_claude_sessions
+  | Start_agent of { project : string; kind : Config.agent_kind }
+  | Resume_session of { session_id : string }
+  | Stop_session of { thread_id : string }
+  | Cleanup_channels
+  | Restart
+  | Help
+  | Unknown of string
+
+(** Does this message look like a bot command? Requires ! prefix. *)
+let is_command content =
+  let trimmed = String.trim content in
+  String.length trimmed > 0 && trimmed.[0] = '!'
+
+let parse content =
+  let parts = String.split_on_char ' ' (String.trim content) in
+  let parts = match parts with
+    | w :: rest when String.length w > 0 && w.[0] = '!' ->
+      String.lowercase_ascii (String.sub w 1 (String.length w - 1)) :: rest
+    | other -> other
+  in
+  match parts with
+  | ["projects"] | ["list"] -> List_projects
+  | ["sessions"] -> List_sessions
+  | ["claude-sessions"] -> List_claude_sessions
+  | "start" :: project :: kind_str :: _ ->
+    let kind = match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with
+      | Ok k -> k | Error _ -> Config.Claude in
+    Start_agent { project; kind }
+  | ["start"; project] ->
+    Start_agent { project; kind = Config.Claude }
+  | ["start"] ->
+    List_projects
+  | ["resume"; session_id] -> Resume_session { session_id }
+  | ["stop"; thread_id] -> Stop_session { thread_id }
+  | ["cleanup-channels"] | ["cleanup"] -> Cleanup_channels
+  | ["restart"] -> Restart
+  | ["help"] -> Help
+  | _ -> Unknown content
+
+(** Fuzzy-match a query against project names.
+    Tries: exact, case-insensitive, numeric index, prefix, substring.
+    Returns None on ambiguous or no match. *)
+let find_project_fuzzy projects query =
+  let q = String.lowercase_ascii query in
+  match List.find_opt (fun (p : Project.t) -> p.name = query) projects with
+  | Some _ as found -> found
+  | None ->
+  match List.find_opt (fun (p : Project.t) ->
+    String.lowercase_ascii p.name = q) projects with
+  | Some _ as found -> found
+  | None ->
+  match int_of_string_opt query with
+  | Some n when n >= 1 && n <= List.length projects ->
+    Some (List.nth projects (n - 1))
+  | _ ->
+  let prefix_matches = List.filter (fun (p : Project.t) ->
+    let name = String.lowercase_ascii p.name in
+    String.length name >= String.length q
+    && String.sub name 0 (String.length q) = q
+  ) projects in
+  match prefix_matches with
+  | [p] -> Some p
+  | _ ->
+  let substr_matches = List.filter (fun (p : Project.t) ->
+    let name = String.lowercase_ascii p.name in
+    let rec has_substr i =
+      if i + String.length q > String.length name then false
+      else if String.sub name i (String.length q) = q then true
+      else has_substr (i + 1)
+    in
+    has_substr 0
+  ) projects in
+  match substr_matches with
+  | [p] -> Some p
+  | _ -> None

--- a/lib/discord_agents.ml
+++ b/lib/discord_agents.ml
@@ -1,11 +1,17 @@
 (** Discord Agents — top-level library module. *)
 
+module Resource = Resource
 module Config = Config
 module Project = Project
 module Agent_process = Agent_process
+module Agent_runner = Agent_runner
 module Discord_types = Discord_types
 module Discord_rest = Discord_rest
 module Discord_gateway = Discord_gateway
+module Session_store = Session_store
+module Channel_manager = Channel_manager
+module Command = Command
+module Claude_sessions = Claude_sessions
 module Session = Session
 module Websocket = Websocket
 module Bot = Bot

--- a/lib/ids.ml
+++ b/lib/ids.ml
@@ -1,0 +1,41 @@
+(** Type-safe ID wrappers. Prevents mixing up thread IDs, channel IDs, etc.
+    Each ID type is a distinct abstract type backed by string. *)
+
+module type ID = sig
+  type t
+  val of_string : string -> t
+  val to_string : t -> string
+  val compare : t -> t -> int
+  val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
+end
+
+module Make () : ID = struct
+  type t = string
+  let of_string s = s
+  let to_string s = s
+  let compare = String.compare
+  let equal = String.equal
+  let pp fmt s = Format.pp_print_string fmt s
+end
+
+module Thread_id = Make ()
+module Channel_id = Make ()
+module Session_id = Make ()
+module Guild_id = Make ()
+
+(** Channel names are always lowercased by Discord.
+    This type normalizes on construction. *)
+module Channel_name : sig
+  type t
+  val of_string : string -> t
+  val to_string : t -> string
+  val compare : t -> t -> int
+  val equal : t -> t -> bool
+end = struct
+  type t = string
+  let of_string s = String.lowercase_ascii s
+  let to_string s = s
+  let compare = String.compare
+  let equal = String.equal
+end

--- a/lib/resource.ml
+++ b/lib/resource.ml
@@ -1,0 +1,57 @@
+(** Safe resource management — prevents file descriptor leaks.
+    Every file/lock operation goes through these helpers. *)
+
+let with_file_in path f =
+  let ic = open_in path in
+  Fun.protect ~finally:(fun () -> close_in ic) (fun () -> f ic)
+
+let with_file_out path f =
+  let oc = open_out path in
+  Fun.protect ~finally:(fun () -> close_out oc) (fun () -> f oc)
+
+(** Read entire file contents safely. *)
+let read_file path =
+  with_file_in path (fun ic ->
+    let n = in_channel_length ic in
+    let s = Bytes.create n in
+    really_input ic s 0 n;
+    Bytes.to_string s)
+
+(** Write string to file atomically (temp + rename). *)
+let write_file_atomic path content =
+  let tmp = path ^ ".tmp" in
+  (try
+    with_file_out tmp (fun oc ->
+      output_string oc content;
+      output_char oc '\n');
+    Unix.rename tmp path
+  with exn ->
+    (try Sys.remove tmp with _ -> ());
+    raise exn)
+
+(** Execute f while holding an exclusive flock on lock_path.
+    Used for cross-process synchronization (bot + MCP server). *)
+let with_flock lock_path f =
+  let fd = Unix.openfile lock_path [Unix.O_WRONLY; Unix.O_CREAT] 0o600 in
+  Fun.protect ~finally:(fun () ->
+    (try Unix.lockf fd Unix.F_ULOCK 0 with _ -> ());
+    Unix.close fd
+  ) (fun () ->
+    Unix.lockf fd Unix.F_LOCK 0;
+    f ())
+
+(** Generate a random hex string of the given byte length using mirage-crypto-rng. *)
+let random_hex n =
+  let raw = Mirage_crypto_rng.generate n in
+  let hex = Buffer.create (n * 2) in
+  String.iter (fun c ->
+    Buffer.add_string hex (Printf.sprintf "%02x" (Char.code c))
+  ) raw;
+  Buffer.contents hex
+
+(** Generate a UUID v4. *)
+let generate_uuid () =
+  let s = random_hex 16 in
+  Printf.sprintf "%s-%s-%s-%s-%s"
+    (String.sub s 0 8) (String.sub s 8 4) (String.sub s 12 4)
+    (String.sub s 16 4) (String.sub s 20 12)

--- a/lib/session_store.ml
+++ b/lib/session_store.ml
@@ -1,0 +1,142 @@
+(** Session state management with controlled mutation and persistence.
+
+    All session mutations go through this module. It owns the sessions map,
+    handles persistence to disk, and provides atomic operations.
+    Cross-process safety via flock on sessions.json.lock. *)
+
+module SessionMap = Map.Make(String)
+
+type session = {
+  project_name : string;
+  working_dir : string;
+  agent_kind : Config.agent_kind;
+  session_id : string;
+  thread_id : string;
+  system_prompt : string option;
+  mutable message_count : int;
+  mutable processing : bool;
+}
+
+type t = {
+  mutable sessions : session SessionMap.t;
+  mutable last_reload : float;
+}
+
+let sessions_file () =
+  let home = Sys.getenv "HOME" in
+  Filename.concat home ".config/discord-agents/sessions.json"
+
+let lock_file () = sessions_file () ^ ".lock"
+
+(** Serialize sessions to JSON. *)
+let sessions_to_json sessions =
+  let entries = SessionMap.bindings sessions in
+  `List (List.map (fun (_tid, s) ->
+    `Assoc ([
+      ("project_name", `String s.project_name);
+      ("working_dir", `String s.working_dir);
+      ("agent_kind", `String (Config.string_of_agent_kind s.agent_kind));
+      ("session_id", `String s.session_id);
+      ("thread_id", `String s.thread_id);
+      ("message_count", `Int s.message_count);
+    ] @ (match s.system_prompt with
+         | Some sp -> [("system_prompt", `String sp)]
+         | None -> []))
+  ) entries)
+
+(** Deserialize sessions from JSON. *)
+let sessions_of_json json =
+  try
+    let open Yojson.Safe.Util in
+    let entries = to_list json |> List.map (fun j ->
+      let thread_id = j |> member "thread_id" |> to_string in
+      let session = {
+        project_name = j |> member "project_name" |> to_string;
+        working_dir = j |> member "working_dir" |> to_string;
+        agent_kind = (match Config.agent_kind_of_string
+          (j |> member "agent_kind" |> to_string) with
+          | Ok k -> k | Error _ -> Config.Claude);
+        session_id = j |> member "session_id" |> to_string;
+        thread_id;
+        system_prompt = j |> member "system_prompt" |> to_string_option;
+        message_count = j |> member "message_count" |> to_int;
+        processing = false;
+      } in
+      (thread_id, session)
+    ) in
+    List.fold_left (fun acc (tid, s) -> SessionMap.add tid s acc)
+      SessionMap.empty entries
+  with exn ->
+    Logs.warn (fun m -> m "session_store: parse error: %s" (Printexc.to_string exn));
+    SessionMap.empty
+
+(** Save sessions to disk with file locking. *)
+let save (t : t) =
+  let json = sessions_to_json t.sessions in
+  let path = sessions_file () in
+  Resource.with_flock (lock_file ()) (fun () ->
+    Resource.write_file_atomic path (Yojson.Safe.pretty_to_string json))
+
+(** Load sessions from disk. *)
+let load_from_disk () =
+  let path = sessions_file () in
+  if not (Sys.file_exists path) then SessionMap.empty
+  else
+    try
+      let contents = Resource.read_file path in
+      sessions_of_json (Yojson.Safe.from_string contents)
+    with exn ->
+      Logs.warn (fun m -> m "session_store: load error: %s" (Printexc.to_string exn));
+      SessionMap.empty
+
+(** Create a session store, loading persisted sessions from disk. *)
+let create () =
+  { sessions = load_from_disk (); last_reload = Unix.gettimeofday () }
+
+(** Add a session and persist to disk. *)
+let add t ~thread_id session =
+  t.sessions <- SessionMap.add thread_id session t.sessions;
+  save t
+
+(** Remove a session and persist to disk. *)
+let remove t ~thread_id =
+  t.sessions <- SessionMap.remove thread_id t.sessions;
+  save t
+
+(** Find a session by thread ID. *)
+let find_opt t ~thread_id =
+  SessionMap.find_opt thread_id t.sessions
+
+(** Get all sessions as (thread_id, session) pairs. *)
+let bindings t = SessionMap.bindings t.sessions
+
+(** Number of active sessions. *)
+let count t = SessionMap.cardinal t.sessions
+
+(** Increment message count for a session and persist. *)
+let increment_message_count t session =
+  session.message_count <- session.message_count + 1;
+  save t
+
+(** Reload sessions from disk if the file changed.
+    Rate-limited to once per 5 seconds. Merges new sessions
+    from disk without overwriting in-memory state. *)
+let maybe_reload t =
+  let now = Unix.gettimeofday () in
+  if now -. t.last_reload >= 5.0 then begin
+    t.last_reload <- now;
+    let path = sessions_file () in
+    if Sys.file_exists path then
+      try
+        let stat = Unix.stat path in
+        if stat.Unix.st_mtime > t.last_reload -. 5.0 then begin
+          let loaded = load_from_disk () in
+          SessionMap.iter (fun tid session ->
+            if not (SessionMap.mem tid t.sessions) then
+              t.sessions <- SessionMap.add tid session t.sessions
+          ) loaded;
+          Logs.debug (fun m -> m "session_store: reloaded (%d total)"
+            (SessionMap.cardinal t.sessions))
+        end
+      with Unix.Unix_error _ -> ()
+  end


### PR DESCRIPTION
## Summary

Decomposed the 1127-line `bot.ml` monolith into 7 focused modules, each owning its state and enforcing invariants through its API:

| Module | Lines | Responsibility |
|---|---|---|
| `resource.ml` | 57 | Safe file I/O (Fun.protect), atomic writes, flock, UUID |
| `ids.ml` | 41 | Type-safe ID wrappers, case-normalizing Channel_name |
| `command.ml` | 84 | Pure command parsing, fuzzy project matching |
| `session_store.ml` | 142 | Session map + flock persistence, rate-limited reload |
| `channel_manager.ml` | 136 | Project↔channel mapping, on-demand creation, cleanup |
| `agent_runner.ml` | 97 | Streaming agent output, message splitting, typing refresh |
| `claude_sessions.ml` | 142 | Disk session discovery, project dir resolution |
| `bot.ml` | 414 | Thin wiring layer (was 1127) |

### Bugs eliminated by structure

- **FD leaks**: `Resource.with_file_in/out` makes them impossible
- **Session persistence skipped**: `Session_store.add/remove` always persist
- **Case mismatch**: `Channel_manager` always compares case-insensitively
- **Command hijacking**: `Command.is_command` requires `!` prefix
- **Lost-update race**: `Session_store` uses flock on every write
- **Unbounded concurrency**: `session.processing` checked in one place

## Test plan

- [ ] `nix develop --command dune build` passes
- [ ] Bot starts, connects, responds to `!help`
- [ ] `!start discord-agents` creates worktree + thread
- [ ] Messages in thread get streamed Claude responses
- [ ] `!restart` rebuilds and restarts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)