### PR TITLE
feat: handle image attachments from Discord messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _build/
 result
 result-*
 .direnv/
+.discord-attachments/

--- a/lib/agent_runner.ml
+++ b/lib/agent_runner.ml
@@ -59,14 +59,82 @@ let build_context_header ~(session : Session_store.session) ~author_name
     channel_type
     (sanitize_context_value author_name)
 
+(** Check if a content_type string indicates an image. *)
+let is_image_content_type = function
+  | Some ct ->
+    let ct = String.lowercase_ascii ct in
+    String.length ct >= 6 && String.sub ct 0 6 = "image/"
+  | None -> false
+
+(** Check if a filename has an image extension. *)
+let is_image_filename filename =
+  let lf = String.lowercase_ascii filename in
+  List.exists (fun ext -> Filename.check_suffix lf ext)
+    [".png"; ".jpg"; ".jpeg"; ".gif"; ".webp"; ".bmp"; ".svg"]
+
+(** Filter attachments to only images, by content_type or filename. *)
+let image_attachments (attachments : Discord_types.attachment list) =
+  List.filter (fun (a : Discord_types.attachment) ->
+    is_image_content_type a.content_type || is_image_filename a.filename
+  ) attachments
+
+(** Download image attachments to temp files in the working directory.
+    Returns a list of (filename, local_path) for successfully downloaded images. *)
+let download_images ~rest ~working_dir
+    (attachments : Discord_types.attachment list) =
+  let images = image_attachments attachments in
+  List.filter_map (fun (a : Discord_types.attachment) ->
+    (* Cap at 25MB to avoid huge downloads *)
+    if a.size > 25 * 1024 * 1024 then begin
+      Logs.warn (fun m -> m "agent_runner: skipping large attachment %s (%d bytes)"
+        a.filename a.size);
+      None
+    end else
+      let tmp_dir = Filename.concat working_dir ".discord-attachments" in
+      (try Unix.mkdir tmp_dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+      let local_path = Filename.concat tmp_dir
+        (Printf.sprintf "%s_%s" a.id a.filename) in
+      match Discord_rest.download_url rest ~url:a.url () with
+      | Ok data ->
+        (try
+          let oc = open_out_bin local_path in
+          output_string oc data;
+          close_out oc;
+          Some (a.filename, local_path)
+        with exn ->
+          Logs.warn (fun m -> m "agent_runner: failed to save %s: %s"
+            a.filename (Printexc.to_string exn));
+          None)
+      | Error e ->
+        Logs.warn (fun m -> m "agent_runner: failed to download %s: %s"
+          a.filename e);
+        None
+  ) images
+
+(** Build a prompt suffix describing downloaded image attachments.
+    Tells the agent where to find the files so it can use Read to view them. *)
+let image_prompt_suffix downloaded_images =
+  match downloaded_images with
+  | [] -> ""
+  | images ->
+    let lines = List.map (fun (filename, path) ->
+      Printf.sprintf "- %s: %s" filename path
+    ) images in
+    Printf.sprintf "\n\n[Attached images — use the Read tool to view them]\n%s"
+      (String.concat "\n" lines)
+
 (** Run an agent and stream its output to a Discord channel.
     Handles message creation/editing, typing indicators, and splitting.
     Returns Ok () on success, Error msg on failure. *)
 let run ~sw ~env ~rest ~session ~(channel_id : Discord_types.channel_id)
-    ~prompt ~author_name ~channel_name ~channel_type () =
+    ~prompt ?(attachments=[]) ~author_name ~channel_name ~channel_type () =
+  (* Download any image attachments and append paths to the prompt *)
+  let downloaded_images = download_images ~rest
+    ~working_dir:session.Session_store.working_dir attachments in
+  let full_prompt = prompt ^ image_prompt_suffix downloaded_images in
   let context_prompt =
     build_context_header ~session ~author_name ~channel_name ~channel_type
-    ^ prompt
+    ^ full_prompt
   in
   (* Send typing indicator *)
   ignore (Discord_rest.send_typing rest ~channel_id ());

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -354,6 +354,7 @@ let handle_thread_message t msg ?channel_info () =
             resolve_channel_context t ~channel_id ~session ?channel_info () in
           match Agent_runner.run ~sw:t.sw ~env:t.env ~rest:t.rest
                   ~session ~channel_id ~prompt:msg.content
+                  ~attachments:msg.attachments
                   ~author_name ~channel_name ~channel_type () with
           | Ok () ->
             Session_store.increment_message_count t.sessions session

--- a/lib/discord_rest.ml
+++ b/lib/discord_rest.ml
@@ -246,6 +246,24 @@ let get_channel t ~(channel_id : Discord_types.channel_id) () =
      with exn -> Error (Printf.sprintf "get_channel: parse error: %s" (Printexc.to_string exn)))
   | Error e -> Error e
 
+(** Download a file from an arbitrary URL (e.g. Discord CDN).
+    Returns the raw bytes on success. *)
+let download_url t ~url () =
+  let uri = Uri.of_string url in
+  let headers = Http.Header.of_list [
+    ("User-Agent", "DiscordBot (discord-agents/0.1.0, OCaml)");
+  ] in
+  try
+    let (resp, body) =
+      Cohttp_eio.Client.call t.client ~sw:t.sw ~headers `GET uri in
+    let status = Http.Response.status resp in
+    let code = Http.Status.to_int status in
+    let body_str = read_body body in
+    if code >= 200 && code < 300 then Ok body_str
+    else Error (Printf.sprintf "download_url %s: HTTP %d" url code)
+  with exn ->
+    Error (Printf.sprintf "download_url %s: %s" url (Printexc.to_string exn))
+
 (** Get the gateway URL for WebSocket connection. *)
 let get_gateway t =
   match request t ~meth:`GET ~path:"/gateway/bot" () with


### PR DESCRIPTION
## Summary
- Downloads image attachments from Discord CDN to temp files in `.discord-attachments/` within the agent's working directory
- Appends file paths to the prompt so Claude can use its Read tool to view the images
- Filters to image types only (png, jpg, gif, webp, etc.), skips files >25MB

## Changes
- `discord_rest.ml`: new `download_url` function for fetching arbitrary URLs via the existing cohttp-eio client
- `agent_runner.ml`: image filtering, downloading, temp file management, and prompt construction
- `bot.ml`: passes `msg.attachments` through to `agent_runner.run`
- `.gitignore`: excludes `.discord-attachments/`

## Test plan
- [ ] Send a message with an image attachment in a session thread — verify Claude sees and describes the image
- [ ] Send a message with a non-image attachment (e.g. .txt) — verify it's ignored
- [ ] Send a message with no attachments — verify no change in behavior
- [ ] Send multiple images in one message — verify all are downloaded and included

🤖 Generated with [Claude Code](https://claude.com/claude-code)