### PR TITLE
fix: round-6 council findings on PR #32 — durability, prompt-expansion, rollback, channel_info

### DIFF
--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -902,13 +902,6 @@ let resolve_channel_context t ~(channel_id : Discord_types.channel_id)
       in
       (name, "thread")
 
-(** Handle a message in a session thread.
-    [channel_info] is passed through when the caller already fetched it.
-
-    During drain mode (restart pending), messages are still processed but
-    the user is warned. This is intentional: blocking messages during drain
-    would prevent using other sessions while a long-running task finishes.
-    The restart waits for all session.processing flags to go false. *)
 (** Run the agent for one message and drain any messages that queued
     behind it. Caller must have set [session.processing <- true] and
     is responsible for resetting it on exit (typically via Fun.protect
@@ -917,8 +910,18 @@ let resolve_channel_context t ~(channel_id : Discord_types.channel_id)
     Extracted from the body of [handle_thread_message] so the auto-trigger
     path in [fork_initial_prompt_run] can reuse it without going
     back through the queue check (which would cause it to queue itself
-    behind the very flag we set to close the gateway race). *)
+    behind the very flag we set to close the gateway race).
+
+    [?prompt_override] — when [Some p], the agent receives [p] instead
+    of [msg.content], and [session.initial_prompt]'s prepend is skipped
+    (the override caller has already woven the prompt into the agent
+    input themselves). The auto-trigger uses this so the agent gets
+    the FULL pre-sanitize prompt rather than the first chunk of a
+    multi-part visible-message split. [session.initial_prompt] still
+    gets cleared on success — the durable copy was only insurance
+    against a crash before the override-driven run completed. *)
 let rec process_session_message t session
+    ?prompt_override
     (msg : Discord_types.message) channel_info =
   let child_pid = ref None in
   Fun.protect ~finally:(fun () ->
@@ -937,20 +940,25 @@ let rec process_session_message t session
       child_pid := Some pid;
       register_child_pid t pid;
       Logs.info (fun m -> m "bot: registered child pid %d" pid) in
-    (* Forward-compat: [session.initial_prompt] is no longer set by any
-       current caller (control_api now posts the prompt visibly and
-       feeds it to handle_thread_message directly — see
-       control_api.handle_start_session). The prepend stays so a
-       sessions.json persisted before that change still gets the
-       intended preface on its first message after a bot restart.
-       Removable once we're sure no on-disk session still carries
-       a non-None [initial_prompt]. *)
+    (* [session.initial_prompt] is set by [control_api.handle_start_session]
+       (mirroring the prompt content for crash-safe recovery), and by
+       any pre-existing on-disk session persisted before PR #32. The
+       prepend kicks in when no [prompt_override] was provided —
+       i.e., a normal user-typed message after a crash, or a session
+       reloaded from sessions.json with [initial_prompt] still set.
+       The auto-trigger path passes the full prompt via
+       [prompt_override] and bypasses the prepend. In both cases we
+       clear [initial_prompt] on success below so the next user message
+       isn't rewrapped. *)
     let had_initial_prompt = Option.is_some session.initial_prompt in
-    let prompt = match session.initial_prompt with
-      | Some ctx ->
-        Printf.sprintf "<session-context>\n%s\n</session-context>\n\n%s"
-          ctx msg.content
-      | None -> msg.content
+    let prompt = match prompt_override with
+      | Some p -> p
+      | None ->
+        (match session.initial_prompt with
+         | Some ctx ->
+           Printf.sprintf "<session-context>\n%s\n</session-context>\n\n%s"
+             ctx msg.content
+         | None -> msg.content)
     in
     let on_scroll_content chunks lines_used =
       (* Cap stored content at ~100KB to prevent memory bloat.
@@ -1021,6 +1029,13 @@ let rec process_session_message t session
       ~message_id:pending.msg.id ~emoji:"\xE2\x8F\xB3" ());
     process_session_message t session pending.msg pending.channel_info
 
+(** Handle a message in a session thread.
+    [channel_info] is passed through when the caller already fetched it.
+
+    During drain mode (restart pending), messages are still processed but
+    the user is warned. This is intentional: blocking messages during drain
+    would prevent using other sessions while a long-running task finishes.
+    The restart waits for all session.processing flags to go false. *)
 let handle_thread_message t msg ?channel_info () =
   if t.draining then
     ignore (Discord_rest.create_message t.rest
@@ -1050,18 +1065,31 @@ let handle_thread_message t msg ?channel_info () =
     immediately, bypassing the queue check that
     [handle_thread_message] would otherwise impose on a busy session.
 
-    Order requirement: caller MUST set [session.processing <- true]
-    *before* calling [Session_store.add], so that any user message
-    landing in the new thread between [add] and our fork queues
-    correctly behind us — and MUST keep that flag set until calling
-    here. The fork's [Fun.protect] resets the flag when the run
-    completes (after the queue drain). *)
-let fork_initial_prompt_run t ~session ~msg =
+    [~prompt] is what the agent sees as its first user turn — passed
+    via [prompt_override] so we use the full pre-sanitize content the
+    MCP caller supplied, not [msg.content] (which holds only the first
+    Discord chunk after any UTF-8-expansion-driven split).
+
+    [?channel_info] lets the caller hand in the [Discord_types.channel]
+    they already received from [create_thread_no_message], so
+    [resolve_channel_context] doesn't have to make a redundant
+    [get_channel] REST call to recover the name.
+
+    Preconditions (caller must uphold; checked by assertion below):
+    - [session.processing] MUST already be [true] before
+      [Session_store.add] published the session, so any user message
+      landing in the new thread queues into [pending_queue] instead
+      of racing through [handle_thread_message]'s idle path.
+    The fork's [Fun.protect] resets [processing] to [false] when the
+    run completes (after the queue drain). *)
+let fork_initial_prompt_run t ~session ~msg ~prompt ?channel_info () =
+  assert session.Session_store.processing;
   Eio.Fiber.fork ~sw:t.sw (fun () ->
     Fun.protect ~finally:(fun () ->
       session.Session_store.processing <- false
     ) (fun () ->
-      process_session_message t session msg None))
+      process_session_message t session
+        ~prompt_override:prompt msg channel_info))
 
 (** Ensure a session exists for a channel (control or project channels).
     Creates a persistent Claude session so the channel can handle chat directly. *)

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -225,17 +225,27 @@ let handle_start_session (bot : Bot.t) params =
               "Working on the prompt below \u{2014} send a message any \
                time to add to the conversation."
             | None -> "Send a message to interact." in
-          (* Build the session struct with [initial_prompt:None] —
-             when an initial_prompt was supplied, we post it as a
-             visible Discord message below and feed that message to
-             the agent runner directly. Stashing it in
-             [session.initial_prompt] would silently prepend it to
-             whatever the user sends next instead, so the user never
-             sees what context the agent received. *)
+          (* Build the session. When an [initial_prompt] is supplied we
+             store it on the session as a *durable* backup: the visible
+             prompt message we post below is the agent's first turn on
+             the success path, but if the bot crashes between
+             [Session_store.add] and the auto-trigger fiber's
+             completion, the persisted [initial_prompt] lets the next
+             user message after restart resurrect the task via the
+             [<session-context>] prepend in [process_session_message].
+
+             Importantly the auto-trigger path passes the prompt to
+             [fork_initial_prompt_run] via [~prompt] (a [prompt_override])
+             so the agent gets the full pre-sanitize content, and
+             [process_session_message] does NOT prepend [initial_prompt]
+             a second time. On success the field is cleared. On crash
+             the field survives, and the user's next message picks it
+             up — same observable behavior as the pre-PR-#32 hidden
+             context, just with the prompt also visibly posted. *)
           let session = Session_store.make_session
             ~project_name:p.name ~working_dir ~agent_kind:kind
             ~session_id ~thread_id:thread_ch.Discord_types.id
-            ~system_prompt:None ~initial_prompt:None () in
+            ~system_prompt:None ~initial_prompt () in
           (* Race-safe ordering for the auto-trigger.
 
              When an initial_prompt is set, we MUST publish the
@@ -284,16 +294,19 @@ let handle_start_session (bot : Bot.t) params =
              match Discord_rest.create_message bot.rest
                      ~channel_id:thread_ch.id ~content:prompt () with
              | Error e ->
-               (* Roll back: the session is half-published (in store
-                  but [processing] locked, no agent fiber will fire),
-                  and the thread holds an orphan announcement. Remove
-                  the session, delete the thread, and surface the
-                  error to the MCP caller. *)
+               (* Roll back. Delete the thread FIRST: it nukes the
+                  announcement, the user-typed messages that may have
+                  raced into [pending_queue], and the
+                  hourglass/eyes reactions on them in one shot. If
+                  [delete_channel] fails (network, permissions),
+                  surface an in-thread error so the user sees
+                  *something* before we drop the session — handle_message
+                  would otherwise treat the now-orphan thread as
+                  "unknown thread under project channel" and auto-create
+                  a default-worktree session for any subsequent message,
+                  with no record of what just happened. *)
                Logs.warn (fun m -> m
                  "control_api: failed to post initial_prompt: %s" e);
-               session.processing <- false;
-               Session_store.remove bot.sessions
-                 ~thread_id:thread_ch.id;
                (match Discord_rest.delete_channel bot.rest
                        ~channel_id:thread_ch.id () with
                 | Ok _ -> ()
@@ -301,12 +314,22 @@ let handle_start_session (bot : Bot.t) params =
                   Logs.warn (fun m -> m
                     "control_api: failed to clean up orphan thread \
                      %s after prompt-post failure: %s"
-                    thread_ch.id de));
+                    thread_ch.id de);
+                  ignore (Discord_rest.create_message bot.rest
+                    ~channel_id:thread_ch.id
+                    ~content:(Printf.sprintf
+                      "Session setup failed (%s); this thread is no \
+                       longer attached to an agent."
+                      e) ()));
+               session.processing <- false;
+               Session_store.remove bot.sessions
+                 ~thread_id:thread_ch.id;
                error_response (Printf.sprintf
                  "Failed to post initial_prompt: %s" e)
              | Ok prompt_msg ->
                Bot.fork_initial_prompt_run bot
-                 ~session ~msg:prompt_msg;
+                 ~session ~msg:prompt_msg ~prompt
+                 ~channel_info:thread_ch ();
                ok_response [
                  ("thread_id", `String thread_ch.id);
                  ("working_dir", `String working_dir);


### PR DESCRIPTION
## Summary

Follow-up to merged PR #32. Round-6 council review against the merged stack surfaced one Critical, two Important, and a few nits. All addressed here.

### Critical — initial_prompt is no longer crash-safe

PR #32 built the session with `initial_prompt:None` on the auto-trigger path. A bot crash between `Session_store.add` and the auto-trigger fiber's completion silently lost the prompt as agent input — the visible message stayed in the thread but the agent never ran on it after restart. The pre-PR-#32 hidden-context path kept the prompt in `sessions.json` until success, so this was a real durability regression.

**Fix:** store the prompt on `session.initial_prompt` as a durable backup. The auto-trigger run uses a new `?prompt_override` on `process_session_message` so it can pass the full pre-sanitize prompt through without going through the `<session-context>` prepend (avoiding double-wrapping). On success the field is cleared. On crash the field survives, the user's next message post-restart picks it up via the existing prepend path, and the task resurfaces.

### Important — auto-trigger only saw the first Discord chunk after UTF-8 expansion

The auto-trigger fed `prompt_msg.content` into the agent, which is just the first chunk after `Discord_rest.create_message`'s sanitize-driven split. The new `~prompt` parameter on `fork_initial_prompt_run` takes the full pre-sanitize content the MCP caller supplied, so the agent never loses tail bytes regardless of how Discord splits the visible message.

### Important — rollback could leak a half-set-up session

Previous order: `processing<-false → Session_store.remove → delete_channel`. If `delete_channel` failed, the session was gone but the thread (with announcement and queued messages) remained; `handle_message`'s unknown-thread fallback would auto-create a default-worktree session on the next message with no record of what just happened.

**Fix:** `delete_channel` FIRST. Success nukes everything in one shot. On failure, post an in-thread error ("Session setup failed; this thread is no longer attached to an agent.") so the user sees what happened, then remove the session.

### Nits

- `fork_initial_prompt_run` now takes `?channel_info`; `control_api` threads through `thread_ch` from `create_thread_no_message` so `resolve_channel_context` reuses it instead of making a redundant `get_channel` REST call.
- Moved the misplaced doc-comment for `handle_thread_message` (was sitting above `process_session_message` since the round-2 extraction).
- Added `assert session.processing` at `fork_initial_prompt_run` entry — the precondition was documented but not enforced.
- Aligned drain-refusal wording: `control_api`'s "Bot is restarting; try again shortly." → "Bot is restarting. Try again shortly." (matches `handle_message`).

## Test plan

- [x] `dune build` clean
- [x] `dune runtest` passes (205 unit + 14 project + 6 live contract tests)
- [ ] Manual: `scripts/run-branch.sh fix/initial-prompt-durability`, then `start_session` with `initial_prompt`. Verify:
  - [ ] Visible prompt posts; agent auto-triggers; ✅ on completion
  - [ ] (Crash recovery) After bot restart with the session in `sessions.json` carrying `initial_prompt`, sending a message in the thread runs the agent with the prepended context — old durable behavior, restored
  - [ ] Long initial_prompt (~1900 bytes with multibyte content) — agent gets the full prompt even if the visible message split into multiple Discord posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
