### PR TITLE
feat: Gemini agent support (stacked on #27)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ lib/agent_runner.ml      — Agent lifecycle, streaming output to Discord, typin
 lib/agent_process.ml     — Subprocess management, stream-json parsing, formatting, escaping
 lib/session_store.ml     — Session state, persistence to disk, message queue
 lib/command.ml           — Pure command parsing (no I/O)
+lib/claude_sessions.ml   — Claude Code session discovery on disk (~/.claude/projects/)
+lib/gemini_sessions.ml   — Gemini CLI session discovery on disk (~/.gemini/tmp/)
 lib/channel_manager.ml   — Channel creation, ordering, cleanup
 lib/config.ml            — Configuration (JSON file + DISCORD_BOT_TOKEN env)
 lib/project.ml           — Project discovery, dedup by remote, worktree management
@@ -50,12 +52,13 @@ test/test_formatting.ml  — Tests for formatting, wrapping, escaping, command p
 
 Commands require a `!` prefix:
 
-- `start <project>` — start a session (fuzzy matches project name)
+- `start <project> [agent]` — start a session (agent ∈ {claude, codex, gemini}; defaults to claude)
 - `start` — show numbered project list
-- `resume <session_id>` — resume an existing Claude Code session
+- `resume [agent] <session_id>` — resume an existing session (agent defaults to claude; tries gemini if not found)
 - `projects` — list discovered projects with numbers
 - `sessions` — list active bot sessions
 - `claude-sessions` — list recent Claude Code sessions on this machine
+- `gemini-sessions` — list recent Gemini CLI sessions on this machine
 - `stop <thread_id>` — stop a session
 - `rename [thread_id] <name>` — rename a thread
 - `desktop` — set wrapping to desktop width (120 chars)
@@ -96,6 +99,21 @@ Claude Code CLI with `--output-format stream-json` emits:
 - `{"type": "result", "result": "...", "session_id": "..."}` — final result
 
 Tool results (output from tool execution) are NOT emitted as separate events. They are internal to Claude Code CLI. We display tool inputs (diffs, commands) from tool_use blocks but cannot show tool output.
+
+Gemini CLI with `-o stream-json` emits a different, flatter schema:
+- `{"type":"init","session_id":"<uuid>","model":"..."}` — session id assigned server-side
+- `{"type":"message","role":"assistant","content":"...","delta":true}` — incremental text
+- `{"type":"tool_use","tool_name":"run_shell_command","parameters":{...}}` — tool call
+- `{"type":"tool_result","status":"success|error","output":"..."}` — tool result (Gemini *does* emit these)
+- `{"type":"result","status":"...","stats":{...}}` — turn complete
+
+Parsers live in `lib/agent_process.ml`: `parse_stream_json_line` (Claude), `parse_codex_json_line` (Codex), `parse_gemini_stream_json_line` (Gemini). Each maps its agent's schema onto the shared `stream_event` type (`Text_delta` / `Tool_use` / `Tool_result` / `Result`).
+
+## MCP configuration
+
+Claude receives MCP servers via `--mcp-config <path>` (written to `~/.config/discord-agents/mcp-generated.json`). Codex does not use MCP.
+
+Gemini has no `--mcp-config` flag; it loads `mcpServers` from `<cwd>/.gemini/settings.json`. For each Gemini session we write that file into the worktree and append `.gemini/` to the worktree's `.git/info/exclude` so it doesn't appear as untracked. Gemini tool names (`run_shell_command`, `read_file`, `write_file`, `replace`, `search_file_content`, `glob`) are translated to Claude-equivalents (`Bash`, `Read`, `Write`, `Edit`, `Grep`, `Glob`) so the existing tool summarizers apply.
 
 ## Bare repo / worktree setup
 

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -930,6 +930,94 @@ let parse_codex_json_line line =
     | _ -> [Other line]
   with _ -> [Other line]
 
+(** Parse a `gemini -p ... -o stream-json` event line.
+    Gemini emits one flat JSON object per line:
+    - {"type":"init","session_id":"<uuid>","model":"..."} — session id is
+      assigned server-side in this event; capture for resume.
+    - {"type":"message","role":"user","content":"..."} — echo of the
+      prompt we sent; skip.
+    - {"type":"message","role":"assistant","content":"...","delta":true}
+      — incremental assistant text.
+    - {"type":"tool_use","tool_name":"...","tool_id":"...",
+       "parameters":{...}} — tool invocation.
+    - {"type":"tool_result","tool_id":"...","status":"success|error",
+       "output":"...","error":{...}} — tool completed.
+    - {"type":"result","status":"success","stats":{...}} — turn
+      complete; triggers a flush (no text or session_id here).
+
+    Gemini's tool names differ from Claude's (run_shell_command, read_file,
+    write_file, ...). Since Gemini passes parameters under the same field
+    names Claude uses (command, file_path, content, pattern), we translate
+    the tool name so [summarize_tool_input] and [detail_of_tool_input]
+    produce matching output to Claude's. *)
+let gemini_tool_name_of name =
+  match name with
+  | "run_shell_command" -> "Bash"
+  | "read_file" -> "Read"
+  | "write_file" -> "Write"
+  | "replace" | "edit" -> "Edit"
+  | "search_file_content" -> "Grep"
+  | "glob" -> "Glob"
+  | "web_fetch" -> "WebFetch"
+  | "google_web_search" | "web_search" -> "WebSearch"
+  | other -> other
+
+let parse_gemini_stream_json_line line =
+  try
+    let json = Yojson.Safe.from_string line in
+    let open Yojson.Safe.Util in
+    let typ = json |> member "type" |> to_string_option in
+    match typ with
+    | Some "init" ->
+      (match json |> member "session_id" |> to_string_option with
+       | Some sid -> [Result { text = ""; session_id = Some sid }]
+       | None -> [])
+    | Some "message" ->
+      (match json |> member "role" |> to_string_option with
+       | Some "assistant" ->
+         (match json |> member "content" |> to_string_option with
+          | Some text when text <> "" -> [Text_delta text]
+          | _ -> [])
+       | _ -> [])  (* user echo or unknown role: skip *)
+    | Some "tool_use" ->
+      let raw_name = json |> member "tool_name" |> to_string_option
+        |> Option.value ~default:"unknown" in
+      let name = gemini_tool_name_of raw_name in
+      let params = json |> member "parameters" in
+      let summary = summarize_tool_input name params in
+      let detail = detail_of_tool_input name params in
+      [Tool_use { tool_name = name; tool_summary = summary;
+                  tool_detail = detail }]
+    | Some "tool_result" ->
+      let status = json |> member "status" |> to_string_option
+        |> Option.value ~default:"" in
+      let output = json |> member "output" |> to_string_option
+        |> Option.value ~default:"" in
+      let err_msg =
+        match json |> member "error" with
+        | `Null -> ""
+        | obj ->
+          (match obj |> member "message" |> to_string_option with
+           | Some m -> m
+           | None -> "")
+        | exception _ -> ""
+      in
+      let content = match status, output, err_msg with
+        | _, "", "" -> ""
+        | "error", "", m -> Printf.sprintf "[error] %s" m
+        | "error", o, "" -> Printf.sprintf "[error] %s" o
+        | "error", o, m -> Printf.sprintf "[error] %s\n%s" m o
+        | _, o, _ -> o
+      in
+      if content = "" then [] else [Tool_result { content }]
+    | Some "result" ->
+      (* Turn complete. No session_id here (already captured at init),
+         and no aggregated text (assistant deltas already delivered it).
+         Emit an empty Result to trigger a flush, matching Codex. *)
+      [Result { text = ""; session_id = None }]
+    | _ -> [Other line]
+  with _ -> [Other line]
+
 (** Build the command args for an agent invocation. *)
 let claude_args ~session_id ~message_count ~prompt =
   let session_flag =
@@ -948,6 +1036,16 @@ let codex_args ~session_id ~message_count ~prompt =
   if message_count = 0 then base @ [prompt]
   else base @ ["resume"; session_id; prompt]
 
+(** Gemini allocates its session id server-side in the init event, like
+    Codex. [parse_gemini_stream_json_line] emits it via Result.session_id
+    on the first run and [--resume <uuid>] is used on subsequent turns.
+    --yolo auto-approves tool calls, matching Claude's bypassPermissions
+    mode; Discord can't answer interactive approval prompts. *)
+let gemini_args ~session_id ~message_count ~prompt =
+  let base = ["gemini"; "-p"; prompt; "-o"; "stream-json"; "--yolo"] in
+  if message_count = 0 then base
+  else base @ ["--resume"; session_id]
+
 (** Spawn an agent and stream its output via a callback.
     The callback is called with each parsed event as it arrives.
     [?on_pid] is called with the child PID immediately after spawn,
@@ -958,37 +1056,76 @@ let run_streaming ~sw ~env ~working_dir ~kind ~session_id ~message_count
   let mgr = Eio.Stdenv.process_mgr env in
   let fs = Eio.Stdenv.fs env in
   let cwd = Eio.Path.(fs / working_dir) in
-  (* Generate MCP config with absolute path to the Python script.
-     The static mcp.json has a relative path that breaks when Claude
-     runs in a different working directory. *)
+  (* Locate scripts/mcp-server.py (absolute path). The static mcp.json has
+     a relative path that breaks when the agent runs from a worktree. *)
+  let mcp_script_path =
+    try
+      let exe = Sys.executable_name in
+      let exe = if Filename.is_relative exe then Filename.concat (Sys.getcwd ()) exe else exe in
+      let rec find_root path =
+        let candidate = Filename.concat path "scripts/mcp-server.py" in
+        if Sys.file_exists candidate then candidate
+        else
+          let parent = Filename.dirname path in
+          if parent = path then "scripts/mcp-server.py"
+          else find_root parent
+      in
+      find_root (Filename.dirname exe)
+    with _ -> "scripts/mcp-server.py"
+  in
+  let mcp_json = Printf.sprintf
+    {|{"mcpServers":{"discord-agents":{"command":"python3","args":["%s"]}}}|}
+    mcp_script_path
+  in
+  let write_file ~path contents =
+    try
+      let oc = open_out path in
+      output_string oc contents;
+      close_out oc
+    with _ -> ()
+  in
+  (* Claude: write --mcp-config at a known location and pass the path. *)
   let mcp_config =
-    let script_path =
-      try
-        let exe = Sys.executable_name in
-        let exe = if Filename.is_relative exe then Filename.concat (Sys.getcwd ()) exe else exe in
-        let rec find_root path =
-          let candidate = Filename.concat path "scripts/mcp-server.py" in
-          if Sys.file_exists candidate then candidate
-          else
-            let parent = Filename.dirname path in
-            if parent = path then "scripts/mcp-server.py"
-            else find_root parent
-        in
-        find_root (Filename.dirname exe)
-      with _ -> "scripts/mcp-server.py"
-    in
-    (* Write a temp MCP config with the absolute script path *)
     let config_dir = Filename.concat (Sys.getenv "HOME") ".config/discord-agents" in
     let config_path = Filename.concat config_dir "mcp-generated.json" in
-    let json = Printf.sprintf
-      {|{"mcpServers":{"discord-agents":{"command":"python3","args":["%s"]}}}|}
-      script_path in
-    (try
-      let oc = open_out config_path in
-      output_string oc json;
-      close_out oc
-    with _ -> ());
+    write_file ~path:config_path mcp_json;
     config_path
+  in
+  (* Gemini has no --mcp-config flag; it loads mcpServers from the project's
+     .gemini/settings.json. Write it into the worktree and add .gemini/ to
+     the worktree's git excludes so it doesn't show as untracked. *)
+  let write_gemini_settings () =
+    let gemini_dir = Filename.concat working_dir ".gemini" in
+    (try if not (Sys.file_exists gemini_dir) then Unix.mkdir gemini_dir 0o755
+     with _ -> ());
+    write_file ~path:(Filename.concat gemini_dir "settings.json") mcp_json;
+    let exclude_path = Filename.concat working_dir ".git/info/exclude" in
+    try
+      if Sys.file_exists exclude_path then begin
+        let existing =
+          let ic = open_in exclude_path in
+          let n = in_channel_length ic in
+          let s = Bytes.create n in
+          really_input ic s 0 n;
+          close_in ic;
+          Bytes.to_string s
+        in
+        let has_needle =
+          let needle = ".gemini/" in
+          let nlen = String.length needle in
+          let rec has i =
+            if i + nlen > String.length existing then false
+            else if String.sub existing i nlen = needle then true
+            else has (i + 1)
+          in has 0
+        in
+        if not has_needle then begin
+          let oc = open_out_gen [Open_append] 0o644 exclude_path in
+          output_string oc "\n.gemini/\n";
+          close_out oc
+        end
+      end
+    with _ -> ()
   in
   let args = match kind with
     | Config.Claude ->
@@ -1001,7 +1138,9 @@ let run_streaming ~sw ~env ~working_dir ~kind ~session_id ~message_count
       in
       base
     | Config.Codex -> codex_args ~session_id ~message_count ~prompt
-    | Config.Gemini -> ["gemini"; "-p"; prompt; "-o"; "stream-json"]
+    | Config.Gemini ->
+      write_gemini_settings ();
+      gemini_args ~session_id ~message_count ~prompt
   in
   let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
   let stderr_r, stderr_w = Eio.Process.pipe ~sw mgr in
@@ -1031,8 +1170,9 @@ let run_streaming ~sw ~env ~working_dir ~kind ~session_id ~message_count
           let line = Eio.Buf_read.line reader in
           if String.length line > 0 then begin
             let events = match kind with
-              | Config.Claude | Config.Gemini -> parse_stream_json_line line
+              | Config.Claude -> parse_stream_json_line line
               | Config.Codex -> parse_codex_json_line line
+              | Config.Gemini -> parse_gemini_stream_json_line line
             in
             List.iter on_event events
           end

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -435,13 +435,57 @@ let handle_command t msg cmd =
                "**%s** session started for **%s**%s\nWorking in: `%s`\nSend a message to interact."
                kind_str p.name branch_str working_dir) ())
        end)
-  | Command.Resume_session { session_id } ->
+  | Command.List_gemini_sessions ->
     Eio.Fiber.fork ~sw:t.sw (fun () ->
-      let found = Eio_unix.run_in_systhread (fun () ->
-        Claude_sessions.find_by_prefix session_id) in
+      let sessions = Gemini_sessions.discover ~hours:24 () in
+      let lines = List.map (fun (s : Gemini_sessions.info) ->
+        let age_min = int_of_float ((Unix.gettimeofday () -. s.mtime) /. 60.0) in
+        let age_str = if age_min < 60 then Printf.sprintf "%dm ago" age_min
+          else Printf.sprintf "%dh ago" (age_min / 60) in
+        let sid_short = String.sub s.session_id 0
+          (min 8 (String.length s.session_id)) in
+        let wd_str = if s.working_dir = "" then "(unknown project)"
+          else s.working_dir in
+        Printf.sprintf "- `%s` %s\n  %s — *%s*"
+          sid_short age_str wd_str
+          (if s.summary = "" then "(no summary)" else s.summary)
+      ) (List.filteri (fun i _ -> i < 10) sessions) in
+      reply (if lines = [] then "No recent Gemini sessions found."
+        else "**Recent Gemini sessions** (last 24h):\n" ^ String.concat "\n" lines
+             ^ "\n\nUse `!resume gemini <session_id_prefix>` to attach."))
+  | Command.Resume_session { session_id; kind } ->
+    Eio.Fiber.fork ~sw:t.sw (fun () ->
+      (* Locate the session in the requested store (or try both if
+         kind = None; prefer Claude for legacy callers). *)
+      let try_claude () =
+        match Eio_unix.run_in_systhread (fun () ->
+          Claude_sessions.find_by_prefix session_id) with
+        | Some (sid, wd) -> Some (Config.Claude, sid, wd)
+        | None -> None
+      in
+      let try_gemini () =
+        match Gemini_sessions.find_by_prefix session_id with
+        | Some (sid, wd) -> Some (Config.Gemini, sid, wd)
+        | None -> None
+      in
+      let found = match kind with
+        | Some Config.Claude -> try_claude ()
+        | Some Config.Gemini -> try_gemini ()
+        | Some Config.Codex -> None  (* Codex session resume not implemented *)
+        | None ->
+          (match try_claude () with
+           | Some _ as r -> r
+           | None -> try_gemini ())
+      in
       match found with
-      | None -> reply (Printf.sprintf "No Claude session matching `%s`." session_id)
-      | Some (full_sid, raw_working_dir) ->
+      | None ->
+        let kind_label = match kind with
+          | Some k -> Config.string_of_agent_kind k ^ " "
+          | None -> "" in
+        reply (Printf.sprintf "No %ssession matching `%s`." kind_label session_id)
+      | Some (found_kind, full_sid, raw_working_dir) ->
+        let kind_label = Config.string_of_agent_kind found_kind in
+        let kind_title = String.capitalize_ascii kind_label in
         let sid_short = String.sub full_sid 0 (min 8 (String.length full_sid)) in
         (* Match working directory to a known project for channel routing *)
         let matched_project = List.find_opt (fun (p : Project.t) ->
@@ -468,15 +512,18 @@ let handle_command t msg cmd =
         in
         let project_name = match matched_project with
           | Some p -> p.name
-          | None -> Filename.basename raw_working_dir
+          | None ->
+            if raw_working_dir = "" then "gemini-session"
+            else Filename.basename raw_working_dir
         in
         (match Discord_rest.create_thread_no_message t.rest
-                ~channel_id:thread_parent ~name:(Printf.sprintf "resume / %s" sid_short) () with
+                ~channel_id:thread_parent
+                ~name:(Printf.sprintf "resume %s / %s" kind_label sid_short) () with
         | Error e -> reply (Printf.sprintf "Failed to create thread: %s" e)
         | Ok thread_ch ->
           let session : Session_store.session = {
             project_name; working_dir;
-            agent_kind = Config.Claude; session_id = full_sid;
+            agent_kind = found_kind; session_id = full_sid;
             thread_id = thread_ch.Discord_types.id;
             system_prompt = None; message_count = 1; processing = false;
             pending_queue = Queue.create (); initial_prompt = None;
@@ -484,8 +531,8 @@ let handle_command t msg cmd =
           Session_store.add t.sessions ~thread_id:thread_ch.id session;
           ignore (Discord_rest.create_message t.rest ~channel_id:thread_ch.id
             ~content:(Printf.sprintf
-              "**Resumed** Claude session `%s`\nWorking in: `%s`\nSend a message to continue."
-              sid_short working_dir) ())))
+              "**Resumed** %s session `%s`\nWorking in: `%s`\nSend a message to continue."
+              kind_title sid_short working_dir) ())))
   | Command.Stop_session { thread_id } ->
     (match Session_store.find_opt t.sessions ~thread_id with
      | None -> reply "Session not found."
@@ -640,8 +687,9 @@ let handle_command t msg cmd =
       "`!projects` — list discovered projects";
       "`!sessions` — list active bot sessions";
       "`!claude-sessions` — list recent Claude sessions";
-      "`!start <project> [agent]` — start a session (defaults to claude)";
-      "`!resume <session_id>` — resume a Claude session";
+      "`!gemini-sessions` — list recent Gemini sessions";
+      "`!start <project> [agent]` — start a session (claude|codex|gemini; defaults to claude)";
+      "`!resume [agent] <session_id>` — resume a session (agent defaults to claude)";
       "`!stop <thread_id>` — stop a session";
       "`!rename [thread_id] <name>` — rename a thread";
       "`!status` — bot status and running processes";
@@ -909,7 +957,8 @@ let handle_message t (msg : Discord_types.message) =
       let cmd = Command.parse msg.content in
       match cmd with
       | Command.Status | Command.List_projects | Command.List_sessions
-      | Command.List_claude_sessions | Command.Help ->
+      | Command.List_claude_sessions | Command.List_gemini_sessions
+      | Command.Help ->
         handle_command t msg cmd
       | _ ->
         ignore (Discord_rest.create_message t.rest

--- a/lib/command.ml
+++ b/lib/command.ml
@@ -7,8 +7,9 @@ type t =
   | List_projects
   | List_sessions
   | List_claude_sessions
+  | List_gemini_sessions
   | Start_agent of { project : string; kind : Config.agent_kind }
-  | Resume_session of { session_id : string }
+  | Resume_session of { session_id : string; kind : Config.agent_kind option }
   | Stop_session of { thread_id : string }
   | Cleanup_channels
   | Restart
@@ -39,6 +40,7 @@ let parse content =
   | ["projects"] | ["list"] -> List_projects
   | ["sessions"] -> List_sessions
   | ["claude-sessions"] -> List_claude_sessions
+  | ["gemini-sessions"] -> List_gemini_sessions
   | "start" :: project :: kind_str :: _ ->
     let kind = match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with
       | Ok k -> k | Error _ -> Config.Claude in
@@ -47,7 +49,11 @@ let parse content =
     Start_agent { project; kind = Config.Claude }
   | ["start"] ->
     List_projects
-  | ["resume"; session_id] -> Resume_session { session_id }
+  | ["resume"; session_id] -> Resume_session { session_id; kind = None }
+  | ["resume"; kind_str; session_id] ->
+    (match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with
+     | Ok k -> Resume_session { session_id; kind = Some k }
+     | Error _ -> Unknown content)
   | ["stop"; thread_id] -> Stop_session { thread_id }
   | ["cleanup-channels"] | ["cleanup"] -> Cleanup_channels
   | "rename" :: rest when rest <> [] ->

--- a/lib/gemini_sessions.ml
+++ b/lib/gemini_sessions.ml
@@ -1,0 +1,161 @@
+(** Discovery of Gemini CLI sessions on disk.
+
+    Scans ~/.gemini/tmp/<project-dir>/chats/session-*.json for recent
+    session files, extracts metadata (first user message, project hash),
+    and resolves projectHash back to a filesystem path via
+    ~/.gemini/projects.json (projectHash = sha256 of the absolute path). *)
+
+type info = {
+  session_id : string;
+  working_dir : string;  (** Resolved from projectHash; "" if unresolvable *)
+  summary : string;
+  mtime : float;
+}
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
+    let n = in_channel_length ic in
+    let s = Bytes.create n in
+    really_input ic s 0 n;
+    Bytes.to_string s)
+
+(** SHA-256 of a string via the [sha256sum] shell utility.
+    Returns hex digest or "" on failure. We shell out to avoid taking
+    a cryptographic-hash dependency for one-shot session discovery. *)
+let sha256_hex s =
+  try
+    let tmp = Filename.temp_file "gemini_sess" "" in
+    Fun.protect ~finally:(fun () -> try Sys.remove tmp with _ -> ())
+      (fun () ->
+        let oc = open_out tmp in
+        output_string oc s;
+        close_out oc;
+        let ic = Unix.open_process_in
+          (Printf.sprintf "sha256sum %s 2>/dev/null" (Filename.quote tmp)) in
+        let line = try input_line ic with End_of_file -> "" in
+        ignore (Unix.close_process_in ic);
+        match String.index_opt line ' ' with
+        | Some i -> String.sub line 0 i
+        | None -> String.trim line)
+  with _ -> ""
+
+(** Build a {sha256(path) -> path} table from ~/.gemini/projects.json. *)
+let build_hash_table () =
+  let home = Sys.getenv "HOME" in
+  let path = Filename.concat home ".gemini/projects.json" in
+  let tbl = Hashtbl.create 32 in
+  if not (Sys.file_exists path) then tbl
+  else begin
+    (try
+      let json = Yojson.Safe.from_string (read_file path) in
+      let open Yojson.Safe.Util in
+      (match json |> member "projects" with
+       | `Assoc pairs ->
+         List.iter (fun (project_path, _name) ->
+           let h = sha256_hex project_path in
+           if h <> "" then Hashtbl.replace tbl h project_path
+         ) pairs
+       | _ -> ())
+    with _ -> ());
+    tbl
+  end
+
+(** Extract (sessionId, projectHash, firstUserText) from a Gemini session
+    JSON. Returns None if the file isn't a parseable session. *)
+let extract_meta fpath =
+  try
+    let json = Yojson.Safe.from_string (read_file fpath) in
+    let open Yojson.Safe.Util in
+    let sid = json |> member "sessionId" |> to_string_option in
+    let phash = json |> member "projectHash" |> to_string_option
+      |> Option.value ~default:"" in
+    let summary =
+      match json |> member "messages" with
+      | `List (m :: _) ->
+        (match m |> member "type" |> to_string_option with
+         | Some "user" ->
+           (match m |> member "content" with
+            | `List items ->
+              (match List.find_opt (fun it ->
+                 match it |> member "text" |> to_string_option with
+                 | Some _ -> true | None -> false) items with
+               | Some first ->
+                 (match first |> member "text" |> to_string_option with
+                  | Some t -> String.sub t 0 (min 80 (String.length t))
+                  | None -> "")
+               | None -> "")
+            | `String s -> String.sub s 0 (min 80 (String.length s))
+            | _ -> "")
+         | _ -> "")
+      | _ -> ""
+    in
+    match sid with
+    | Some sid -> Some (sid, phash, summary)
+    | None -> None
+  with _ -> None
+
+(** Walk ~/.gemini/tmp/*/chats/*.json, yielding (fpath, mtime) for each
+    session-*.json newer than cutoff. *)
+let walk_sessions ?(cutoff=neg_infinity) () =
+  let home = Sys.getenv "HOME" in
+  let tmp_dir = Filename.concat home ".gemini/tmp" in
+  if not (Sys.file_exists tmp_dir) then []
+  else
+    let acc = ref [] in
+    let project_dirs =
+      try Sys.readdir tmp_dir |> Array.to_list with _ -> [] in
+    List.iter (fun proj_name ->
+      let chats_dir = Filename.concat
+        (Filename.concat tmp_dir proj_name) "chats" in
+      if (try Sys.is_directory chats_dir with Sys_error _ -> false) then begin
+        let files =
+          try Sys.readdir chats_dir |> Array.to_list with Sys_error _ -> [] in
+        List.iter (fun fname ->
+          if Filename.check_suffix fname ".json"
+             && String.length fname >= 8
+             && String.sub fname 0 8 = "session-" then begin
+            let fpath = Filename.concat chats_dir fname in
+            match (try Some (Unix.stat fpath) with Unix.Unix_error _ -> None) with
+            | Some st when st.Unix.st_mtime > cutoff ->
+              acc := (fpath, st.Unix.st_mtime) :: !acc
+            | _ -> ()
+          end
+        ) files
+      end
+    ) project_dirs;
+    !acc
+
+(** Scan for recent Gemini sessions. Returns newest first. *)
+let discover ?(hours=24) () =
+  Eio_unix.run_in_systhread @@ fun () ->
+  let cutoff = Unix.gettimeofday () -. (float_of_int hours *. 3600.0) in
+  let hash_tbl = build_hash_table () in
+  let files = walk_sessions ~cutoff () in
+  let infos = List.filter_map (fun (fpath, mtime) ->
+    match extract_meta fpath with
+    | Some (session_id, phash, summary) ->
+      let working_dir = try Hashtbl.find hash_tbl phash with Not_found -> "" in
+      Some { session_id; working_dir; summary; mtime }
+    | None -> None
+  ) files in
+  List.sort (fun a b -> compare b.mtime a.mtime) infos
+
+(** Find a session by ID prefix across all projects.
+    Returns (full_session_id, working_dir) or None. *)
+let find_by_prefix session_id_prefix =
+  Eio_unix.run_in_systhread @@ fun () ->
+  let hash_tbl = build_hash_table () in
+  let files = walk_sessions () in
+  let prefix_len = String.length session_id_prefix in
+  let matched = List.find_map (fun (fpath, _) ->
+    match extract_meta fpath with
+    | Some (sid, phash, _) ->
+      if String.length sid >= prefix_len
+         && String.sub sid 0 prefix_len = session_id_prefix then
+        let wd = try Hashtbl.find hash_tbl phash with Not_found -> "" in
+        Some (sid, wd)
+      else None
+    | None -> None
+  ) files in
+  matched

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -405,8 +405,13 @@ let cmd_testable =
       | Discord_agents.Command.List_projects -> "List_projects"
       | List_sessions -> "List_sessions"
       | List_claude_sessions -> "List_claude_sessions"
+      | List_gemini_sessions -> "List_gemini_sessions"
       | Start_agent { project; _ } -> "Start_agent(" ^ project ^ ")"
-      | Resume_session { session_id } -> "Resume_session(" ^ session_id ^ ")"
+      | Resume_session { session_id; kind = None } ->
+        "Resume_session(" ^ session_id ^ ")"
+      | Resume_session { session_id; kind = Some k } ->
+        Printf.sprintf "Resume_session(%s,%s)"
+          (Discord_agents.Config.string_of_agent_kind k) session_id
       | Stop_session { thread_id } -> "Stop_session(" ^ thread_id ^ ")"
       | Cleanup_channels -> "Cleanup_channels"
       | Restart -> "Restart"
@@ -518,7 +523,47 @@ let test_parse_scroll_zero () =
     Alcotest.(check pass) "zero scroll is Unknown" () ()
   | _ -> Alcotest.fail "expected Unknown for zero scroll"
 
+let test_parse_resume_no_kind () =
+  Alcotest.(check cmd_testable) "resume without kind arg"
+    (Discord_agents.Command.Resume_session { session_id = "abc12345"; kind = None })
+    (Discord_agents.Command.parse "!resume abc12345")
+
+let test_parse_resume_with_gemini_kind () =
+  Alcotest.(check cmd_testable) "resume with gemini kind"
+    (Discord_agents.Command.Resume_session {
+       session_id = "xyz"; kind = Some Discord_agents.Config.Gemini })
+    (Discord_agents.Command.parse "!resume gemini xyz")
+
+let test_parse_resume_with_claude_kind () =
+  Alcotest.(check cmd_testable) "resume with claude kind"
+    (Discord_agents.Command.Resume_session {
+       session_id = "xyz"; kind = Some Discord_agents.Config.Claude })
+    (Discord_agents.Command.parse "!resume claude xyz")
+
+let test_parse_resume_invalid_kind () =
+  match Discord_agents.Command.parse "!resume nonesuch xyz" with
+  | Discord_agents.Command.Unknown _ ->
+    Alcotest.(check pass) "invalid kind is Unknown" () ()
+  | _ -> Alcotest.fail "expected Unknown for invalid agent kind"
+
+let test_parse_gemini_sessions () =
+  Alcotest.(check cmd_testable) "gemini-sessions"
+    Discord_agents.Command.List_gemini_sessions
+    (Discord_agents.Command.parse "!gemini-sessions")
+
+let test_parse_start_gemini () =
+  Alcotest.(check cmd_testable) "start project gemini"
+    (Discord_agents.Command.Start_agent {
+       project = "myproj"; kind = Discord_agents.Config.Gemini })
+    (Discord_agents.Command.parse "!start myproj gemini")
+
 let command_tests = [
+  Alcotest.test_case "resume without kind" `Quick test_parse_resume_no_kind;
+  Alcotest.test_case "resume with gemini kind" `Quick test_parse_resume_with_gemini_kind;
+  Alcotest.test_case "resume with claude kind" `Quick test_parse_resume_with_claude_kind;
+  Alcotest.test_case "resume invalid kind" `Quick test_parse_resume_invalid_kind;
+  Alcotest.test_case "gemini-sessions" `Quick test_parse_gemini_sessions;
+  Alcotest.test_case "start with gemini kind" `Quick test_parse_start_gemini;
   Alcotest.test_case "desktop" `Quick test_parse_desktop;
   Alcotest.test_case "mobile" `Quick test_parse_mobile;
   Alcotest.test_case "wrapping no arg" `Quick test_parse_wrapping_no_arg;
@@ -909,6 +954,134 @@ let codex_json_tests = [
   Alcotest.test_case "backticks sanitized in summary" `Quick test_codex_command_injection_summary;
 ]
 
+(* ── parse_gemini_stream_json_line ────────────────────────────────── *)
+
+let parse_gemini = Discord_agents.Agent_process.parse_gemini_stream_json_line
+
+let test_gemini_init_captures_session_id () =
+  let line = {|{"type":"init","timestamp":"t","session_id":"s-42","model":"m"}|} in
+  Alcotest.(check (option string)) "init session_id"
+    (Some "s-42") (expect_session_id (parse_gemini line))
+
+let test_gemini_init_without_session_dropped () =
+  let line = {|{"type":"init","model":"m"}|} in
+  Alcotest.(check int) "init with no session_id emits nothing"
+    0 (List.length (parse_gemini line))
+
+let test_gemini_user_message_skipped () =
+  let line = {|{"type":"message","role":"user","content":"hello"}|} in
+  Alcotest.(check int) "user echo is not forwarded"
+    0 (List.length (parse_gemini line))
+
+let test_gemini_assistant_delta () =
+  let line = {|{"type":"message","role":"assistant","content":"Hello","delta":true}|} in
+  Alcotest.(check (option string)) "assistant content becomes Text_delta"
+    (Some "Hello") (expect_text (parse_gemini line))
+
+let test_gemini_assistant_empty_dropped () =
+  let line = {|{"type":"message","role":"assistant","content":"","delta":true}|} in
+  Alcotest.(check int) "empty assistant content emits nothing"
+    0 (List.length (parse_gemini line))
+
+let test_gemini_shell_tool_use () =
+  let line = {|{"type":"tool_use","tool_name":"run_shell_command","tool_id":"t1","parameters":{"command":"ls /tmp","description":"list"}}|} in
+  match expect_tool (parse_gemini line) with
+  | Some info ->
+    Alcotest.(check string) "maps to Bash" "Bash" info.tool_name;
+    Alcotest.(check string) "summary is the command" "ls /tmp" info.tool_summary;
+    Alcotest.(check bool) "detail is bash code block"
+      true (String.length info.tool_detail >= 7
+            && String.sub info.tool_detail 0 7 = "```bash")
+  | None -> Alcotest.fail "expected single Tool_use"
+
+let test_gemini_read_file_tool_use () =
+  let line = {|{"type":"tool_use","tool_name":"read_file","tool_id":"t2","parameters":{"file_path":"/etc/hostname"}}|} in
+  match expect_tool (parse_gemini line) with
+  | Some info ->
+    Alcotest.(check string) "maps to Read" "Read" info.tool_name;
+    Alcotest.(check bool) "summary mentions path"
+      true (try ignore (Str.search_forward
+              (Str.regexp_string "/etc/hostname") info.tool_summary 0); true
+            with Not_found -> false)
+  | None -> Alcotest.fail "expected single Tool_use"
+
+let test_gemini_write_file_tool_use () =
+  let line = {|{"type":"tool_use","tool_name":"write_file","tool_id":"t3","parameters":{"file_path":"/tmp/a.ml","content":"let () = ()"}}|} in
+  match expect_tool (parse_gemini line) with
+  | Some info ->
+    Alcotest.(check string) "maps to Write" "Write" info.tool_name;
+    Alcotest.(check bool) "detail is ocaml code block"
+      true (String.length info.tool_detail >= 8
+            && String.sub info.tool_detail 0 8 = "```ocaml")
+  | None -> Alcotest.fail "expected single Tool_use"
+
+let test_gemini_unknown_tool_passthrough () =
+  let line = {|{"type":"tool_use","tool_name":"novel_tool","tool_id":"t4","parameters":{"x":"y"}}|} in
+  match expect_tool (parse_gemini line) with
+  | Some info ->
+    Alcotest.(check string) "unknown tool name preserved"
+      "novel_tool" info.tool_name
+  | None -> Alcotest.fail "expected single Tool_use"
+
+let test_gemini_tool_result_success () =
+  let line = {|{"type":"tool_result","tool_id":"t1","status":"success","output":"hello world"}|} in
+  Alcotest.(check (option string)) "success carries output"
+    (Some "hello world") (expect_tool_result (parse_gemini line))
+
+let test_gemini_tool_result_error () =
+  let line = {|{"type":"tool_result","tool_id":"t1","status":"error","output":"bad path","error":{"type":"invalid","message":"nope"}}|} in
+  match expect_tool_result (parse_gemini line) with
+  | Some content ->
+    Alcotest.(check bool) "content marked as error"
+      true (String.length content >= 7 && String.sub content 0 7 = "[error]");
+    Alcotest.(check bool) "includes error message"
+      true (try ignore (Str.search_forward
+              (Str.regexp_string "nope") content 0); true
+            with Not_found -> false)
+  | None -> Alcotest.fail "expected single Tool_result"
+
+let test_gemini_tool_result_empty_dropped () =
+  let line = {|{"type":"tool_result","tool_id":"t1","status":"success","output":""}|} in
+  Alcotest.(check int) "empty output with no error emits nothing"
+    0 (List.length (parse_gemini line))
+
+let test_gemini_result_flushes () =
+  let line = {|{"type":"result","status":"success","stats":{"total_tokens":1}}|} in
+  match parse_gemini line with
+  | [Discord_agents.Agent_process.Result { session_id = None; text = "" }] -> ()
+  | _ -> Alcotest.fail "expected Result with empty text and no session_id"
+
+let test_gemini_malformed_becomes_other () =
+  let line = "YOLO mode is enabled." in
+  match parse_gemini line with
+  | [Discord_agents.Agent_process.Other raw] ->
+    Alcotest.(check string) "preserves raw line" line raw
+  | _ -> Alcotest.fail "expected Other event"
+
+let test_gemini_unknown_type_becomes_other () =
+  let line = {|{"type":"novel_event","foo":"bar"}|} in
+  match parse_gemini line with
+  | [Discord_agents.Agent_process.Other _] -> ()
+  | _ -> Alcotest.fail "expected Other for unknown type"
+
+let gemini_json_tests = [
+  Alcotest.test_case "init captures session_id" `Quick test_gemini_init_captures_session_id;
+  Alcotest.test_case "init missing session_id dropped" `Quick test_gemini_init_without_session_dropped;
+  Alcotest.test_case "user echo skipped" `Quick test_gemini_user_message_skipped;
+  Alcotest.test_case "assistant delta is Text_delta" `Quick test_gemini_assistant_delta;
+  Alcotest.test_case "empty assistant dropped" `Quick test_gemini_assistant_empty_dropped;
+  Alcotest.test_case "run_shell_command maps to Bash" `Quick test_gemini_shell_tool_use;
+  Alcotest.test_case "read_file maps to Read" `Quick test_gemini_read_file_tool_use;
+  Alcotest.test_case "write_file maps to Write" `Quick test_gemini_write_file_tool_use;
+  Alcotest.test_case "unknown tool name passthrough" `Quick test_gemini_unknown_tool_passthrough;
+  Alcotest.test_case "tool_result success" `Quick test_gemini_tool_result_success;
+  Alcotest.test_case "tool_result error prefixed" `Quick test_gemini_tool_result_error;
+  Alcotest.test_case "empty tool_result dropped" `Quick test_gemini_tool_result_empty_dropped;
+  Alcotest.test_case "result flushes with no session_id" `Quick test_gemini_result_flushes;
+  Alcotest.test_case "malformed becomes Other" `Quick test_gemini_malformed_becomes_other;
+  Alcotest.test_case "unknown type becomes Other" `Quick test_gemini_unknown_type_becomes_other;
+]
+
 (* ── runner ──────────────────────────────────────────────────────── *)
 
 let () =
@@ -924,4 +1097,5 @@ let () =
     "tool_detail", tool_detail_tests;
     "escape_nested_fences", escape_nested_fences_tests;
     "codex_json", codex_json_tests;
+    "gemini_json", gemini_json_tests;
   ]


### PR DESCRIPTION
## Summary
- Wires `Config.Gemini` end-to-end: `!start <project> gemini` (and the `start_session` MCP tool) now spawns real Gemini CLI sessions with streaming text, tool calls, and MCP tool access in Discord.
- Adds `parse_gemini_stream_json_line` that maps Gemini's flat stream-json schema (`init` / `message{role,delta}` / `tool_use` / `tool_result` / `result`) onto the existing `Text_delta` / `Tool_use` / `Tool_result` / `Result` types. Tool names translate from Gemini-native (`run_shell_command`, `read_file`, …) to Claude-equivalents so `summarize_tool_input` / `detail_of_tool_input` apply unchanged.
- Per-worktree MCP wiring: Gemini has no `--mcp-config` flag, so we write `<worktree>/.gemini/settings.json` with the discord-agents MCP server before each run and append `.gemini/` to the worktree's `.git/info/exclude`. Verified live that Gemini picks up the config and connects to the MCP server.
- Session discovery via a new `lib/gemini_sessions.ml` (scans `~/.gemini/tmp/*/chats/session-*.json`, resolves `projectHash` → filesystem path via `~/.gemini/projects.json` + sha256sum). Surfaces via new `!gemini-sessions` command.
- `!resume` now takes an optional agent kind: `!resume <sid>` auto-detects, `!resume gemini <sid>` / `!resume claude <sid>` disambiguate.

## Stacking
Stacked on #27 (feat/codex-support). Merge that first; this PR's base is `feat/codex-support` and will need rebasing to `master` after #27 lands. Reuses the `on_session_id` / `Session_store.set_session_id` machinery that #27 added, since Gemini also assigns its session id server-side (in the `init` event).

## Flags
Gemini is invoked with `-p <prompt> -o stream-json --yolo`. `--yolo` auto-approves tool calls — without it Gemini waits for interactive approval on each tool use, and Discord can't answer. This matches Claude's `--permission-mode bypassPermissions` posture.

## Test plan
- [x] `dune runtest` — 106 tests pass, including 15 new `gemini_json` cases (each event shape, tool-name translation, error/empty `tool_result`, malformed-line fallback) and 6 new `command_parsing` cases (`!gemini-sessions`, `!resume [kind] sid` variants, `!start project gemini`).
- [x] Live check that Gemini loads per-worktree `.gemini/settings.json` and connects to the discord-agents MCP server (confirmed via `gemini -p "List MCP tools" -o stream-json --yolo` — it enumerates `start_session`, `list_projects`, etc.).
- [ ] Smoke test in Discord: `!start <project> gemini`, send a prompt that edits a file and runs a shell command, verify text + tool summaries + tool output appear.
- [ ] Second message in the same thread — verify the subprocess is `gemini -p ... --resume <uuid>` (session id captured from `init`).
- [ ] `!gemini-sessions` returns recent entries with resolved project paths.
- [ ] `!resume gemini <sid>` attaches to a prior Gemini session and continues it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)