### PR TITLE
fix: default Codex sessions to yolo mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ Non-command messages in control/project channels are routed to a Claude session 
 - **Channel reordering**: Active project channels float to the top of the category.
 - **Worktrees**: Each `start` command creates an isolated git worktree (`agent/<kind>-<uuid>`).
 - **Graceful restart**: `!restart` drains active sessions, rebuilds, and respawns.
+- **Codex sandbox**: Codex sessions run with `--dangerously-bypass-approvals-and-sandbox` (no filesystem sandbox, no approval prompts). The bot is single-tenant on a personal machine and the lighter `--full-auto` blocks edits the user routinely makes; see issue #35 for plumbing this through configuration so the sandboxed mode can be opted into.
 
 ## Discord formatting gotchas
 

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1373,7 +1373,8 @@ let codex_mcp_overrides () =
     "--" separator prevents prompts that happen to begin with "-"
     from being mistaken for a Codex flag. *)
 let codex_args ~session_id ~session_id_confirmed ~prompt =
-  let base = ["codex"; "exec"; "--json"; "--full-auto";
+  let base = ["codex"; "exec"; "--json";
+              "--dangerously-bypass-approvals-and-sandbox";
               "--skip-git-repo-check"]
              @ codex_mcp_overrides () in
   if not session_id_confirmed then base @ ["--"; prompt]
@@ -1386,7 +1387,8 @@ let codex_args ~session_id ~session_id_confirmed ~prompt =
 
     [--yolo] auto-approves tool calls; without it Gemini blocks on an
     interactive approval prompt that the non-interactive subprocess
-    can't answer (mirrors Codex's [--full-auto]).
+    can't answer (mirrors Codex's
+    [--dangerously-bypass-approvals-and-sandbox]).
 
     Gemini's MCP server config is written into [.gemini/settings.json]
     by [setup_gemini_mcp], which run_streaming calls before invoking

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1371,7 +1371,17 @@ let codex_mcp_overrides () =
     first-turn failure that happened before thread.started, or skip
     resume after a first-turn failure that happened after it. The
     "--" separator prevents prompts that happen to begin with "-"
-    from being mistaken for a Codex flag. *)
+    from being mistaken for a Codex flag.
+
+    [--dangerously-bypass-approvals-and-sandbox] disables both the
+    approval prompts (which a non-interactive subprocess can't
+    answer anyway) and Codex's workspace-write filesystem sandbox.
+    The lighter-weight [--full-auto] only handles the approval
+    half. We pick the heavier flag because the bot's stated trust
+    model (README.md "no sandboxing in discord-agents itself") is
+    that the user runs it on a personal machine and Codex's sandbox
+    has historically blocked legitimate edits inside the worktree.
+    See issue #35 for making this configurable. *)
 let codex_args ~session_id ~session_id_confirmed ~prompt =
   let base = ["codex"; "exec"; "--json";
               "--dangerously-bypass-approvals-and-sandbox";
@@ -1385,10 +1395,13 @@ let codex_args ~session_id ~session_id_confirmed ~prompt =
     Result. Subsequent runs resume only when [session_id_confirmed],
     matching the same coherence contract Codex uses.
 
-    [--yolo] auto-approves tool calls; without it Gemini blocks on an
+    [--yolo] auto-approves tool calls so Gemini doesn't block on an
     interactive approval prompt that the non-interactive subprocess
-    can't answer (mirrors Codex's
-    [--dangerously-bypass-approvals-and-sandbox]).
+    can't answer. It is *not* a full equivalent of Codex's
+    [--dangerously-bypass-approvals-and-sandbox]: that flag also
+    drops Codex's filesystem sandbox, while Gemini's [--yolo] only
+    covers approvals. The closer Codex analogue for [--yolo] is
+    [--full-auto].
 
     Gemini's MCP server config is written into [.gemini/settings.json]
     by [setup_gemini_mcp], which run_streaming calls before invoking

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -2336,8 +2336,9 @@ let test_codex_args_fresh () =
     (List.length args >= 2 && List.nth args 0 = "codex"
      && List.nth args 1 = "exec");
   Alcotest.(check bool) "includes --json" true (List.mem "--json" args);
-  Alcotest.(check bool) "includes --full-auto" true
-    (List.mem "--full-auto" args);
+  Alcotest.(check bool) "includes --dangerously-bypass-approvals-and-sandbox"
+    true
+    (List.mem "--dangerously-bypass-approvals-and-sandbox" args);
   Alcotest.(check bool) "includes --skip-git-repo-check" true
     (List.mem "--skip-git-repo-check" args);
   Alcotest.(check bool) "no resume on fresh" false (List.mem "resume" args);


### PR DESCRIPTION
## Summary
- Swap Codex's `--full-auto` for `--dangerously-bypass-approvals-and-sandbox` in `codex_args` (lib/agent_process.ml) so Codex sessions skip both the approval prompts and the workspace-write sandbox, matching how the user runs Codex outside the bot.
- Rewrite the `gemini_args` cross-reference comment: Gemini's `--yolo` only covers approvals, so `--full-auto` is the closer analogue, not the new flag.
- `CLAUDE.md` gains a "Codex sandbox" line in the Key behaviors section so a future reader greppinng for sandbox/yolo lands on the rationale.
- Update `test_codex_args_fresh` to assert the new flag.

## Why
The lighter `--full-auto` was blocking edits the user routinely makes inside worktrees, and the bot already disclaims having any sandbox of its own (README.md). Picking the heavier flag matches how Codex is actually used day-to-day on this machine.

## Follow-up
Filed #35 to plumb the sandbox mode through configuration so the sandboxed mode can be opted into. The council review on this PR also flagged two adjacent design questions (worktree-creation fallback, `!resume` cwd handling) that are noted in #35 as things to think about while implementing — neither is a regression introduced by this PR.

## Test plan
- [x] `nix develop --command dune build`
- [x] `nix develop --command dune runtest` (full suite passes, including the live `agent_contracts` Codex tests)
- [ ] Smoke test: `!start <project> codex` and confirm the session can edit files Codex's `--full-auto` sandbox previously blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)