### PR TITLE
feat: initial prompt for new session threads

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -184,5 +184,8 @@ let () =
         end
       in
       loop ());
+    (* Start control API server on Unix domain socket *)
+    Eio.Fiber.fork ~sw (fun () ->
+      Discord_agents.Control_api.start ~bot ~sw ~env);
     Discord_agents.Bot.run ~sw ~env bot
   end

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -77,6 +77,16 @@ let working_dir_of_project (p : Project.t) =
     Ok p.path
 
 (** System prompt for control channel Claude — knows about MCP tools. *)
+(** Shared instructions for agents that can start sessions. *)
+let session_starting_instructions =
+  "When starting a session, ALWAYS provide:\n\
+   - A short descriptive thread_name (max 80 chars) that captures the task — \
+   do NOT include the project name. Example: \"fix auth token refresh bug\"\n\
+   - An initial_prompt that gives the new agent context about what to do. \
+   Summarize the user's request and any relevant context from the conversation. \
+   Keep it concise — the agent should be able to start working immediately, \
+   but hand control back to the user quickly rather than acting autonomously."
+
 let control_system_prompt projects =
   let project_list = String.concat "\n" (List.mapi (fun i (p : Project.t) ->
     Printf.sprintf "  %d. %s (%s)" (i+1) p.name p.path
@@ -98,13 +108,7 @@ USE THESE TOOLS. When the user asks to work on a project, start a session, etc.,
 call the appropriate tool. Prefer the conversational MCP tools over suggesting \
 !commands — the user shouldn't need to use !commands.
 
-When starting a session, ALWAYS provide:
-- A short descriptive thread_name (max 80 chars) that captures the task — \
-do NOT include the project name. Example: \"fix auth token refresh bug\"
-- An initial_prompt that gives the new agent context about what to do. \
-Summarize the user's request and any relevant context from the conversation. \
-Keep it concise — the agent should be able to start working immediately, \
-but hand control back to the user quickly rather than acting autonomously.
+%s
 
 Known projects:
 %s
@@ -116,7 +120,8 @@ stomp on each other's work.
 
 IMPORTANT: When linking to GitHub PRs, issues, or commits, always use full URLs \
 (e.g. https://github.com/owner/repo/pull/1) — never shorthand like owner/repo#1. \
-Discord does not render GitHub shorthand as clickable links." project_list
+Discord does not render GitHub shorthand as clickable links."
+  session_starting_instructions project_list
 
 (** System prompt for project channel Claude — scoped to one project. *)
 let project_system_prompt (project : Project.t) =
@@ -142,13 +147,7 @@ start working on something that needs its own worktree — e.g. \"start a sessio
 code changes will be made.
 - When in doubt, just chat. The user will ask for a thread if they want one.
 
-When starting a session, ALWAYS provide:
-- A short descriptive thread_name (max 80 chars) that captures the task — \
-do NOT include the project name. Example: \"fix auth token refresh bug\"
-- An initial_prompt that gives the new agent context about what to do. \
-Summarize the user's request and any relevant context from the conversation. \
-Keep it concise — the agent should be able to start working immediately, \
-but hand control back to the user quickly rather than acting autonomously.
+%s
 
 Prefer the conversational MCP tools over suggesting !commands.
 Keep responses concise — this is Discord.
@@ -158,7 +157,8 @@ IMPORTANT: When linking to GitHub PRs, issues, or commits, always use full URLs 
 Discord does not render GitHub shorthand as clickable links.
 
 IMPORTANT: When starting sessions, always create a fresh worktree so agents don't \
-stomp on each other's work." project.name project.path
+stomp on each other's work."
+  project.name project.path session_starting_instructions
 
 (** Trigger a graceful restart: drain → reap → build → spawn.
     Callable from command handler or signal handler.
@@ -609,7 +609,7 @@ let handle_thread_message t msg ?channel_info () =
               let had_initial_prompt = Option.is_some session.initial_prompt in
               let prompt = match session.initial_prompt with
                 | Some ctx ->
-                  Printf.sprintf "[Session context from the creating agent: %s]\n\n%s"
+                  Printf.sprintf "<session-context>\n%s\n</session-context>\n\n%s"
                     ctx msg.content
                 | None -> msg.content
               in

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -76,7 +76,6 @@ let working_dir_of_project (p : Project.t) =
   else
     Ok p.path
 
-(** System prompt for control channel Claude — knows about MCP tools. *)
 (** Shared instructions for agents that can start sessions. *)
 let session_starting_instructions =
   "When starting a session, ALWAYS provide:\n\
@@ -737,7 +736,9 @@ let handle_message t (msg : Discord_types.message) =
          handle_thread_message t msg ()
        | None -> ())
     | None ->
-      (* Check if this is a thread under a project channel *)
+      (* Check if this is a thread under a project channel.
+         Since the control API creates sessions directly in bot memory,
+         no disk reload is needed — sessions are always authoritative. *)
       (match Session_store.find_opt t.sessions ~thread_id:msg.channel_id with
        | Some _ -> handle_thread_message t msg ()
        | None ->
@@ -750,29 +751,19 @@ let handle_message t (msg : Discord_types.message) =
             in
             (match parent_project with
              | Some proj_name ->
-               (* This is a thread under a project channel. If no session
-                  exists, it may have just been created by the MCP server.
-                  Force-reload from disk before auto-creating, to avoid
-                  racing with the MCP server and creating a duplicate
-                  session with wrong session_id/working_dir/initial_prompt. *)
-               Session_store.force_reload t.sessions;
-               (match Session_store.find_opt t.sessions ~thread_id:msg.channel_id with
-                | Some _ ->
+               (* Thread under a project channel with no session —
+                  auto-create one (e.g. manually created in Discord). *)
+               let proj = List.find_opt (fun (p : Project.t) ->
+                 p.name = proj_name) t.projects in
+               (match proj with
+                | Some p ->
+                  let wd = match working_dir_of_project p with
+                    | Ok d -> d | Error _ -> p.path in
+                  ensure_channel_session t ~channel_id:msg.channel_id
+                    ~project_name:p.name ~working_dir:wd
+                    ~system_prompt:None;
                   handle_thread_message t msg ~channel_info:ch ()
-                | None ->
-                  (* Still not found after reload — genuinely new thread
-                     (e.g. manually created in Discord). Auto-create. *)
-                  let proj = List.find_opt (fun (p : Project.t) ->
-                    p.name = proj_name) t.projects in
-                  (match proj with
-                   | Some p ->
-                     let wd = match working_dir_of_project p with
-                       | Ok d -> d | Error _ -> p.path in
-                     ensure_channel_session t ~channel_id:msg.channel_id
-                       ~project_name:p.name ~working_dir:wd
-                       ~system_prompt:None;
-                     handle_thread_message t msg ~channel_info:ch ()
-                   | None -> handle_thread_message t msg ()))
+                | None -> handle_thread_message t msg ())
              | None -> handle_thread_message t msg ())
           | Error e ->
             Logs.warn (fun m -> m "bot: channel lookup failed for %s: %s"

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -606,10 +606,9 @@ let handle_thread_message t msg ?channel_info () =
               (* On the first message, prepend any initial context from the
                  session creator (e.g. the project channel agent that started
                  this thread). Consumed once, then cleared. *)
+              let had_initial_prompt = Option.is_some session.initial_prompt in
               let prompt = match session.initial_prompt with
                 | Some ctx ->
-                  session.initial_prompt <- None;
-                  Session_store.save t.sessions;
                   Printf.sprintf "[Session context from the creating agent: %s]\n\n%s"
                     ctx msg.content
                 | None -> msg.content
@@ -625,6 +624,12 @@ let handle_thread_message t msg ?channel_info () =
               | Ok () ->
                 ignore (Discord_rest.create_reaction t.rest ~channel_id
                   ~message_id ~emoji:"\xE2\x9C\x85" ());
+                (* Clear initial_prompt only after successful run so it
+                   survives failures and retries *)
+                if had_initial_prompt then begin
+                  session.initial_prompt <- None;
+                  Session_store.save t.sessions
+                end;
                 Session_store.increment_message_count t.sessions session
               | Error _ ->
                 ignore (Discord_rest.create_reaction t.rest ~channel_id
@@ -706,10 +711,19 @@ let handle_message t (msg : Discord_types.message) =
          handle_thread_message t msg ()
        | None -> ())
     | None ->
-      (* Check if this is a thread under a project channel *)
-      (match Session_store.find_opt t.sessions ~thread_id:msg.channel_id with
-       | Some _ -> handle_thread_message t msg ()
-       | None ->
+      (* Check if this is a thread under a project channel.
+         If not found, force-reload from disk in case the MCP server
+         just created this session (avoids 5-second reload race). *)
+      let session_found =
+        match Session_store.find_opt t.sessions ~thread_id:msg.channel_id with
+        | Some _ -> true
+        | None ->
+          Session_store.force_reload t.sessions;
+          Option.is_some (Session_store.find_opt t.sessions ~thread_id:msg.channel_id)
+      in
+      (match session_found with
+       | true -> handle_thread_message t msg ()
+       | false ->
          (* Look up the channel to find its parent *)
          (match Discord_rest.get_channel t.rest ~channel_id:msg.channel_id () with
           | Ok ch ->

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -98,9 +98,13 @@ USE THESE TOOLS. When the user asks to work on a project, start a session, etc.,
 call the appropriate tool. Prefer the conversational MCP tools over suggesting \
 !commands — the user shouldn't need to use !commands.
 
-When starting a session, ALWAYS provide a short descriptive thread_name (max 80 chars) \
-that captures the task — do NOT include the project name. Example: \
-\"fix auth token refresh bug\" not \"myproject / fix auth token refresh bug\".
+When starting a session, ALWAYS provide:
+- A short descriptive thread_name (max 80 chars) that captures the task — \
+do NOT include the project name. Example: \"fix auth token refresh bug\"
+- An initial_prompt that gives the new agent context about what to do. \
+Summarize the user's request and any relevant context from the conversation. \
+Keep it concise — the agent should be able to start working immediately, \
+but hand control back to the user quickly rather than acting autonomously.
 
 Known projects:
 %s
@@ -138,9 +142,13 @@ start working on something that needs its own worktree — e.g. \"start a sessio
 code changes will be made.
 - When in doubt, just chat. The user will ask for a thread if they want one.
 
-When starting a session, ALWAYS provide a short descriptive thread_name (max 80 chars) \
-that captures the task — do NOT include the project name. Example: \
-\"fix auth token refresh bug\" not \"myproject / fix auth token refresh bug\".
+When starting a session, ALWAYS provide:
+- A short descriptive thread_name (max 80 chars) that captures the task — \
+do NOT include the project name. Example: \"fix auth token refresh bug\"
+- An initial_prompt that gives the new agent context about what to do. \
+Summarize the user's request and any relevant context from the conversation. \
+Keep it concise — the agent should be able to start working immediately, \
+but hand control back to the user quickly rather than acting autonomously.
 
 Prefer the conversational MCP tools over suggesting !commands.
 Keep responses concise — this is Discord.
@@ -336,7 +344,8 @@ let handle_command t msg cmd =
              project_name = p.name; working_dir; agent_kind = kind;
              session_id = Resource.generate_uuid ();
              thread_id = thread_ch.Discord_types.id;
-             system_prompt = None; message_count = 0; processing = false; pending_queue = Queue.create ();
+             system_prompt = None; message_count = 0; processing = false;
+             pending_queue = Queue.create (); initial_prompt = None;
            } in
            Session_store.add t.sessions ~thread_id:thread_ch.id session;
            let branch_str = match branch_info with
@@ -362,7 +371,8 @@ let handle_command t msg cmd =
             project_name = Filename.basename working_dir; working_dir;
             agent_kind = Config.Claude; session_id = full_sid;
             thread_id = thread_ch.Discord_types.id;
-            system_prompt = None; message_count = 1; processing = false; pending_queue = Queue.create ();
+            system_prompt = None; message_count = 1; processing = false;
+            pending_queue = Queue.create (); initial_prompt = None;
           } in
           Session_store.add t.sessions ~thread_id:thread_ch.id session;
           ignore (Discord_rest.create_message t.rest ~channel_id:thread_ch.id
@@ -593,8 +603,19 @@ let handle_thread_message t msg ?channel_info () =
                 child_pid := Some pid;
                 register_child_pid t pid;
                 Logs.info (fun m -> m "bot: registered child pid %d" pid) in
+              (* On the first message, prepend any initial context from the
+                 session creator (e.g. the project channel agent that started
+                 this thread). Consumed once, then cleared. *)
+              let prompt = match session.initial_prompt with
+                | Some ctx ->
+                  session.initial_prompt <- None;
+                  Session_store.save t.sessions;
+                  Printf.sprintf "[Session context from the creating agent: %s]\n\n%s"
+                    ctx msg.content
+                | None -> msg.content
+              in
               let result = Agent_runner.run ~sw:t.sw ~env:t.env ~rest:t.rest
-                      ~session ~channel_id ~prompt:msg.content
+                      ~session ~channel_id ~prompt
                       ~attachments:msg.attachments
                       ~author_name ~channel_name ~channel_type
                       ~wrap_width:t.wrap_width ~on_pid () in
@@ -630,7 +651,8 @@ let ensure_channel_session t ~channel_id ~project_name ~working_dir ~system_prom
     let session : Session_store.session = {
       project_name; working_dir; agent_kind = Config.Claude;
       session_id = Resource.generate_uuid (); thread_id = channel_id;
-      system_prompt; message_count = 0; processing = false; pending_queue = Queue.create ();
+      system_prompt; message_count = 0; processing = false;
+      pending_queue = Queue.create (); initial_prompt = None;
     } in
     Session_store.add t.sessions ~thread_id:channel_id session;
     Logs.info (fun m -> m "bot: auto-created session for %s" project_name)

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -361,14 +361,41 @@ let handle_command t msg cmd =
         Claude_sessions.find_by_prefix session_id) in
       match found with
       | None -> reply (Printf.sprintf "No Claude session matching `%s`." session_id)
-      | Some (full_sid, working_dir) ->
+      | Some (full_sid, raw_working_dir) ->
         let sid_short = String.sub full_sid 0 (min 8 (String.length full_sid)) in
-        match Discord_rest.create_thread_no_message t.rest
-                ~channel_id ~name:(Printf.sprintf "resume / %s" sid_short) () with
+        (* Match working directory to a known project for channel routing *)
+        let matched_project = List.find_opt (fun (p : Project.t) ->
+          raw_working_dir = p.path
+          || (String.length raw_working_dir > String.length p.path + 1
+              && String.sub raw_working_dir 0 (String.length p.path + 1)
+                 = p.path ^ "/")
+        ) t.projects in
+        let thread_parent = match matched_project with
+          | Some p ->
+            (match Channel_manager.find_or_create ~rest:t.rest
+                     ~guild_id:t.config.guild_id ~project:p t.channels with
+             | Some ch_id -> ch_id
+             | None -> channel_id)
+          | None -> channel_id
+        in
+        (* If working_dir is a bare repo root, use the main worktree instead *)
+        let working_dir = match matched_project with
+          | Some p when p.is_bare && raw_working_dir = p.path ->
+            (match working_dir_of_project p with
+             | Ok wd -> wd
+             | Error _ -> raw_working_dir)
+          | _ -> raw_working_dir
+        in
+        let project_name = match matched_project with
+          | Some p -> p.name
+          | None -> Filename.basename raw_working_dir
+        in
+        (match Discord_rest.create_thread_no_message t.rest
+                ~channel_id:thread_parent ~name:(Printf.sprintf "resume / %s" sid_short) () with
         | Error e -> reply (Printf.sprintf "Failed to create thread: %s" e)
         | Ok thread_ch ->
           let session : Session_store.session = {
-            project_name = Filename.basename working_dir; working_dir;
+            project_name; working_dir;
             agent_kind = Config.Claude; session_id = full_sid;
             thread_id = thread_ch.Discord_types.id;
             system_prompt = None; message_count = 1; processing = false;
@@ -378,7 +405,7 @@ let handle_command t msg cmd =
           ignore (Discord_rest.create_message t.rest ~channel_id:thread_ch.id
             ~content:(Printf.sprintf
               "**Resumed** Claude session `%s`\nWorking in: `%s`\nSend a message to continue."
-              sid_short working_dir) ()))
+              sid_short working_dir) ())))
   | Command.Stop_session { thread_id } ->
     (match Session_store.find_opt t.sessions ~thread_id with
      | None -> reply "Session not found."

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -652,11 +652,10 @@ let handle_thread_message t msg ?channel_info () =
                 ignore (Discord_rest.create_reaction t.rest ~channel_id
                   ~message_id ~emoji:"\xE2\x9C\x85" ());
                 (* Clear initial_prompt only after successful run so it
-                   survives failures and retries *)
-                if had_initial_prompt then begin
+                   survives failures and retries. Cleared before
+                   increment_message_count to persist in a single save. *)
+                if had_initial_prompt then
                   session.initial_prompt <- None;
-                  Session_store.save t.sessions
-                end;
                 Session_store.increment_message_count t.sessions session
               | Error _ ->
                 ignore (Discord_rest.create_reaction t.rest ~channel_id
@@ -738,19 +737,10 @@ let handle_message t (msg : Discord_types.message) =
          handle_thread_message t msg ()
        | None -> ())
     | None ->
-      (* Check if this is a thread under a project channel.
-         If not found, force-reload from disk in case the MCP server
-         just created this session (avoids 5-second reload race). *)
-      let session_found =
-        match Session_store.find_opt t.sessions ~thread_id:msg.channel_id with
-        | Some _ -> true
-        | None ->
-          Session_store.force_reload t.sessions;
-          Option.is_some (Session_store.find_opt t.sessions ~thread_id:msg.channel_id)
-      in
-      (match session_found with
-       | true -> handle_thread_message t msg ()
-       | false ->
+      (* Check if this is a thread under a project channel *)
+      (match Session_store.find_opt t.sessions ~thread_id:msg.channel_id with
+       | Some _ -> handle_thread_message t msg ()
+       | None ->
          (* Look up the channel to find its parent *)
          (match Discord_rest.get_channel t.rest ~channel_id:msg.channel_id () with
           | Ok ch ->
@@ -760,20 +750,29 @@ let handle_message t (msg : Discord_types.message) =
             in
             (match parent_project with
              | Some proj_name ->
-               let proj = List.find_opt (fun (p : Project.t) ->
-                 p.name = proj_name) t.projects in
-               (match proj with
-                | Some p ->
-                  let wd = match working_dir_of_project p with
-                    | Ok d -> d | Error _ -> p.path in
-                  (* Worker threads get no system prompt — they're focused agents.
-                     They still get MCP tools via agent_process.ml. *)
-                  ensure_channel_session t ~channel_id:msg.channel_id
-                    ~project_name:p.name ~working_dir:wd
-                    ~system_prompt:None;
-                  (* Pass the already-fetched channel info to avoid a second API call *)
+               (* This is a thread under a project channel. If no session
+                  exists, it may have just been created by the MCP server.
+                  Force-reload from disk before auto-creating, to avoid
+                  racing with the MCP server and creating a duplicate
+                  session with wrong session_id/working_dir/initial_prompt. *)
+               Session_store.force_reload t.sessions;
+               (match Session_store.find_opt t.sessions ~thread_id:msg.channel_id with
+                | Some _ ->
                   handle_thread_message t msg ~channel_info:ch ()
-                | None -> handle_thread_message t msg ())
+                | None ->
+                  (* Still not found after reload — genuinely new thread
+                     (e.g. manually created in Discord). Auto-create. *)
+                  let proj = List.find_opt (fun (p : Project.t) ->
+                    p.name = proj_name) t.projects in
+                  (match proj with
+                   | Some p ->
+                     let wd = match working_dir_of_project p with
+                       | Ok d -> d | Error _ -> p.path in
+                     ensure_channel_session t ~channel_id:msg.channel_id
+                       ~project_name:p.name ~working_dir:wd
+                       ~system_prompt:None;
+                     handle_thread_message t msg ~channel_info:ch ()
+                   | None -> handle_thread_message t msg ()))
              | None -> handle_thread_message t msg ())
           | Error e ->
             Logs.warn (fun m -> m "bot: channel lookup failed for %s: %s"

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -1,0 +1,324 @@
+(** Unix domain socket control API — JSON-RPC-style server.
+
+    Runs as a daemon fiber inside the bot's main switch. Accepts
+    connections on a Unix socket, reads one JSON request per connection,
+    dispatches to bot operations, and writes one JSON response.
+
+    Protocol: line-delimited JSON over Unix domain socket.
+    Request:  {"method": "...", "params": {...}}
+    Response: {"ok": true, ...} or {"error": "..."}
+
+    Replaces the MCP server's direct session file / Discord REST access. *)
+
+let socket_path () =
+  let home = Sys.getenv "HOME" in
+  Filename.concat home ".config/discord-agents/control.sock"
+
+(** Read one line from a buffered reader, up to a size limit. *)
+let read_line_limited reader =
+  try
+    let line = Eio.Buf_read.line reader in
+    if String.length line > 1_000_000 then
+      Error "request too large"
+    else
+      Ok line
+  with
+  | End_of_file -> Error "empty request"
+  | exn -> Error (Printexc.to_string exn)
+
+(** Send a JSON response and close. *)
+let send_response flow json =
+  let data = Yojson.Safe.to_string json ^ "\n" in
+  try Eio.Flow.copy_string data flow
+  with _ -> ()  (* client may have disconnected *)
+
+let ok_response body =
+  `Assoc (("ok", `Bool true) :: body)
+
+let error_response msg =
+  `Assoc [("error", `String msg)]
+
+(* ── Handlers ──────────────────────────────────────────────────── *)
+
+let handle_health (bot : Bot.t) =
+  let uptime = int_of_float (Unix.gettimeofday () -. bot.started_at) in
+  ok_response [
+    ("uptime_seconds", `Int uptime);
+    ("sessions", `Int (Session_store.count bot.sessions));
+    ("projects", `Int (List.length bot.projects));
+    ("channels", `Int (Channel_manager.count bot.channels));
+  ]
+
+let handle_list_projects (bot : Bot.t) =
+  let projects = List.map (fun (p : Project.t) ->
+    `Assoc [
+      ("name", `String p.name);
+      ("path", `String p.path);
+      ("is_bare", `Bool p.is_bare);
+    ]
+  ) bot.projects in
+  ok_response [("projects", `List projects)]
+
+let handle_list_sessions (bot : Bot.t) =
+  let entries = Session_store.bindings bot.sessions in
+  let sessions = List.map (fun (_tid, (s : Session_store.session)) ->
+    `Assoc [
+      ("project_name", `String s.project_name);
+      ("agent_kind", `String (Config.string_of_agent_kind s.agent_kind));
+      ("message_count", `Int s.message_count);
+      ("thread_id", `String s.thread_id);
+      ("session_id", `String s.session_id);
+    ]
+  ) entries in
+  ok_response [("sessions", `List sessions)]
+
+let handle_list_claude_sessions _bot params =
+  let hours = match params with
+    | Some (`Assoc l) ->
+      (match List.assoc_opt "hours" l with
+       | Some (`Int h) -> h | _ -> 24)
+    | _ -> 24 in
+  let sessions = Claude_sessions.discover ~hours () in
+  let items = List.map (fun (s : Claude_sessions.info) ->
+    let sid_short = String.sub s.session_id 0
+      (min 8 (String.length s.session_id)) in
+    let age_min = int_of_float ((Unix.gettimeofday () -. s.mtime) /. 60.0) in
+    `Assoc [
+      ("session_id", `String s.session_id);
+      ("session_id_short", `String sid_short);
+      ("project_dir", `String s.project_dir);
+      ("working_dir", `String s.working_dir);
+      ("summary", `String s.summary);
+      ("age_minutes", `Int age_min);
+    ]
+  ) sessions in
+  ok_response [("sessions", `List items)]
+
+let handle_start_session (bot : Bot.t) params =
+  let open Yojson.Safe.Util in
+  let params = match params with Some p -> p | None ->
+    failwith "missing params" in
+  let project_str = params |> member "project" |> to_string in
+  let kind_str = match params |> member "agent" |> to_string_option with
+    | Some s -> s | None -> "claude" in
+  let kind = match Config.agent_kind_of_string kind_str with
+    | Ok k -> k | Error _ -> failwith ("unknown agent: " ^ kind_str) in
+  let thread_name = params |> member "thread_name" |> to_string_option in
+  let initial_prompt = params |> member "initial_prompt" |> to_string_option in
+  let initial_prompt = match initial_prompt with
+    | Some s ->
+      let s = String.trim s in
+      let s = if String.length s > 4000
+        then String.sub s 0 4000 else s in
+      if s = "" then None else Some s
+    | None -> None in
+  match Command.find_project_fuzzy bot.projects project_str with
+  | None -> error_response (Printf.sprintf "No project matching '%s'." project_str)
+  | Some p ->
+    let kind_str = Config.string_of_agent_kind kind in
+    let branch_name = Printf.sprintf "agent/%s-%s"
+      kind_str (String.sub (Resource.generate_uuid ()) 0 8) in
+    let working_dir, branch_info =
+      match Project.create_worktree p ~branch_name with
+      | Ok wt -> wt, Some branch_name
+      | Error e ->
+        Logs.warn (fun m -> m "control_api: worktree failed: %s" e);
+        (match Bot.working_dir_of_project p with
+         | Ok wd -> wd, None
+         | Error _ -> "", None)
+    in
+    if working_dir = "" then
+      error_response "No working directory available."
+    else
+      let thread_display_name = match thread_name with
+        | Some n when String.length (String.trim n) > 0 ->
+          let n = String.trim n in
+          if String.length n > 80 then String.sub n 0 80 else n
+        | _ -> Printf.sprintf "%s / %s" kind_str p.name
+      in
+      let thread_parent =
+        match Channel_manager.find_or_create ~rest:bot.rest
+                ~guild_id:bot.config.guild_id ~project:p bot.channels with
+        | Some ch_id -> ch_id
+        | None ->
+          (match bot.config.control_channel_id with
+           | Some ctl -> ctl | None -> "")
+      in
+      if thread_parent = "" then
+        error_response "No channel found for thread creation."
+      else
+        match Discord_rest.create_thread_no_message bot.rest
+                ~channel_id:thread_parent ~name:thread_display_name () with
+        | Error e -> error_response (Printf.sprintf "Failed to create thread: %s" e)
+        | Ok thread_ch ->
+          let session_id = Resource.generate_uuid () in
+          let session : Session_store.session = {
+            project_name = p.name; working_dir; agent_kind = kind;
+            session_id; thread_id = thread_ch.Discord_types.id;
+            system_prompt = None; message_count = 0; processing = false;
+            pending_queue = Queue.create (); initial_prompt;
+          } in
+          Session_store.add bot.sessions ~thread_id:thread_ch.id session;
+          let branch_str = match branch_info with
+            | Some b -> Printf.sprintf "\nBranch: `%s`" b | None -> "" in
+          ignore (Discord_rest.create_message bot.rest ~channel_id:thread_ch.id
+            ~content:(Printf.sprintf
+              "**%s** session started for **%s**%s\nWorking in: `%s`\nSend a message to interact."
+              kind_str p.name branch_str working_dir) ());
+          ok_response [
+            ("thread_id", `String thread_ch.id);
+            ("working_dir", `String working_dir);
+            ("branch", match branch_info with
+              | Some b -> `String b | None -> `Null);
+            ("project_name", `String p.name);
+            ("session_id", `String session_id);
+          ]
+
+let handle_resume_session (bot : Bot.t) params =
+  let open Yojson.Safe.Util in
+  let params = match params with Some p -> p | None ->
+    failwith "missing params" in
+  let sid_prefix = params |> member "session_id" |> to_string in
+  let found = Eio_unix.run_in_systhread (fun () ->
+    Claude_sessions.find_by_prefix sid_prefix) in
+  match found with
+  | None -> error_response (Printf.sprintf "No Claude session matching '%s'." sid_prefix)
+  | Some (full_sid, raw_working_dir) ->
+    let sid_short = String.sub full_sid 0 (min 8 (String.length full_sid)) in
+    let matched_project = List.find_opt (fun (p : Project.t) ->
+      raw_working_dir = p.path
+      || (String.length raw_working_dir > String.length p.path + 1
+          && String.sub raw_working_dir 0 (String.length p.path + 1)
+             = p.path ^ "/")
+    ) bot.projects in
+    let thread_parent = match matched_project with
+      | Some p ->
+        (match Channel_manager.find_or_create ~rest:bot.rest
+                 ~guild_id:bot.config.guild_id ~project:p bot.channels with
+         | Some ch_id -> ch_id
+         | None ->
+           (match bot.config.control_channel_id with
+            | Some ctl -> ctl | None -> ""))
+      | None ->
+        (match bot.config.control_channel_id with
+         | Some ctl -> ctl | None -> "")
+    in
+    if thread_parent = "" then
+      error_response "No channel found for thread creation."
+    else
+      let working_dir = match matched_project with
+        | Some p when p.is_bare && raw_working_dir = p.path ->
+          (match Bot.working_dir_of_project p with
+           | Ok wd -> wd | Error _ -> raw_working_dir)
+        | _ -> raw_working_dir
+      in
+      let project_name = match matched_project with
+        | Some p -> p.name
+        | None -> Filename.basename raw_working_dir
+      in
+      let thread_name = Printf.sprintf "resume / %s" sid_short in
+      (match Discord_rest.create_thread_no_message bot.rest
+              ~channel_id:thread_parent ~name:thread_name () with
+      | Error e -> error_response (Printf.sprintf "Failed to create thread: %s" e)
+      | Ok thread_ch ->
+        let session : Session_store.session = {
+          project_name; working_dir;
+          agent_kind = Config.Claude; session_id = full_sid;
+          thread_id = thread_ch.Discord_types.id;
+          system_prompt = None; message_count = 1; processing = false;
+          pending_queue = Queue.create (); initial_prompt = None;
+        } in
+        Session_store.add bot.sessions ~thread_id:thread_ch.id session;
+        ignore (Discord_rest.create_message bot.rest ~channel_id:thread_ch.id
+          ~content:(Printf.sprintf
+            "**Resumed** Claude session `%s`\nWorking in: `%s`\nSend a message to continue."
+            sid_short working_dir) ());
+        ok_response [
+          ("thread_id", `String thread_ch.id);
+          ("working_dir", `String working_dir);
+          ("session_id", `String full_sid);
+          ("project_name", `String project_name);
+        ])
+
+let handle_restart (bot : Bot.t) =
+  Bot.trigger_restart bot ~notify:(fun msg ->
+    Logs.info (fun m -> m "control_api restart: %s" msg));
+  ok_response [("message", `String "Restart initiated.")]
+
+let handle_rename_thread (bot : Bot.t) params =
+  let open Yojson.Safe.Util in
+  let params = match params with Some p -> p | None ->
+    failwith "missing params" in
+  let thread_id = params |> member "thread_id" |> to_string in
+  let name = params |> member "name" |> to_string in
+  match Discord_rest.modify_channel bot.rest ~channel_id:thread_id ~name () with
+  | Ok _ -> ok_response [("message", `String (Printf.sprintf "Renamed to %s." name))]
+  | Error e -> error_response (Printf.sprintf "Rename failed: %s" e)
+
+let handle_cleanup_channels (bot : Bot.t) =
+  match Channel_manager.cleanup ~rest:bot.rest
+          ~guild_id:bot.config.guild_id ~projects:bot.projects bot.channels with
+  | Error e -> error_response (Printf.sprintf "Cleanup failed: %s" e)
+  | Ok 0 -> ok_response [("deleted", `Int 0); ("message", `String "No stale channels.")]
+  | Ok n -> ok_response [("deleted", `Int n);
+      ("message", `String (Printf.sprintf "Cleaned up %d stale channels." n))]
+
+(* ── Router ────────────────────────────────────────────────────── *)
+
+let dispatch (bot : Bot.t) method_ params =
+  try
+    match method_ with
+    | "health" -> handle_health bot
+    | "list_projects" -> handle_list_projects bot
+    | "list_sessions" -> handle_list_sessions bot
+    | "list_claude_sessions" -> handle_list_claude_sessions bot params
+    | "start_session" -> handle_start_session bot params
+    | "resume_session" -> handle_resume_session bot params
+    | "restart" -> handle_restart bot
+    | "rename_thread" -> handle_rename_thread bot params
+    | "cleanup_channels" -> handle_cleanup_channels bot
+    | _ -> error_response (Printf.sprintf "Unknown method: %s" method_)
+  with exn ->
+    Logs.warn (fun m -> m "control_api: handler error: %s" (Printexc.to_string exn));
+    error_response (Printexc.to_string exn)
+
+(* ── Connection handler ────────────────────────────────────────── *)
+
+let handle_connection bot flow =
+  let reader = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) flow in
+  match read_line_limited reader with
+  | Error e ->
+    send_response flow (error_response e)
+  | Ok line ->
+    let response = match Yojson.Safe.from_string line with
+      | exception _ -> error_response "invalid JSON"
+      | json ->
+        let open Yojson.Safe.Util in
+        let method_ = json |> member "method" |> to_string_option in
+        let params = match json |> member "params" with
+          | `Null -> None | p -> Some p in
+        (match method_ with
+         | None -> error_response "missing 'method' field"
+         | Some m -> dispatch bot m params)
+    in
+    send_response flow response
+
+(* ── Server ────────────────────────────────────────────────────── *)
+
+let start ~(bot : Bot.t) ~sw ~(env : Eio_unix.Stdenv.base) =
+  let path = socket_path () in
+  (* Remove stale socket from a previous run *)
+  (try Unix.unlink path with Unix.Unix_error _ -> ());
+  let net = Eio.Stdenv.net env in
+  let addr = `Unix path in
+  let socket = Eio.Net.listen ~sw ~backlog:5 ~reuse_addr:true net addr in
+  Logs.info (fun m -> m "control_api: listening on %s" path);
+  (* Accept loop — each connection handled in its own fiber *)
+  let rec accept_loop () =
+    let flow, _addr = Eio.Net.accept ~sw socket in
+    Eio.Fiber.fork ~sw (fun () ->
+      Fun.protect ~finally:(fun () -> Eio.Flow.close flow) (fun () ->
+        handle_connection bot flow));
+    accept_loop ()
+  in
+  accept_loop ()

--- a/lib/discord_agents.ml
+++ b/lib/discord_agents.ml
@@ -15,3 +15,4 @@ module Claude_sessions = Claude_sessions
 module Session = Session
 module Websocket = Websocket
 module Bot = Bot
+module Control_api = Control_api

--- a/lib/session_store.ml
+++ b/lib/session_store.ml
@@ -130,6 +130,18 @@ let increment_message_count t session =
   session.message_count <- session.message_count + 1;
   save t
 
+(** Force-reload sessions from disk, bypassing the rate limit.
+    Merges new sessions from disk without overwriting in-memory state.
+    Use when a message arrives for an unknown thread that may have been
+    created externally (e.g. by the MCP server). *)
+let force_reload t =
+  let loaded = load_from_disk () in
+  SessionMap.iter (fun tid session ->
+    if not (SessionMap.mem tid t.sessions) then
+      t.sessions <- SessionMap.add tid session t.sessions
+  ) loaded;
+  t.last_reload <- Unix.gettimeofday ()
+
 (** Reload sessions from disk if the file changed.
     Rate-limited to once per 5 seconds. Merges new sessions
     from disk without overwriting in-memory state. *)

--- a/lib/session_store.ml
+++ b/lib/session_store.ml
@@ -130,21 +130,12 @@ let increment_message_count t session =
   session.message_count <- session.message_count + 1;
   save t
 
-(** Force-reload sessions from disk, bypassing the rate limit.
-    Merges new sessions from disk without overwriting in-memory state.
-    Use when a message arrives for an unknown thread that may have been
-    created externally (e.g. by the MCP server). *)
-let force_reload t =
-  let loaded = load_from_disk () in
-  SessionMap.iter (fun tid session ->
-    if not (SessionMap.mem tid t.sessions) then
-      t.sessions <- SessionMap.add tid session t.sessions
-  ) loaded;
-  t.last_reload <- Unix.gettimeofday ()
-
 (** Reload sessions from disk if the file changed.
     Rate-limited to once per 5 seconds. Merges new sessions
-    from disk without overwriting in-memory state. *)
+    from disk without overwriting in-memory state.
+    NOTE: With the control API, the bot is the sole session writer.
+    This is kept for crash recovery (loading persisted state on startup)
+    but is no longer needed for cross-process synchronization. *)
 let maybe_reload t =
   let now = Unix.gettimeofday () in
   if now -. t.last_reload >= 5.0 then begin

--- a/lib/session_store.ml
+++ b/lib/session_store.ml
@@ -21,6 +21,7 @@ type session = {
   mutable message_count : int;
   mutable processing : bool;
   pending_queue : pending_message Queue.t;
+  mutable initial_prompt : string option;  (* One-shot context for the first message *)
 }
 
 type t = {
@@ -47,6 +48,9 @@ let sessions_to_json sessions =
       ("message_count", `Int s.message_count);
     ] @ (match s.system_prompt with
          | Some sp -> [("system_prompt", `String sp)]
+         | None -> [])
+      @ (match s.initial_prompt with
+         | Some ip -> [("initial_prompt", `String ip)]
          | None -> []))
   ) entries)
 
@@ -68,6 +72,7 @@ let sessions_of_json json =
         message_count = j |> member "message_count" |> to_int;
         processing = false;
         pending_queue = Queue.create ();
+        initial_prompt = j |> member "initial_prompt" |> to_string_option;
       } in
       (thread_id, session)
     ) in

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -45,6 +45,7 @@ def _with_sessions_lock(fn):
             fcntl.flock(lock_fd, fcntl.LOCK_UN)
 
 def load_sessions():
+    """Load sessions (read-only). Lock held only during read."""
     def _load():
         if SESSIONS_FILE.exists():
             try:
@@ -54,13 +55,31 @@ def load_sessions():
         return []
     return _with_sessions_lock(_load)
 
+def _save_sessions_unlocked(sessions):
+    """Write sessions to disk. Caller must hold the lock."""
+    tmp = SESSIONS_FILE.with_suffix('.json.tmp')
+    tmp.write_text(json.dumps(sessions, indent=2) + "\n")
+    tmp.rename(SESSIONS_FILE)
+
 def save_sessions(sessions):
     """Atomic write with file locking."""
-    def _save():
-        tmp = SESSIONS_FILE.with_suffix('.json.tmp')
-        tmp.write_text(json.dumps(sessions, indent=2) + "\n")
-        tmp.rename(SESSIONS_FILE)
-    _with_sessions_lock(_save)
+    _with_sessions_lock(lambda: _save_sessions_unlocked(sessions))
+
+def modify_sessions(fn):
+    """Atomically load, modify, and save sessions under a single lock.
+    fn receives the session list and must return the modified list."""
+    def _modify():
+        if SESSIONS_FILE.exists():
+            try:
+                sessions = json.loads(SESSIONS_FILE.read_text())
+            except json.JSONDecodeError:
+                sessions = []
+        else:
+            sessions = []
+        result = fn(sessions)
+        _save_sessions_unlocked(result)
+        return result
+    return _with_sessions_lock(_modify)
 
 # --- Discord REST helpers ---
 
@@ -481,9 +500,8 @@ def handle_tool_call(name, arguments, config, projects):
         thread_id = result.get("id", "")
         session_id = str(uuid.uuid4())
 
-        # Add to sessions
+        # Add to sessions (atomic load+modify+save to avoid races)
         initial_prompt = arguments.get("initial_prompt", "").strip()[:4000] or None
-        sessions = load_sessions()
         session_entry = {
             "project_name": proj["name"],
             "working_dir": worktree_path,
@@ -494,8 +512,7 @@ def handle_tool_call(name, arguments, config, projects):
         }
         if initial_prompt:
             session_entry["initial_prompt"] = initial_prompt
-        sessions.append(session_entry)
-        save_sessions(sessions)
+        modify_sessions(lambda ss: ss + [session_entry])
 
         # Post welcome message
         discord_request("POST", f"/channels/{thread_id}/messages", token, {
@@ -544,16 +561,14 @@ def handle_tool_call(name, arguments, config, projects):
 
         thread_id = result.get("id", "")
 
-        sessions = load_sessions()
-        sessions.append({
+        modify_sessions(lambda ss: ss + [{
             "project_name": Path(working_dir).name,
             "working_dir": working_dir,
             "agent_kind": "claude",
             "session_id": full_sid,
             "thread_id": thread_id,
             "message_count": 1,  # >0 so bot uses --resume
-        })
-        save_sessions(sessions)
+        }])
 
         discord_request("POST", f"/channels/{thread_id}/messages", token, {
             "content": f"**Resumed** Claude session `{full_sid[:8]}`\n"

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -546,12 +546,35 @@ def handle_tool_call(name, arguments, config, projects):
         # Resolve working dir from project dir name
         working_dir = resolve_project_dir(proj_dir_name)
 
-        channel_id = control_channel or ""
-        if not channel_id:
-            return "No control channel configured."
+        # Match working directory to a known project for channel routing
+        matched_project = None
+        for p in projects:
+            if working_dir == p["path"] or working_dir.startswith(p["path"] + "/"):
+                matched_project = p
+                break
+
+        # Route thread to project channel (like start_session does)
+        target_channel = control_channel or ""
+        if matched_project and guild_id and token:
+            channels = discord_request("GET", f"/guilds/{guild_id}/channels", token)
+            if isinstance(channels, list):
+                for ch in channels:
+                    if (ch.get("name", "").lower() == matched_project["name"].lower()
+                            and ch.get("type") == 0):
+                        target_channel = ch["id"]
+                        break
+
+        if not target_channel:
+            return "No channel found for thread creation."
+
+        # If working_dir is a bare repo root, use the main worktree instead
+        if matched_project and matched_project["is_bare"] and working_dir == matched_project["path"]:
+            working_dir = find_working_dir(matched_project)
+
+        project_name = matched_project["name"] if matched_project else Path(working_dir).name
 
         thread_name = f"resume / {full_sid[:8]}"
-        result = discord_request("POST", f"/channels/{channel_id}/threads", token, {
+        result = discord_request("POST", f"/channels/{target_channel}/threads", token, {
             "name": thread_name,
             "type": 11,
             "auto_archive_duration": 1440,
@@ -562,7 +585,7 @@ def handle_tool_call(name, arguments, config, projects):
         thread_id = result.get("id", "")
 
         modify_sessions(lambda ss: ss + [{
-            "project_name": Path(working_dir).name,
+            "project_name": project_name,
             "working_dir": working_dir,
             "agent_kind": "claude",
             "session_id": full_sid,

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -1,321 +1,61 @@
 #!/usr/bin/env python3
 """MCP server for discord-agents bot control.
 
-Exposes bot operations as tools that Claude can call natively via
-the tool-use protocol. Communicates with Discord via REST API and
-manages sessions via the shared sessions.json file.
+Thin stdio-to-UDS proxy: receives MCP tool calls via JSON-RPC over stdin,
+forwards them to the bot's control API over a Unix domain socket, and
+returns the formatted response.
+
+All session state, Discord REST calls, and worktree management are owned
+by the bot process. This server never touches sessions.json or Discord
+directly.
 
 Protocol: JSON-RPC 2.0 over stdio (MCP standard).
 """
 
 import json
-import os
-import signal
+import socket
 import sys
-import subprocess
-import urllib.request
-import uuid
-import time
 from pathlib import Path
 
 # --- Configuration ---
 
 CONFIG_DIR = Path.home() / ".config" / "discord-agents"
-CONFIG_FILE = CONFIG_DIR / "config.json"
-SESSIONS_FILE = CONFIG_DIR / "sessions.json"
+CONTROL_SOCKET = CONFIG_DIR / "control.sock"
 
-def load_config():
-    if CONFIG_FILE.exists():
-        return json.loads(CONFIG_FILE.read_text())
-    return {}
+# --- Bot control API client ---
 
-SESSIONS_LOCK = CONFIG_DIR / "sessions.json.lock"
-
-import fcntl
-
-def _with_sessions_lock(fn):
-    """Execute fn while holding an exclusive lock on sessions.json.lock.
-    Prevents lost-update races between the bot and MCP server.
-    Uses fcntl.lockf (POSIX record locks) to match the OCaml side's
-    Unix.lockf — flock and lockf are independent lock families on Linux. """
-    SESSIONS_LOCK.parent.mkdir(parents=True, exist_ok=True)
-    with open(SESSIONS_LOCK, 'w') as lock_fd:
-        fcntl.lockf(lock_fd, fcntl.LOCK_EX)
-        try:
-            return fn()
-        finally:
-            fcntl.lockf(lock_fd, fcntl.LOCK_UN)
-
-def load_sessions():
-    """Load sessions (read-only). Lock held only during read."""
-    def _load():
-        if SESSIONS_FILE.exists():
-            try:
-                return json.loads(SESSIONS_FILE.read_text())
-            except json.JSONDecodeError:
-                return []
-        return []
-    return _with_sessions_lock(_load)
-
-def _save_sessions_unlocked(sessions):
-    """Write sessions to disk. Caller must hold the lock."""
-    tmp = SESSIONS_FILE.with_suffix('.json.tmp')
-    tmp.write_text(json.dumps(sessions, indent=2) + "\n")
-    tmp.rename(SESSIONS_FILE)
-
-def save_sessions(sessions):
-    """Atomic write with file locking."""
-    _with_sessions_lock(lambda: _save_sessions_unlocked(sessions))
-
-def modify_sessions(fn):
-    """Atomically load, modify, and save sessions under a single lock.
-    fn receives the session list and must return the modified list."""
-    def _modify():
-        if SESSIONS_FILE.exists():
-            try:
-                sessions = json.loads(SESSIONS_FILE.read_text())
-            except json.JSONDecodeError:
-                sessions = []
-        else:
-            sessions = []
-        result = fn(sessions)
-        _save_sessions_unlocked(result)
-        return result
-    return _with_sessions_lock(_modify)
-
-# --- Discord REST helpers ---
-
-def discord_request(method, path, token, body=None):
-    url = f"https://discord.com/api/v10{path}"
-    data = json.dumps(body).encode() if body else None
-    req = urllib.request.Request(url, data=data, method=method, headers={
-        "Authorization": f"Bot {token}",
-        "Content-Type": "application/json",
-        "User-Agent": "DiscordBot (discord-agents-mcp/0.1.0)",
-    })
+def control_request(method, params=None, timeout=60):
+    """Send a JSON request to the bot's control API over Unix domain socket.
+    Returns the parsed JSON response, or {"error": "..."} on failure."""
+    request = {"method": method}
+    if params:
+        request["params"] = params
     try:
-        resp = urllib.request.urlopen(req, timeout=30)
-        if resp.status == 204:
-            return {"ok": True}
-        return json.loads(resp.read())
-    except urllib.error.HTTPError as e:
-        try:
-            body = e.read().decode()[:200]
-        except Exception:
-            body = "(unreadable)"
-        return {"error": f"HTTP {e.code}: {body}"}
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(timeout)
+        sock.connect(str(CONTROL_SOCKET))
+        sock.sendall((json.dumps(request) + "\n").encode())
+        # Read response (one JSON line)
+        data = b""
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+            if b"\n" in data:
+                break
+        sock.close()
+        return json.loads(data.decode().strip())
+    except FileNotFoundError:
+        return {"error": "Bot is not running (control socket not found)."}
+    except ConnectionRefusedError:
+        return {"error": "Bot is not running (connection refused)."}
+    except socket.timeout:
+        return {"error": "Bot did not respond in time."}
     except Exception as e:
-        return {"error": f"request failed: {e}"}
+        return {"error": f"Control API error: {e}"}
 
-# --- Project discovery ---
-
-def discover_projects(base_directories):
-    """Discover git projects, deduplicate by remote URL."""
-    projects = []
-    seen_remotes = {}
-
-    for base_dir in base_directories:
-        base = Path(base_dir)
-        if not base.is_dir():
-            continue
-        for entry in sorted(base.iterdir()):
-            if not entry.is_dir():
-                continue
-            try:
-                is_bare = (entry / "HEAD").exists() and (entry / "objects").is_dir()
-                is_git = (entry / ".git").exists()
-            except OSError:
-                continue
-            if not (is_bare or is_git):
-                continue
-
-            # Get remote URL
-            remote = None
-            for try_dir in ([entry] if not is_bare else
-                           [entry / "master", entry / "main", entry]):
-                if try_dir.is_dir():
-                    try:
-                        result = subprocess.run(
-                            ["git", "-C", str(try_dir), "remote", "get-url", "origin"],
-                            capture_output=True, text=True, timeout=5)
-                        if result.returncode == 0:
-                            remote = result.stdout.strip()
-                            break
-                    except (subprocess.TimeoutExpired, OSError):
-                        pass
-
-            # Deduplicate by remote (normalize URL for comparison)
-            if remote:
-                # Normalize: strip .git suffix, convert SSH to HTTPS-like key
-                norm = remote.rstrip("/")
-                if norm.endswith(".git"):
-                    norm = norm[:-4]
-                norm = norm.replace("git@github.com:", "github.com/")
-                norm = norm.replace("https://github.com/", "github.com/")
-                norm = norm.lower()
-                remote_key = norm
-
-                if remote_key in seen_remotes:
-                    # Prefer bare repos
-                    if is_bare and not seen_remotes[remote_key]["is_bare"]:
-                        seen_remotes[remote_key] = {
-                            "name": repo_name_from_url(remote),
-                            "path": str(entry), "is_bare": is_bare,
-                            "remote_url": remote
-                        }
-                    continue
-                name = repo_name_from_url(remote)
-                seen_remotes[remote_key] = {
-                    "name": name, "path": str(entry),
-                    "is_bare": is_bare, "remote_url": remote
-                }
-            else:
-                projects.append({
-                    "name": entry.name, "path": str(entry),
-                    "is_bare": is_bare, "remote_url": None
-                })
-
-    return sorted(list(seen_remotes.values()) + projects, key=lambda p: p["name"])
-
-def repo_name_from_url(url):
-    """Extract repo name from git URL."""
-    url = url.rstrip("/")
-    if url.endswith(".git"):
-        url = url[:-4]
-    # Handle SSH format: git@github.com:user/repo
-    if ":" in url.split("/")[-1] if "/" in url else url:
-        parts = url.split(":")
-        if len(parts) == 2:
-            url = parts[1]
-    return url.split("/")[-1]
-
-def find_project_fuzzy(projects, query):
-    """Find a project by exact, case-insensitive, prefix, or substring match."""
-    q = query.lower()
-    # Exact
-    for p in projects:
-        if p["name"] == query:
-            return p
-    # Case-insensitive
-    for p in projects:
-        if p["name"].lower() == q:
-            return p
-    # Numeric index
-    try:
-        n = int(query)
-        if 1 <= n <= len(projects):
-            return projects[n - 1]
-    except ValueError:
-        pass
-    # Prefix
-    prefix_matches = [p for p in projects if p["name"].lower().startswith(q)]
-    if len(prefix_matches) == 1:
-        return prefix_matches[0]
-    # Substring
-    substr_matches = [p for p in projects if q in p["name"].lower()]
-    if len(substr_matches) == 1:
-        return substr_matches[0]
-    return None
-
-def find_working_dir(project):
-    """Find a usable working directory for a project."""
-    path = Path(project["path"])
-    if project["is_bare"]:
-        for name in ["master", "main"]:
-            candidate = path / name
-            if candidate.is_dir():
-                return str(candidate)
-    return str(path)
-
-def create_worktree(project, branch_name):
-    """Create a git worktree for an agent session."""
-    path = Path(project["path"])
-    worktree_path = path / branch_name
-
-    # Find default branch
-    start_point = "HEAD"
-    for branch in ["main", "master"]:
-        result = subprocess.run(
-            ["git", "-C", str(path), "rev-parse", "--verify", branch],
-            capture_output=True, timeout=5)
-        if result.returncode == 0:
-            start_point = branch
-            break
-
-    result = subprocess.run(
-        ["git", "-C", str(path), "worktree", "add", "-b",
-         branch_name, str(worktree_path), start_point],
-        capture_output=True, text=True, timeout=30)
-    if result.returncode == 0:
-        return str(worktree_path)
-    else:
-        return None
-
-# --- Claude session discovery ---
-
-def discover_claude_sessions(hours=24):
-    """Find recent Claude Code sessions on disk."""
-    claude_dir = Path.home() / ".claude" / "projects"
-    if not claude_dir.exists():
-        return []
-
-    cutoff = time.time() - hours * 3600
-    sessions = []
-
-    for proj_dir in claude_dir.iterdir():
-        if not proj_dir.is_dir():
-            continue
-        for f in proj_dir.iterdir():
-            if not f.name.endswith(".jsonl") or "/" in f.name:
-                continue
-            try:
-                stat = f.stat()
-            except OSError:
-                continue
-            if stat.st_mtime < cutoff:
-                continue
-
-            session_id = f.stem
-            # Get first user message as summary
-            summary = ""
-            try:
-                with open(f) as fh:
-                    for line in fh:
-                        try:
-                            d = json.loads(line)
-                            if d.get("type") == "user":
-                                msg = d.get("message", {})
-                                content = msg.get("content", "") if isinstance(msg, dict) else ""
-                                if isinstance(content, list):
-                                    for item in content:
-                                        if isinstance(item, dict) and item.get("type") == "text":
-                                            summary = item["text"][:80]
-                                            break
-                                elif isinstance(content, str):
-                                    summary = content[:80]
-                                if summary:
-                                    break
-                        except json.JSONDecodeError:
-                            continue
-            except OSError:
-                pass
-
-            age_min = int((time.time() - stat.st_mtime) / 60)
-            if age_min < 60:
-                age_str = f"{age_min}m ago"
-            else:
-                age_str = f"{age_min // 60}h ago"
-
-            sessions.append({
-                "session_id": session_id,
-                "project_dir": proj_dir.name,
-                "age": age_str,
-                "summary": summary or "(no summary)",
-            })
-
-    return sorted(sessions, key=lambda s: s["age"])[:15]
-
-# --- Tool implementations ---
+# --- Tool definitions ---
 
 TOOLS = [
     {
@@ -428,19 +168,26 @@ TOOLS = [
     }
 ]
 
-def handle_tool_call(name, arguments, config, projects):
-    token = config.get("discord_token", "")
-    guild_id = config.get("guild_id", "")
-    control_channel = config.get("control_channel_id")
+# --- Tool handlers (thin UDS proxies) ---
+
+def handle_tool_call(name, arguments):
+    """Forward tool call to the bot's control API and format the response."""
 
     if name == "list_projects":
+        result = control_request("list_projects")
+        if "error" in result:
+            return result["error"]
+        projects = result.get("projects", [])
         lines = [f"{i+1}. **{p['name']}** — `{p['path']}`"
-                 + (" [bare]" if p["is_bare"] else "")
+                 + (" [bare]" if p.get("is_bare") else "")
                  for i, p in enumerate(projects)]
         return "\n".join(lines) if lines else "No projects found."
 
     elif name == "list_sessions":
-        sessions = load_sessions()
+        result = control_request("list_sessions")
+        if "error" in result:
+            return result["error"]
+        sessions = result.get("sessions", [])
         if not sessions:
             return "No active sessions."
         lines = [f"- **{s['project_name']}** / {s['agent_kind']} — {s['message_count']} messages (thread: <#{s['thread_id']}>)"
@@ -448,294 +195,70 @@ def handle_tool_call(name, arguments, config, projects):
         return "\n".join(lines)
 
     elif name == "list_claude_sessions":
-        hours = arguments.get("hours", 24)
-        sessions = discover_claude_sessions(hours)
+        result = control_request("list_claude_sessions", arguments)
+        if "error" in result:
+            return result["error"]
+        sessions = result.get("sessions", [])
         if not sessions:
             return "No recent Claude sessions found."
-        lines = [f"- `{s['session_id'][:8]}` {s['age']} — {s['summary']}"
-                 for s in sessions]
-        return "\n".join(lines) + f"\n\nUse resume_session with a session ID prefix to attach."
+        lines = []
+        for s in sessions:
+            age = s.get("age_minutes", 0)
+            age_str = f"{age}m ago" if age < 60 else f"{age // 60}h ago"
+            summary = s.get("summary", "(no summary)")
+            lines.append(f"- `{s['session_id_short']}` {age_str} — {summary}")
+        return "\n".join(lines) + "\n\nUse resume_session with a session ID prefix to attach."
 
     elif name == "start_session":
-        project_query = arguments.get("project", "")
-        agent = arguments.get("agent", "claude")
-        proj = find_project_fuzzy(projects, project_query)
-        if not proj:
-            suggestions = [p for p in projects if project_query.lower() in p["name"].lower()]
-            if suggestions:
-                return f"No unique match for '{project_query}'. Did you mean:\n" + \
-                       "\n".join(f"- {p['name']}" for p in suggestions[:5])
-            return f"No project matching '{project_query}'. Use list_projects to see available projects."
-
-        # Create worktree
-        branch_name = f"agent/{agent}-{uuid.uuid4().hex[:8]}"
-        worktree_path = create_worktree(proj, branch_name)
-        if not worktree_path:
-            worktree_path = find_working_dir(proj)
-
-        # Create Discord thread
-        channel_id = control_channel or ""
-        # Try to find project channel
-        if guild_id and token:
-            channels = discord_request("GET", f"/guilds/{guild_id}/channels", token)
-            if isinstance(channels, list):
-                for ch in channels:
-                    if (ch.get("name", "").lower() == proj["name"].lower()
-                            and ch.get("type") == 0):
-                        channel_id = ch["id"]
-                        break
-
-        if not channel_id:
-            return f"No channel found for thread creation. Start the session manually."
-
-        thread_name = arguments.get("thread_name", "").strip()
-        if not thread_name or len(thread_name) > 80:
-            thread_name = f"{agent} / {proj['name']}"
-        result = discord_request("POST", f"/channels/{channel_id}/threads", token, {
-            "name": thread_name,
-            "type": 11,  # PUBLIC_THREAD
-            "auto_archive_duration": 1440,
-        })
+        result = control_request("start_session", arguments, timeout=120)
         if "error" in result:
-            return f"Failed to create thread: {result['error']}"
-
-        thread_id = result.get("id", "")
-        session_id = str(uuid.uuid4())
-
-        # Add to sessions (atomic load+modify+save to avoid races)
-        initial_prompt = arguments.get("initial_prompt", "").strip()[:4000] or None
-        session_entry = {
-            "project_name": proj["name"],
-            "working_dir": worktree_path,
-            "agent_kind": agent,
-            "session_id": session_id,
-            "thread_id": thread_id,
-            "message_count": 0,
-        }
-        if initial_prompt:
-            session_entry["initial_prompt"] = initial_prompt
-        modify_sessions(lambda ss: ss + [session_entry])
-
-        # Post welcome message
-        discord_request("POST", f"/channels/{thread_id}/messages", token, {
-            "content": f"**{agent}** session started for **{proj['name']}**\n"
-                      f"Branch: `{branch_name}`\n"
-                      f"Working in: `{worktree_path}`\n"
-                      f"Send a message to interact with the agent."
-        })
-
-        return f"Started {agent} session for **{proj['name']}** in <#{thread_id}>.\nWorking in: `{worktree_path}`"
+            return result["error"]
+        tid = result.get("thread_id", "")
+        wd = result.get("working_dir", "")
+        pname = result.get("project_name", "")
+        return f"Started session for **{pname}** in <#{tid}>.\nWorking in: `{wd}`"
 
     elif name == "resume_session":
-        sid_prefix = arguments.get("session_id", "")
-        # Find matching session
-        claude_dir = Path.home() / ".claude" / "projects"
-        found = None
-        for proj_dir in claude_dir.iterdir():
-            if not proj_dir.is_dir():
-                continue
-            for f in proj_dir.iterdir():
-                if f.name.endswith(".jsonl") and f.stem.startswith(sid_prefix):
-                    found = (f.stem, proj_dir.name)
-                    break
-            if found:
-                break
-
-        if not found:
-            return f"No Claude session found matching `{sid_prefix}`."
-
-        full_sid, proj_dir_name = found
-        # Resolve working dir from project dir name
-        working_dir = resolve_project_dir(proj_dir_name)
-
-        # Match working directory to a known project for channel routing
-        matched_project = None
-        for p in projects:
-            if working_dir == p["path"] or working_dir.startswith(p["path"] + "/"):
-                matched_project = p
-                break
-
-        # Route thread to project channel (like start_session does)
-        target_channel = control_channel or ""
-        if matched_project and guild_id and token:
-            channels = discord_request("GET", f"/guilds/{guild_id}/channels", token)
-            if isinstance(channels, list):
-                for ch in channels:
-                    if (ch.get("name", "").lower() == matched_project["name"].lower()
-                            and ch.get("type") == 0):
-                        target_channel = ch["id"]
-                        break
-
-        if not target_channel:
-            return "No channel found for thread creation."
-
-        # If working_dir is a bare repo root, use the main worktree instead
-        if matched_project and matched_project["is_bare"] and working_dir == matched_project["path"]:
-            working_dir = find_working_dir(matched_project)
-
-        project_name = matched_project["name"] if matched_project else Path(working_dir).name
-
-        thread_name = f"resume / {full_sid[:8]}"
-        result = discord_request("POST", f"/channels/{target_channel}/threads", token, {
-            "name": thread_name,
-            "type": 11,
-            "auto_archive_duration": 1440,
-        })
+        result = control_request("resume_session", arguments, timeout=120)
         if "error" in result:
-            return f"Failed to create thread: {result['error']}"
-
-        thread_id = result.get("id", "")
-
-        modify_sessions(lambda ss: ss + [{
-            "project_name": project_name,
-            "working_dir": working_dir,
-            "agent_kind": "claude",
-            "session_id": full_sid,
-            "thread_id": thread_id,
-            "message_count": 1,  # >0 so bot uses --resume
-        }])
-
-        discord_request("POST", f"/channels/{thread_id}/messages", token, {
-            "content": f"**Resumed** Claude session `{full_sid[:8]}`\n"
-                      f"Working in: `{working_dir}`\n"
-                      f"Send a message to continue."
-        })
-
-        return f"Resumed session `{full_sid[:8]}` in <#{thread_id}>."
+            return result["error"]
+        tid = result.get("thread_id", "")
+        sid = result.get("session_id", "")[:8]
+        return f"Resumed session `{sid}` in <#{tid}>."
 
     elif name == "restart_bot":
-        # Signal the bot to restart via SIGUSR1, which triggers the full
-        # drain → reap → build → spawn pipeline in the bot process.
-        # Read the bot's PID from the pidfile and verify it's alive first
-        # (the pidfile persists after exit since we rely on lockf).
-        pidfile = Path.home() / ".config/discord-agents/discord-agents.pid"
-        try:
-            pid = int(pidfile.read_text().strip())
-        except FileNotFoundError:
-            return "Pidfile not found — is the bot running?"
-        except (ValueError, OSError) as e:
-            return f"Failed to read pidfile: {e}"
-        # Reject invalid PIDs: 0 signals the process group, negative
-        # values signal other groups. Only accept positive integers.
-        if pid <= 0:
-            return f"Invalid PID in pidfile: {pid}"
-        # Verify the process is alive AND is actually discord-agents
-        # (stale pidfile could contain a reused PID)
-        try:
-            os.kill(pid, 0)  # signal 0 = liveness check
-        except ProcessLookupError:
-            return f"Bot process (pid {pid}) not found — pidfile is stale."
-        except PermissionError:
-            pass  # process exists but owned by another user (shouldn't happen)
-        # Verify the process is actually discord-agents, not an unrelated
-        # process that reused the PID after the bot exited
-        try:
-            cmdline = Path(f"/proc/{pid}/cmdline").read_bytes().decode("utf-8", errors="replace")
-            if "discord-agents" not in cmdline:
-                return f"PID {pid} is not discord-agents (pidfile is stale)."
-        except OSError:
-            pass  # non-Linux or process just exited; proceed cautiously
-        try:
-            os.kill(pid, signal.SIGUSR1)
-            return f"Restart signal (SIGUSR1) sent to bot (pid {pid}). It will drain active sessions, then rebuild and restart."
-        except Exception as e:
-            return f"Failed to signal restart: {e}"
+        result = control_request("restart")
+        if "error" in result:
+            return result["error"]
+        return result.get("message", "Restart initiated.")
 
     elif name == "rename_thread":
-        thread_id = arguments.get("thread_id", "")
-        new_name = arguments.get("name", "")
-        if not thread_id or not new_name:
-            return "Both thread_id and name are required."
-        if len(new_name) > 100:
-            new_name = new_name[:100]
-        result = discord_request("PATCH", f"/channels/{thread_id}", token, {
-            "name": new_name,
-        })
+        result = control_request("rename_thread", arguments)
         if "error" in result:
-            return f"Failed to rename thread: {result['error']}"
-        return f"Renamed thread <#{thread_id}> to **{new_name}**."
+            return result["error"]
+        return result.get("message", "Renamed.")
 
     elif name == "cleanup_channels":
-        if not guild_id or not token:
-            return "No guild configured."
-        channels = discord_request("GET", f"/guilds/{guild_id}/channels", token)
-        if not isinstance(channels, list):
-            return f"Failed to get channels: {channels}"
-
-        # Find Agent Projects category
-        cat_id = None
-        for ch in channels:
-            if ch.get("type") == 4 and ch.get("name") == "Agent Projects":
-                cat_id = ch["id"]
-                break
-        if not cat_id:
-            return "No Agent Projects category found."
-
-        project_names = {p["name"].lower() for p in projects}
-        seen = set()
-        to_delete = []
-        for ch in channels:
-            if ch.get("parent_id") != cat_id or ch.get("type") != 0:
-                continue
-            name = ch.get("name", "")
-            if name.lower() in seen or name.lower() not in project_names:
-                to_delete.append(ch)
-            seen.add(name.lower())
-
-        if not to_delete:
-            return "No stale channels to clean up."
-
-        deleted = 0
-        for ch in to_delete:
-            result = discord_request("DELETE", f"/channels/{ch['id']}", token)
-            if "error" not in result:
-                deleted += 1
-            time.sleep(0.5)
-
-        return f"Deleted {deleted} stale channels."
+        result = control_request("cleanup_channels")
+        if "error" in result:
+            return result["error"]
+        return result.get("message", "Done.")
 
     return f"Unknown tool: {name}"
-
-def resolve_project_dir(proj_name):
-    """Resolve Claude's project dir name to a filesystem path.
-    e.g. '-home-tedks-Projects-claude-discord' -> '/home/tedks/Projects/claude-discord'
-    by greedy filesystem walk."""
-    s = proj_name.lstrip("-")
-    parts = s.split("-")
-
-    def resolve(path, remaining_parts):
-        if not remaining_parts:
-            return path
-        # Try longest prefix that exists
-        for n in range(len(remaining_parts), 0, -1):
-            candidate = "-".join(remaining_parts[:n])
-            candidate_path = os.path.join(path, candidate)
-            if os.path.exists(candidate_path):
-                return resolve(candidate_path, remaining_parts[n:])
-        # Nothing matched, just take first part
-        return resolve(os.path.join(path, remaining_parts[0]), remaining_parts[1:])
-
-    return resolve("/", parts)
 
 # --- MCP JSON-RPC server ---
 
 def send_response(id, result):
     msg = {"jsonrpc": "2.0", "id": id, "result": result}
-    out = json.dumps(msg)
-    sys.stdout.write(out + "\n")
+    sys.stdout.write(json.dumps(msg) + "\n")
     sys.stdout.flush()
 
 def send_error(id, code, message):
     msg = {"jsonrpc": "2.0", "id": id, "error": {"code": code, "message": message}}
-    out = json.dumps(msg)
-    sys.stdout.write(out + "\n")
+    sys.stdout.write(json.dumps(msg) + "\n")
     sys.stdout.flush()
 
 def main():
-    config = load_config()
-    base_dirs = config.get("base_directories", [])
-    projects = discover_projects(base_dirs)
-
     for line in sys.stdin:
         line = line.strip()
         if not line:
@@ -754,11 +277,11 @@ def main():
                 "capabilities": {"tools": {}},
                 "serverInfo": {
                     "name": "discord-agents-mcp",
-                    "version": "0.1.0"
+                    "version": "0.2.0"
                 }
             })
         elif method == "notifications/initialized":
-            pass  # No response needed for notifications
+            pass
         elif method == "tools/list":
             send_response(id, {"tools": TOOLS})
         elif method == "tools/call":
@@ -766,7 +289,7 @@ def main():
             tool_name = params.get("name", "")
             arguments = params.get("arguments", {})
             try:
-                result_text = handle_tool_call(tool_name, arguments, config, projects)
+                result_text = handle_tool_call(tool_name, arguments)
                 send_response(id, {
                     "content": [{"type": "text", "text": result_text}]
                 })

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -316,6 +316,10 @@ TOOLS = [
                 "thread_name": {
                     "type": "string",
                     "description": "Short descriptive name for the thread (max 100 chars). If omitted, uses a default name."
+                },
+                "initial_prompt": {
+                    "type": "string",
+                    "description": "Context for the new session agent about what task to work on. Passed to the agent on its first interaction. Keep it concise — describe the goal, not step-by-step instructions."
                 }
             },
             "required": ["project"]
@@ -476,15 +480,19 @@ def handle_tool_call(name, arguments, config, projects):
         session_id = str(uuid.uuid4())
 
         # Add to sessions
+        initial_prompt = arguments.get("initial_prompt", "").strip() or None
         sessions = load_sessions()
-        sessions.append({
+        session_entry = {
             "project_name": proj["name"],
             "working_dir": worktree_path,
             "agent_kind": agent,
             "session_id": session_id,
             "thread_id": thread_id,
             "message_count": 0,
-        })
+        }
+        if initial_prompt:
+            session_entry["initial_prompt"] = initial_prompt
+        sessions.append(session_entry)
         save_sessions(sessions)
 
         # Post welcome message

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -315,11 +315,13 @@ TOOLS = [
                 },
                 "thread_name": {
                     "type": "string",
-                    "description": "Short descriptive name for the thread (max 100 chars). If omitted, uses a default name."
+                    "description": "Short descriptive name for the thread (max 80 chars). If omitted, uses a default name.",
+                    "maxLength": 80
                 },
                 "initial_prompt": {
                     "type": "string",
-                    "description": "Context for the new session agent about what task to work on. Passed to the agent on its first interaction. Keep it concise — describe the goal, not step-by-step instructions."
+                    "description": "Context for the new session agent about what task to work on. Passed to the agent on its first interaction. Keep it concise — describe the goal, not step-by-step instructions.",
+                    "maxLength": 4000
                 }
             },
             "required": ["project"]
@@ -466,7 +468,7 @@ def handle_tool_call(name, arguments, config, projects):
             return f"No channel found for thread creation. Start the session manually."
 
         thread_name = arguments.get("thread_name", "").strip()
-        if not thread_name or len(thread_name) > 100:
+        if not thread_name or len(thread_name) > 80:
             thread_name = f"{agent} / {proj['name']}"
         result = discord_request("POST", f"/channels/{channel_id}/threads", token, {
             "name": thread_name,
@@ -480,7 +482,7 @@ def handle_tool_call(name, arguments, config, projects):
         session_id = str(uuid.uuid4())
 
         # Add to sessions
-        initial_prompt = arguments.get("initial_prompt", "").strip() or None
+        initial_prompt = arguments.get("initial_prompt", "").strip()[:4000] or None
         sessions = load_sessions()
         session_entry = {
             "project_name": proj["name"],

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -35,14 +35,16 @@ import fcntl
 
 def _with_sessions_lock(fn):
     """Execute fn while holding an exclusive lock on sessions.json.lock.
-    Prevents lost-update races between the bot and MCP server."""
+    Prevents lost-update races between the bot and MCP server.
+    Uses fcntl.lockf (POSIX record locks) to match the OCaml side's
+    Unix.lockf — flock and lockf are independent lock families on Linux. """
     SESSIONS_LOCK.parent.mkdir(parents=True, exist_ok=True)
     with open(SESSIONS_LOCK, 'w') as lock_fd:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        fcntl.lockf(lock_fd, fcntl.LOCK_EX)
         try:
             return fn()
         finally:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            fcntl.lockf(lock_fd, fcntl.LOCK_UN)
 
 def load_sessions():
     """Load sessions (read-only). Lock held only during read."""


### PR DESCRIPTION
## Summary
- Channel agents can now pass `initial_prompt` when starting sessions via MCP, giving the new thread's agent context about what to work on
- The prompt is prepended to the first user message then cleared (one-shot)
- System prompts updated to instruct channel agents to always provide context
- Agents are told to hand back control quickly rather than acting autonomously

## How it works
1. User asks the project channel agent to "fix the auth bug"
2. Channel agent calls `start_session` with `thread_name="fix auth bug"` and `initial_prompt="The user wants to fix the authentication token refresh bug. The issue is..."`
3. When the user sends their first message in the new thread, the agent sees the context prepended
4. Context is consumed once and cleared from the session

## Test plan
- [ ] Start a session via MCP from a project channel — verify the agent has context
- [ ] Start a session via `!start` — verify no initial prompt (none to give)
- [ ] Verify initial_prompt persists across bot restart (sessions.json)
- [ ] Verify prompt is only used once (cleared after first message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)