### PR TITLE
feat: pad table columns for Discord rendering

### DIFF
--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -50,53 +50,106 @@ let is_table_line line =
   let s = String.trim line in
   String.length s > 0 && s.[0] = '|'
 
+(** Parse a table row into cells by splitting on '|'.
+    Strips the leading and trailing empty cells produced by the outer pipes. *)
+let parse_table_cells line =
+  let parts = String.split_on_char '|' line in
+  (* Drop leading empty from "| a | b |" → [""; " a "; " b "; ""] *)
+  let parts = match parts with "" :: rest -> rest | p -> p in
+  let parts = match List.rev parts with "" :: rest -> List.rev rest | _ -> parts in
+  List.map String.trim parts
+
+(** Test whether a row is a separator row (e.g. |---|---|).
+    Separator cells contain only dashes and colons. *)
+let is_separator_row cells =
+  cells <> [] && List.for_all (fun cell ->
+    String.length cell > 0 &&
+    String.to_seq cell |> Seq.for_all (fun c -> c = '-' || c = ':')
+  ) cells
+
+(** Render a table block with padded columns and wrap in a code block.
+    Each column is padded to the maximum cell width in that column.
+    Separator rows are regenerated to match the padded widths. *)
+let render_padded_table table_lines =
+  let parsed = List.map parse_table_cells table_lines in
+  (* Compute max width per column *)
+  let max_cols = List.fold_left (fun acc row -> max acc (List.length row)) 0 parsed in
+  let widths = Array.make max_cols 0 in
+  List.iter (fun cells ->
+    List.iteri (fun i cell ->
+      if i < max_cols && not (is_separator_row [cell]) then
+        widths.(i) <- max widths.(i) (String.length cell)
+    ) cells
+  ) parsed;
+  (* Ensure minimum width of 3 for separator dashes *)
+  Array.iteri (fun i w -> if w < 3 then widths.(i) <- 3) widths;
+  (* Render each row *)
+  let buf = Buffer.create 256 in
+  Buffer.add_string buf "```\n";
+  List.iter (fun cells ->
+    let is_sep = is_separator_row cells in
+    Buffer.add_char buf '|';
+    for i = 0 to max_cols - 1 do
+      let cell = if i < List.length cells then List.nth cells i else "" in
+      let w = widths.(i) in
+      if is_sep then begin
+        Buffer.add_char buf ' ';
+        for _ = 1 to w do Buffer.add_char buf '-' done;
+        Buffer.add_char buf ' '
+      end else begin
+        Buffer.add_char buf ' ';
+        Buffer.add_string buf cell;
+        for _ = 1 to w - String.length cell do Buffer.add_char buf ' ' done;
+        Buffer.add_char buf ' '
+      end;
+      Buffer.add_char buf '|'
+    done;
+    Buffer.add_char buf '\n'
+  ) parsed;
+  Buffer.add_string buf "```";
+  Buffer.contents buf
+
 (** Reformat markdown tables in text for Discord display.
     Discord doesn't render markdown tables, so we wrap them in code blocks
-    to preserve the pipe-aligned layout. Skips tables already inside
+    with padded columns for readable alignment. Skips tables already inside
     code blocks (``` fences). *)
 let reformat_tables text =
   let lines = String.split_on_char '\n' text in
   let buf = Buffer.create (String.length text) in
   let in_code = ref false in
-  let in_table = ref false in
+  let table_acc = ref [] in
   let first = ref true in
-  let add_line line =
+  let add_raw line =
     if not !first then Buffer.add_char buf '\n';
     first := false;
     Buffer.add_string buf line
   in
+  let flush_table () =
+    match !table_acc with
+    | [] -> ()
+    | rows ->
+      let rendered = render_padded_table (List.rev rows) in
+      if not !first then Buffer.add_char buf '\n';
+      first := false;
+      Buffer.add_string buf rendered;
+      table_acc := []
+  in
   List.iter (fun line ->
-    (* Track code block state *)
     let trimmed = String.trim line in
     if String.length trimmed >= 3
        && trimmed.[0] = '`' && trimmed.[1] = '`' && trimmed.[2] = '`' then
       in_code := not !in_code;
     if !in_code then begin
-      (* Inside a code block — pass through, close any open table *)
-      if !in_table then begin
-        add_line "```";
-        in_table := false
-      end;
-      add_line line
-    end else if is_table_line line then begin
-      (* Table row outside a code block — wrap in code block *)
-      if not !in_table then begin
-        add_line "```";
-        in_table := true
-      end;
-      add_line line
-    end else begin
-      (* Non-table line outside code block *)
-      if !in_table then begin
-        add_line "```";
-        in_table := false
-      end;
-      add_line line
+      flush_table ();
+      add_raw line
+    end else if is_table_line line then
+      table_acc := line :: !table_acc
+    else begin
+      flush_table ();
+      add_raw line
     end
   ) lines;
-  (* Close unclosed table block *)
-  if !in_table then
-    add_line "```";
+  flush_table ();
   Buffer.contents buf
 
 (** Find the byte offset where a trailing table block begins.

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,3 @@
 (test
  (name test_formatting)
- (libraries discord_agents alcotest))
+ (libraries discord_agents alcotest str))

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -1,68 +1,135 @@
 (** Tests for Discord message formatting: reformat_tables, find_trailing_table_start,
     split_message, and scan_fences. *)
 
+let reformat = Discord_agents.Agent_process.reformat_tables
+
 (* ── reformat_tables ────────────────────────────────────────────── *)
 
 let test_reformat_plain_text () =
   let input = "Hello world.\nThis is normal text.\n\nAnother paragraph." in
   Alcotest.(check string) "plain text unchanged"
-    input (Discord_agents.Agent_process.reformat_tables input)
+    input (reformat input)
 
 let test_reformat_simple_table () =
   let input = "| Name | Value |\n|------|-------|\n| foo  | bar   |" in
-  let expected = "```\n| Name | Value |\n|------|-------|\n| foo  | bar   |\n```" in
-  Alcotest.(check string) "table wrapped in code block"
-    expected (Discord_agents.Agent_process.reformat_tables input)
+  let expected = String.concat "\n" [
+    "```";
+    "| Name | Value |";
+    "| ---- | ----- |";
+    "| foo  | bar   |";
+    "```" ] in
+  Alcotest.(check string) "table wrapped and padded"
+    expected (reformat input)
 
 let test_reformat_table_with_surrounding_text () =
   let input =
     "Here is a table:\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\nText after the table." in
-  let expected =
-    "Here is a table:\n\n```\n| A | B |\n|---|---|\n| 1 | 2 |\n```\n\nText after the table." in
-  Alcotest.(check string) "text before and after table is normal"
-    expected (Discord_agents.Agent_process.reformat_tables input)
+  let result = reformat input in
+  (* Text before table is unchanged *)
+  Alcotest.(check bool) "starts with intro text"
+    true (String.length result > 16
+          && String.sub result 0 16 = "Here is a table:");
+  (* Text after table is unchanged *)
+  Alcotest.(check bool) "ends with outro text"
+    true (let suffix = "Text after the table." in
+          let rlen = String.length result in
+          let slen = String.length suffix in
+          rlen >= slen && String.sub result (rlen - slen) slen = suffix);
+  (* Table is inside code block *)
+  Alcotest.(check bool) "contains code block"
+    true (let has s = try ignore (Str.search_forward (Str.regexp_string s) result 0); true
+          with Not_found -> false in
+          has "```\n|" && has "|\n```")
 
 let test_reformat_table_inside_code_block () =
   let input = "```\n| A | B |\n| 1 | 2 |\n```" in
   Alcotest.(check string) "table inside code block unchanged"
-    input (Discord_agents.Agent_process.reformat_tables input)
+    input (reformat input)
 
 let test_reformat_table_inside_lang_code_block () =
   let input = "```markdown\n| A | B |\n| 1 | 2 |\n```" in
   Alcotest.(check string) "table inside language code block unchanged"
-    input (Discord_agents.Agent_process.reformat_tables input)
+    input (reformat input)
 
 let test_reformat_multiple_tables () =
   let input =
     "First:\n| A | B |\n| 1 | 2 |\n\nSecond:\n| C | D |\n| 3 | 4 |" in
-  let expected =
-    "First:\n```\n| A | B |\n| 1 | 2 |\n```\n\nSecond:\n```\n| C | D |\n| 3 | 4 |\n```" in
-  Alcotest.(check string) "multiple tables each wrapped"
-    expected (Discord_agents.Agent_process.reformat_tables input)
+  let result = reformat input in
+  (* Count code block pairs *)
+  let count_occurrences _sub s =
+    let rec aux pos acc =
+      match String.index_from_opt s pos '`' with
+      | None -> acc
+      | Some i ->
+        if i + 2 < String.length s && s.[i+1] = '`' && s.[i+2] = '`' then
+          aux (i + 3) (acc + 1)
+        else aux (i + 1) acc
+    in aux 0 0
+  in
+  (* 2 tables × 2 fences each = 4 total ``` *)
+  Alcotest.(check int) "four fence markers"
+    4 (count_occurrences "```" result);
+  Alcotest.(check bool) "starts with First:"
+    true (String.length result >= 6 && String.sub result 0 6 = "First:")
 
 let test_reformat_empty_string () =
   Alcotest.(check string) "empty string unchanged"
-    "" (Discord_agents.Agent_process.reformat_tables "")
+    "" (reformat "")
 
 let test_reformat_table_then_code_block () =
   let input =
     "| A | B |\n| 1 | 2 |\n\n```ocaml\nlet x = 1\n```\n\nDone." in
-  let expected =
-    "```\n| A | B |\n| 1 | 2 |\n```\n\n```ocaml\nlet x = 1\n```\n\nDone." in
-  Alcotest.(check string) "table then code block both correct"
-    expected (Discord_agents.Agent_process.reformat_tables input)
+  let result = reformat input in
+  Alcotest.(check bool) "ends with Done."
+    true (let s = "Done." in let rlen = String.length result in
+          rlen >= 5 && String.sub result (rlen - String.length s) (String.length s) = s);
+  Alcotest.(check bool) "contains ocaml code block"
+    true (try ignore (Str.search_forward (Str.regexp_string "```ocaml") result 0); true
+          with Not_found -> false)
 
 let test_reformat_pipe_in_code_not_table () =
-  (* Pipes inside code blocks should not be treated as tables *)
   let input = "```bash\necho hello | grep h\n```" in
   Alcotest.(check string) "pipe in code block not treated as table"
-    input (Discord_agents.Agent_process.reformat_tables input)
+    input (reformat input)
 
 let test_reformat_single_table_row () =
   let input = "| just one row |" in
-  let expected = "```\n| just one row |\n```" in
-  Alcotest.(check string) "single row wrapped"
-    expected (Discord_agents.Agent_process.reformat_tables input)
+  let result = reformat input in
+  Alcotest.(check bool) "wrapped in code block"
+    true (String.length result >= 3 && String.sub result 0 3 = "```");
+  Alcotest.(check bool) "contains the row"
+    true (try ignore (Str.search_forward (Str.regexp_string "just one row") result 0); true
+          with Not_found -> false)
+
+let test_reformat_padding_alignment () =
+  (* Columns with uneven widths get padded *)
+  let input = "| x | longer column |\n| ab | c |" in
+  let result = reformat input in
+  let lines = String.split_on_char '\n' result in
+  (* Skip ``` lines, check data rows have same length *)
+  let data_lines = List.filter (fun l ->
+    String.length l > 0 && l.[0] = '|') lines in
+  (match data_lines with
+   | a :: b :: _ ->
+     Alcotest.(check int) "rows have equal length"
+       (String.length a) (String.length b)
+   | _ -> Alcotest.fail "expected at least 2 data lines")
+
+let test_reformat_separator_regenerated () =
+  (* Separator row should be regenerated with dashes matching column widths *)
+  let input = "| Name | Value |\n|---|---|\n| foo | bar |" in
+  let result = reformat input in
+  let lines = String.split_on_char '\n' result in
+  let sep_lines = List.filter (fun l ->
+    String.length l > 0 && l.[0] = '|' &&
+    String.to_seq l |> Seq.exists (fun c -> c = '-')
+  ) lines in
+  (match sep_lines with
+   | sep :: _ ->
+     (* Separator should have dashes padded to column width *)
+     Alcotest.(check bool) "separator has padded dashes"
+       true (String.length sep > 10)
+   | [] -> Alcotest.fail "no separator row found")
 
 let reformat_tables_tests = [
   Alcotest.test_case "plain text" `Quick test_reformat_plain_text;
@@ -80,6 +147,9 @@ let reformat_tables_tests = [
   Alcotest.test_case "pipe in code block" `Quick
     test_reformat_pipe_in_code_not_table;
   Alcotest.test_case "single row" `Quick test_reformat_single_table_row;
+  Alcotest.test_case "padding alignment" `Quick test_reformat_padding_alignment;
+  Alcotest.test_case "separator regenerated" `Quick
+    test_reformat_separator_regenerated;
 ]
 
 (* ── find_trailing_table_start ──────────────────────────────────── *)


### PR DESCRIPTION
## Summary
- Tables wrapped in code blocks with padded columns for readable alignment
- Table-aware message splitting keeps tables together across messages
- Code block state cleared on tool→text transitions (fixes monospace leak)
- `split_message` moved to `agent_process.ml` (shared utility)
- 26 unit tests covering all formatting functions

## Test plan
- [x] Tables render with aligned columns in Discord
- [x] Text after tables renders normally (not monospace)
- [x] Tables inside code blocks are not double-wrapped
- [x] All 26 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)