### PR TITLE
Harden gateway cancellation and websocket diagnostics

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -164,7 +164,9 @@ let () =
       Logs.info (fun m -> m "shutdown: signal received");
       bot.gateway.shutdown <- true;
       (match bot.gateway.ws with
-       | Some ws -> (try Discord_agents.Websocket.send_close ws with _ -> ())
+       | Some ws ->
+         (try Discord_agents.Websocket.send_close ws with exn ->
+            Discord_agents.Websocket.raise_if_cancelled exn)
        | None -> ());
       Unix.close shutdown_r;
       Unix.close shutdown_w);

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -10,6 +10,7 @@
     --test CHANNEL   Also send a test message to the given channel *)
 
 let setup_logging () =
+  Printexc.record_backtrace true;
   Fmt_tty.setup_std_outputs ();
   Logs.set_reporter (Logs_fmt.reporter ());
   Logs.set_level (Some Logs.Info)

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -298,6 +298,12 @@ let trigger_restart t ~notify =
         notify "Build failed, not restarting."
         (* draining reset by Fun.protect finally *)
       | `Restarting ->
+        t.gateway.shutdown <- true;
+        (match t.gateway.ws with
+         | Some ws ->
+           (try Websocket.send_close ws with exn ->
+              Websocket.raise_if_cancelled exn)
+         | None -> ());
         notify "Build succeeded. New instance starting — shutting down in 30s.";
         (* Wait for new instance to take over, then exit. *)
         Eio.Time.sleep (Eio.Stdenv.clock t.env) 30.0;

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -14,6 +14,11 @@ let socket_path () =
   let home = Sys.getenv "HOME" in
   Filename.concat home ".config/discord-agents/control.sock"
 
+let raise_if_cancelled exn =
+  match exn with
+  | Eio.Cancel.Cancelled _ -> raise exn
+  | _ -> ()
+
 (** Read one line from a buffered reader, up to a size limit. *)
 let read_line_limited reader =
   try
@@ -24,13 +29,17 @@ let read_line_limited reader =
       Ok line
   with
   | End_of_file -> Error "empty request"
-  | exn -> Error (Printexc.to_string exn)
+  | exn ->
+    raise_if_cancelled exn;
+    Error (Printexc.to_string exn)
 
 (** Send a JSON response and close. *)
 let send_response flow json =
   let data = Yojson.Safe.to_string json ^ "\n" in
   try Eio.Flow.copy_string data flow
-  with _ -> ()  (* client may have disconnected *)
+  with exn ->
+    raise_if_cancelled exn;
+    ()
 
 let ok_response body =
   `Assoc (("ok", `Bool true) :: body)
@@ -71,12 +80,31 @@ let handle_health (bot : Bot.t) =
     | Some err -> optional_error_field "last_rest_transport_error" err
     | None -> []
   in
+  let gateway_fields = [
+    ("gateway_connected", `Bool (Option.is_some bot.gateway.ws));
+    ("gateway_resuming", `Bool bot.gateway.resuming);
+    ("gateway_sequence",
+     match bot.gateway.sequence with Some s -> `Int s | None -> `Null);
+  ] in
+  let optional_gateway_fields =
+    (match bot.gateway.last_error with
+     | Some err ->
+       [("last_gateway_error",
+         `String (Resource.truncate_utf8 ~max_bytes:1000
+           (Resource.sanitize_utf8 (Resource.single_line err))))]
+     | None -> [])
+    @
+    (match bot.gateway.last_payload_summary with
+     | Some summary -> [("last_gateway_payload", `String summary)]
+     | None -> [])
+  in
   ok_response ([
     ("uptime_seconds", `Int uptime);
     ("sessions", `Int (Session_store.count bot.sessions));
     ("projects", `Int (List.length (Bot.projects bot)));
     ("channels", `Int (Channel_manager.count (Bot.channels bot)));
-  ] @ rest_fields @ optional_rest_fields @ optional_transport_fields)
+  ] @ rest_fields @ optional_rest_fields
+    @ optional_transport_fields @ gateway_fields @ optional_gateway_fields)
 
 let handle_list_projects (bot : Bot.t) =
   let projects = List.map (fun (p : Project.t) ->
@@ -496,17 +524,20 @@ let dispatch (bot : Bot.t) method_ params =
     | "refresh_projects" -> handle_refresh_projects bot
     | _ -> error_response (Printf.sprintf "Unknown method: %s" method_)
   with exn ->
+    raise_if_cancelled exn;
     Logs.warn (fun m -> m "control_api: handler error: %s" (Printexc.to_string exn));
     error_response (Printexc.to_string exn)
 
 (* ── Connection handler ────────────────────────────────────────── *)
 
 let handle_connection bot flow =
+  let started_at = Unix.gettimeofday () in
   let reader = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) flow in
   match read_line_limited reader with
   | Error e ->
     send_response flow (error_response e)
   | Ok line ->
+    let method_name = ref "<invalid>" in
     let response = match Yojson.Safe.from_string line with
       | exception _ -> error_response "invalid JSON"
       | json ->
@@ -516,9 +547,15 @@ let handle_connection bot flow =
           | `Null -> None | p -> Some p in
         (match method_ with
          | None -> error_response "missing 'method' field"
-         | Some m -> dispatch bot m params)
+         | Some m ->
+           method_name := m;
+           dispatch bot m params)
     in
-    send_response flow response
+    send_response flow response;
+    let elapsed = Unix.gettimeofday () -. started_at in
+    if elapsed >= 0.5 then
+      Logs.warn (fun m -> m "control_api: slow request method=%s elapsed=%.3fs"
+        !method_name elapsed)
 
 (* ── Server ────────────────────────────────────────────────────── *)
 
@@ -527,15 +564,27 @@ let start ~(bot : Bot.t) ~sw ~(env : Eio_unix.Stdenv.base) =
   (* Remove stale socket from a previous run *)
   (try Unix.unlink path with Unix.Unix_error _ -> ());
   let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
   let addr = `Unix path in
-  let socket = Eio.Net.listen ~sw ~backlog:5 ~reuse_addr:true net addr in
+  let socket = Eio.Net.listen ~sw ~backlog:64 ~reuse_addr:true net addr in
   Logs.info (fun m -> m "control_api: listening on %s" path);
   (* Accept loop — each connection handled in its own fiber *)
   let rec accept_loop () =
-    let flow, _addr = Eio.Net.accept ~sw socket in
-    Eio.Fiber.fork ~sw (fun () ->
-      Fun.protect ~finally:(fun () -> Eio.Flow.close flow) (fun () ->
-        handle_connection bot flow));
-    accept_loop ()
+    match
+      try Ok (Eio.Net.accept ~sw socket)
+      with exn ->
+        raise_if_cancelled exn;
+        Error exn
+    with
+    | Ok (flow, _addr) ->
+      Eio.Fiber.fork ~sw (fun () ->
+        Fun.protect ~finally:(fun () -> Eio.Flow.close flow) (fun () ->
+          handle_connection bot flow));
+      accept_loop ()
+    | Error exn ->
+      Logs.warn (fun m -> m "control_api: accept failed: %s"
+        (Printexc.to_string exn));
+      Eio.Time.sleep clock 0.1;
+      accept_loop ()
   in
   accept_loop ()

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -16,7 +16,10 @@ let socket_path () =
 
 let raise_if_cancelled exn =
   match exn with
-  | Eio.Cancel.Cancelled _ -> raise exn
+  | Eio.Cancel.Cancelled _
+  | Out_of_memory
+  | Stack_overflow
+  | Sys.Break -> raise exn
   | _ -> ()
 
 let max_request_size = 1_000_000

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -571,8 +571,10 @@ let start ~(bot : Bot.t) ~sw ~(env : Eio_unix.Stdenv.base) =
   let addr = `Unix path in
   let socket = Eio.Net.listen ~sw ~backlog:64 ~reuse_addr:true net addr in
   Logs.info (fun m -> m "control_api: listening on %s" path);
+  let min_accept_retry_delay = 0.1 in
+  let max_accept_retry_delay = 5.0 in
   (* Accept loop — each connection handled in its own fiber *)
-  let rec accept_loop () =
+  let rec accept_loop retry_delay =
     match
       try Ok (Eio.Net.accept ~sw socket)
       with exn ->
@@ -583,11 +585,11 @@ let start ~(bot : Bot.t) ~sw ~(env : Eio_unix.Stdenv.base) =
       Eio.Fiber.fork ~sw (fun () ->
         Fun.protect ~finally:(fun () -> Eio.Flow.close flow) (fun () ->
           handle_connection bot flow));
-      accept_loop ()
+      accept_loop min_accept_retry_delay
     | Error exn ->
-      Logs.warn (fun m -> m "control_api: accept failed: %s"
-        (Printexc.to_string exn));
-      Eio.Time.sleep clock 0.1;
-      accept_loop ()
+      Logs.warn (fun m -> m "control_api: accept failed: %s; retrying in %.1fs"
+        (Printexc.to_string exn) retry_delay);
+      Eio.Time.sleep clock retry_delay;
+      accept_loop (min max_accept_retry_delay (retry_delay *. 2.0))
   in
-  accept_loop ()
+  accept_loop min_accept_retry_delay

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -19,16 +19,19 @@ let raise_if_cancelled exn =
   | Eio.Cancel.Cancelled _ -> raise exn
   | _ -> ()
 
+let max_request_size = 1_000_000
+
 (** Read one line from a buffered reader, up to a size limit. *)
 let read_line_limited reader =
   try
     let line = Eio.Buf_read.line reader in
-    if String.length line > 1_000_000 then
+    if String.length line > max_request_size then
       Error "request too large"
     else
       Ok line
   with
   | End_of_file -> Error "empty request"
+  | Eio.Buf_read.Buffer_limit_exceeded -> Error "request too large"
   | exn ->
     raise_if_cancelled exn;
     Error (Printexc.to_string exn)
@@ -532,7 +535,7 @@ let dispatch (bot : Bot.t) method_ params =
 
 let handle_connection bot flow =
   let started_at = Unix.gettimeofday () in
-  let reader = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) flow in
+  let reader = Eio.Buf_read.of_flow ~max_size:max_request_size flow in
   match read_line_limited reader with
   | Error e ->
     send_response flow (error_response e)

--- a/lib/discord_gateway.ml
+++ b/lib/discord_gateway.ml
@@ -130,17 +130,23 @@ let payload_diagnostics payload =
     Printf.sprintf "bytes=%d invalid_json" bytes
   | json ->
     let open Yojson.Safe.Util in
+    let safe f ~default =
+      try f () with _ -> default
+    in
     let op =
-      match json |> member "op" |> to_int_option with
+      match safe (fun () -> json |> member "op" |> to_int_option) ~default:None with
       | Some n -> string_of_gateway_opcode (gateway_opcode_of_int n)
       | None -> "?"
     in
-    let event_name =
-      json |> member "t" |> to_string_option |> Option.value ~default:"UNKNOWN"
+    let event_name = safe
+      (fun () -> json |> member "t" |> to_string_option
+        |> Option.value ~default:"UNKNOWN")
+      ~default:"?"
     in
-    let seq =
-      json |> member "s" |> to_int_option
-      |> Option.map string_of_int |> Option.value ~default:"?"
+    let seq = safe
+      (fun () -> json |> member "s" |> to_int_option
+        |> Option.map string_of_int |> Option.value ~default:"?")
+      ~default:"?"
     in
     Printf.sprintf "bytes=%d op=%s event=%s seq=%s"
       bytes op event_name seq
@@ -178,6 +184,7 @@ let handle_payload t ~sw ~(clock : _ Eio.Time.clock) json =
           t.resume_gateway_url <- resume_url;
           t.resuming <- false;
           t.last_error <- None;
+          t.last_payload_summary <- None;
           Logs.info (fun m -> m "gateway: READY as %s (session %s)"
             user.username (Option.value ~default:"?" t.session_id));
           t.handler (Connected user)
@@ -188,6 +195,7 @@ let handle_payload t ~sw ~(clock : _ Eio.Time.clock) json =
      | "RESUMED" ->
        t.resuming <- false;
        t.last_error <- None;
+       t.last_payload_summary <- None;
        Logs.info (fun m -> m "gateway: RESUMED successfully (session %s)"
          (Option.value ~default:"?" t.session_id))
      | "MESSAGE_CREATE" ->
@@ -338,7 +346,8 @@ let connect ~sw ~(env : Eio_unix.Stdenv.base) t =
                summary err));
           recv_loop ()
         | { opcode = Close; _ } ->
-          Logs.info (fun m -> m "gateway: received close frame")
+          Logs.info (fun m -> m "gateway: received close frame");
+          t.handler (Disconnected "close frame")
         | { opcode = _; _ } ->
           recv_loop ()
         | exception exn ->

--- a/lib/discord_gateway.ml
+++ b/lib/discord_gateway.ml
@@ -123,33 +123,35 @@ let string_of_gateway_opcode = function
   | Heartbeat_ack -> "Heartbeat_ack"
   | Unknown_op n -> Printf.sprintf "Unknown_op(%d)" n
 
+let payload_summary_of_json ~bytes json =
+  let open Yojson.Safe.Util in
+  let safe f ~default =
+    try f () with _ -> default
+  in
+  let op =
+    match safe (fun () -> json |> member "op" |> to_int_option) ~default:None with
+    | Some n -> string_of_gateway_opcode (gateway_opcode_of_int n)
+    | None -> "?"
+  in
+  let event_name = safe
+    (fun () -> json |> member "t" |> to_string_option
+      |> Option.value ~default:"UNKNOWN")
+    ~default:"?"
+  in
+  let seq = safe
+    (fun () -> json |> member "s" |> to_int_option
+      |> Option.map string_of_int |> Option.value ~default:"?")
+    ~default:"?"
+  in
+  Printf.sprintf "bytes=%d op=%s event=%s seq=%s"
+    bytes op event_name seq
+
 let payload_diagnostics payload =
   let bytes = String.length payload in
   match Yojson.Safe.from_string payload with
   | exception _ ->
     Printf.sprintf "bytes=%d invalid_json" bytes
-  | json ->
-    let open Yojson.Safe.Util in
-    let safe f ~default =
-      try f () with _ -> default
-    in
-    let op =
-      match safe (fun () -> json |> member "op" |> to_int_option) ~default:None with
-      | Some n -> string_of_gateway_opcode (gateway_opcode_of_int n)
-      | None -> "?"
-    in
-    let event_name = safe
-      (fun () -> json |> member "t" |> to_string_option
-        |> Option.value ~default:"UNKNOWN")
-      ~default:"?"
-    in
-    let seq = safe
-      (fun () -> json |> member "s" |> to_int_option
-        |> Option.map string_of_int |> Option.value ~default:"?")
-      ~default:"?"
-    in
-    Printf.sprintf "bytes=%d op=%s event=%s seq=%s"
-      bytes op event_name seq
+  | json -> payload_summary_of_json ~bytes json
 
 let exn_with_backtrace exn =
   let bt = Printexc.get_backtrace () |> String.trim in
@@ -328,13 +330,15 @@ let connect ~sw ~(env : Eio_unix.Stdenv.base) t =
       let rec recv_loop () =
         match Websocket.recv_frame ws with
         | { Websocket.opcode = Text; payload } ->
-          if String.length payload >= large_payload_warn_threshold then begin
-            let summary = payload_diagnostics payload in
-            t.last_payload_summary <- Some summary;
-            Logs.warn (fun m -> m "gateway: large payload received (%s)" summary)
-          end;
           (try
              let json = Yojson.Safe.from_string payload in
+             if String.length payload >= large_payload_warn_threshold then begin
+               let summary =
+                 payload_summary_of_json ~bytes:(String.length payload) json
+               in
+               t.last_payload_summary <- Some summary;
+               Logs.warn (fun m -> m "gateway: large payload received (%s)" summary)
+             end;
              handle_payload t ~sw ~clock json
            with exn ->
              raise_if_cancelled exn;

--- a/lib/discord_gateway.ml
+++ b/lib/discord_gateway.ml
@@ -80,10 +80,6 @@ let notify_disconnected t reason =
         (Printexc.to_string exn))
   end
 
-let websocket_closed_error = function
-  | Failure msg when String.equal msg "websocket: connection closed" -> true
-  | _ -> false
-
 (** Send a JSON payload over the WebSocket. *)
 let send_json t json =
   match t.ws with
@@ -380,9 +376,7 @@ let connect ~sw ~(env : Eio_unix.Stdenv.base) t =
           recv_loop ()
         | exception exn ->
           raise_if_cancelled exn;
-          if (t.disconnected_notified || t.shutdown)
-             && websocket_closed_error exn
-          then
+          if t.disconnected_notified || t.shutdown then
             ()
           else begin
             let err = exn_with_backtrace exn in

--- a/lib/discord_gateway.ml
+++ b/lib/discord_gateway.ml
@@ -33,6 +33,7 @@ type t = {
   mutable heartbeat_gen : int;  (* generation counter: daemon stops when it mismatches *)
   mutable resuming : bool;
   mutable shutdown : bool;
+  mutable disconnected_notified : bool;
   mutable last_error : string option;
   mutable last_payload_summary : string option;
   mutable handler : handler;
@@ -49,6 +50,7 @@ let create ~token ~intents ~handler =
     heartbeat_gen = 0;
     resuming = false;
     shutdown = false;
+    disconnected_notified = false;
     last_error = None;
     last_payload_summary = None;
     handler }
@@ -64,6 +66,16 @@ let raise_if_cancelled exn =
   match exn with
   | Eio.Cancel.Cancelled _ -> raise exn
   | _ -> ()
+
+let notify_disconnected t reason =
+  if not t.disconnected_notified then begin
+    t.disconnected_notified <- true;
+    try t.handler (Disconnected reason)
+    with exn ->
+      raise_if_cancelled exn;
+      Logs.warn (fun m -> m "gateway: disconnected handler error: %s"
+        (Printexc.to_string exn))
+  end
 
 (** Send a JSON payload over the WebSocket. *)
 let send_json t json =
@@ -271,7 +283,7 @@ let handle_payload t ~sw ~(clock : _ Eio.Time.clock) json =
   | Reconnect ->
     Logs.warn (fun m -> m "gateway: server requested reconnect");
     (match t.ws with Some ws -> Websocket.send_close ws | None -> ());
-    t.handler (Disconnected "reconnect requested")
+    notify_disconnected t "reconnect requested"
   | Invalid_session ->
     let resumable = try Yojson.Safe.Util.to_bool d with _ -> false in
     Logs.warn (fun m -> m "gateway: invalid session (resumable=%b)" resumable);
@@ -281,7 +293,7 @@ let handle_payload t ~sw ~(clock : _ Eio.Time.clock) json =
       t.resuming <- false
     end;
     (match t.ws with Some ws -> Websocket.send_close ws | None -> ());
-    t.handler (Disconnected "invalid session")
+    notify_disconnected t "invalid session"
   | _ ->
     Logs.debug (fun m -> m "gateway: unhandled opcode")
 
@@ -323,6 +335,7 @@ let connect ~sw ~(env : Eio_unix.Stdenv.base) t =
       connect_loop ()
     | Ok ws ->
       t.ws <- Some ws;
+      t.disconnected_notified <- false;
       backoff := 5.0;  (* Reset backoff on successful connect *)
       Logs.info (fun m -> m "gateway: WebSocket connected");
       (* Cancel any stale heartbeat daemon from previous connection *)
@@ -351,7 +364,7 @@ let connect ~sw ~(env : Eio_unix.Stdenv.base) t =
           recv_loop ()
         | { opcode = Close; _ } ->
           Logs.info (fun m -> m "gateway: received close frame");
-          t.handler (Disconnected "close frame")
+          notify_disconnected t "close frame"
         | { opcode = _; _ } ->
           recv_loop ()
         | exception exn ->
@@ -359,7 +372,7 @@ let connect ~sw ~(env : Eio_unix.Stdenv.base) t =
           let err = exn_with_backtrace exn in
           t.last_error <- Some err;
           Logs.warn (fun m -> m "gateway: recv error: %s" err);
-          t.handler (Disconnected ("recv error: " ^ Printexc.to_string exn))
+          notify_disconnected t ("recv error: " ^ Printexc.to_string exn)
       in
       recv_loop ();
       Websocket.close ws;

--- a/lib/discord_gateway.ml
+++ b/lib/discord_gateway.ml
@@ -33,6 +33,8 @@ type t = {
   mutable heartbeat_gen : int;  (* generation counter: daemon stops when it mismatches *)
   mutable resuming : bool;
   mutable shutdown : bool;
+  mutable last_error : string option;
+  mutable last_payload_summary : string option;
   mutable handler : handler;
 }
 
@@ -47,6 +49,8 @@ let create ~token ~intents ~handler =
     heartbeat_gen = 0;
     resuming = false;
     shutdown = false;
+    last_error = None;
+    last_payload_summary = None;
     handler }
 
 let default_intents =
@@ -56,12 +60,18 @@ let default_intents =
   lor Intent.direct_messages
   lor Intent.message_content
 
+let raise_if_cancelled exn =
+  match exn with
+  | Eio.Cancel.Cancelled _ -> raise exn
+  | _ -> ()
+
 (** Send a JSON payload over the WebSocket. *)
 let send_json t json =
   match t.ws with
   | Some ws ->
     (try Websocket.send_text ws (Yojson.Safe.to_string json)
      with exn ->
+       raise_if_cancelled exn;
        Logs.warn (fun m -> m "gateway: send_json error: %s" (Printexc.to_string exn)))
   | None -> Logs.warn (fun m -> m "gateway: send_json but no ws connection")
 
@@ -102,6 +112,48 @@ let resume_payload t =
 let can_resume t =
   Option.is_some t.session_id && Option.is_some t.sequence
 
+let string_of_gateway_opcode = function
+  | Dispatch -> "Dispatch"
+  | Heartbeat -> "Heartbeat"
+  | Identify -> "Identify"
+  | Resume -> "Resume"
+  | Reconnect -> "Reconnect"
+  | Invalid_session -> "Invalid_session"
+  | Hello -> "Hello"
+  | Heartbeat_ack -> "Heartbeat_ack"
+  | Unknown_op n -> Printf.sprintf "Unknown_op(%d)" n
+
+let payload_diagnostics payload =
+  let bytes = String.length payload in
+  match Yojson.Safe.from_string payload with
+  | exception _ ->
+    Printf.sprintf "bytes=%d invalid_json" bytes
+  | json ->
+    let open Yojson.Safe.Util in
+    let op =
+      match json |> member "op" |> to_int_option with
+      | Some n -> string_of_gateway_opcode (gateway_opcode_of_int n)
+      | None -> "?"
+    in
+    let event_name =
+      json |> member "t" |> to_string_option |> Option.value ~default:"UNKNOWN"
+    in
+    let seq =
+      json |> member "s" |> to_int_option
+      |> Option.map string_of_int |> Option.value ~default:"?"
+    in
+    Printf.sprintf "bytes=%d op=%s event=%s seq=%s"
+      bytes op event_name seq
+
+let exn_with_backtrace exn =
+  let bt = Printexc.get_backtrace () |> String.trim in
+  if bt = "" then
+    Printexc.to_string exn
+  else
+    Printf.sprintf "%s\n%s" (Printexc.to_string exn) bt
+
+let large_payload_warn_threshold = 512 * 1024
+
 (** Parse a gateway payload and dispatch events. *)
 let handle_payload t ~sw ~(clock : _ Eio.Time.clock) json =
   let open Yojson.Safe.Util in
@@ -125,14 +177,17 @@ let handle_payload t ~sw ~(clock : _ Eio.Time.clock) json =
           let resume_url = d |> member "resume_gateway_url" |> to_string_option in
           t.resume_gateway_url <- resume_url;
           t.resuming <- false;
+          t.last_error <- None;
           Logs.info (fun m -> m "gateway: READY as %s (session %s)"
             user.username (Option.value ~default:"?" t.session_id));
           t.handler (Connected user)
         with exn ->
+          raise_if_cancelled exn;
           Logs.warn (fun m -> m "gateway: failed to parse READY: %s"
             (Printexc.to_string exn)))
      | "RESUMED" ->
        t.resuming <- false;
+       t.last_error <- None;
        Logs.info (fun m -> m "gateway: RESUMED successfully (session %s)"
          (Option.value ~default:"?" t.session_id))
      | "MESSAGE_CREATE" ->
@@ -140,6 +195,7 @@ let handle_payload t ~sw ~(clock : _ Eio.Time.clock) json =
           let msg = message_of_yojson d in
           t.handler (Message_received msg)
         with exn ->
+          raise_if_cancelled exn;
           Logs.warn (fun m -> m "gateway: failed to parse MESSAGE_CREATE: %s"
             (Printexc.to_string exn)))
      | "THREAD_CREATE" ->
@@ -147,6 +203,7 @@ let handle_payload t ~sw ~(clock : _ Eio.Time.clock) json =
           let ch = channel_of_yojson d in
           t.handler (Thread_created ch)
         with exn ->
+          raise_if_cancelled exn;
           Logs.warn (fun m -> m "gateway: failed to parse THREAD_CREATE: %s"
             (Printexc.to_string exn)))
      | _ ->
@@ -242,10 +299,14 @@ let connect ~sw ~(env : Eio_unix.Stdenv.base) t =
     Logs.info (fun m -> m "gateway: connecting to %s" host);
     (match
       (try Ok (Websocket.connect ~sw ~net ~host ~port:443 ~path:gateway_path)
-       with exn -> Error exn)
+       with exn ->
+         raise_if_cancelled exn;
+         Error exn)
     with
     | Error exn ->
-      Logs.warn (fun m -> m "gateway: connect failed: %s" (Printexc.to_string exn));
+      let err = exn_with_backtrace exn in
+      t.last_error <- Some err;
+      Logs.warn (fun m -> m "gateway: connect failed: %s" err);
       Logs.info (fun m -> m "gateway: retrying in %.0fs..." !backoff);
       Eio.Time.sleep clock !backoff;
       backoff := min (!backoff *. 2.0) 60.0;
@@ -259,21 +320,36 @@ let connect ~sw ~(env : Eio_unix.Stdenv.base) t =
       let rec recv_loop () =
         match Websocket.recv_frame ws with
         | { Websocket.opcode = Text; payload } ->
+          if String.length payload >= large_payload_warn_threshold then begin
+            let summary = payload_diagnostics payload in
+            t.last_payload_summary <- Some summary;
+            Logs.warn (fun m -> m "gateway: large payload received (%s)" summary)
+          end;
           (try
              let json = Yojson.Safe.from_string payload in
              handle_payload t ~sw ~clock json
            with exn ->
-             Logs.warn (fun m -> m "gateway: failed to parse payload: %s"
-               (Printexc.to_string exn)));
+             raise_if_cancelled exn;
+             let summary = payload_diagnostics payload in
+             t.last_payload_summary <- Some summary;
+             let err = exn_with_backtrace exn in
+             t.last_error <- Some err;
+             Logs.warn (fun m -> m "gateway: failed to parse payload (%s): %s"
+               summary err));
           recv_loop ()
         | { opcode = Close; _ } ->
           Logs.info (fun m -> m "gateway: received close frame")
         | { opcode = _; _ } ->
           recv_loop ()
         | exception exn ->
-          Logs.warn (fun m -> m "gateway: recv error: %s" (Printexc.to_string exn))
+          raise_if_cancelled exn;
+          let err = exn_with_backtrace exn in
+          t.last_error <- Some err;
+          Logs.warn (fun m -> m "gateway: recv error: %s" err);
+          t.handler (Disconnected ("recv error: " ^ Printexc.to_string exn))
       in
       recv_loop ();
+      Websocket.close ws;
       t.ws <- None;
       t.heartbeat_gen <- t.heartbeat_gen + 1;
       if can_resume t then

--- a/lib/discord_gateway.ml
+++ b/lib/discord_gateway.ml
@@ -64,7 +64,10 @@ let default_intents =
 
 let raise_if_cancelled exn =
   match exn with
-  | Eio.Cancel.Cancelled _ -> raise exn
+  | Eio.Cancel.Cancelled _
+  | Out_of_memory
+  | Stack_overflow
+  | Sys.Break -> raise exn
   | _ -> ()
 
 let notify_disconnected t reason =
@@ -76,6 +79,10 @@ let notify_disconnected t reason =
       Logs.warn (fun m -> m "gateway: disconnected handler error: %s"
         (Printexc.to_string exn))
   end
+
+let websocket_closed_error = function
+  | Failure msg when String.equal msg "websocket: connection closed" -> true
+  | _ -> false
 
 (** Send a JSON payload over the WebSocket. *)
 let send_json t json =
@@ -138,7 +145,9 @@ let string_of_gateway_opcode = function
 let payload_summary_of_json ~bytes json =
   let open Yojson.Safe.Util in
   let safe f ~default =
-    try f () with _ -> default
+    try f () with exn ->
+      raise_if_cancelled exn;
+      default
   in
   let op =
     match safe (fun () -> json |> member "op" |> to_int_option) ~default:None with
@@ -250,6 +259,8 @@ let handle_payload t ~sw ~(clock : _ Eio.Time.clock) json =
           `Stop_daemon
         else if not t.last_heartbeat_acked then begin
           Logs.warn (fun m -> m "gateway: heartbeat not acked, reconnecting");
+          t.last_error <- Some "heartbeat timeout";
+          notify_disconnected t "heartbeat timeout";
           (match t.ws with Some ws -> Websocket.send_close ws | None -> ());
           `Stop_daemon
         end else begin
@@ -369,20 +380,47 @@ let connect ~sw ~(env : Eio_unix.Stdenv.base) t =
           recv_loop ()
         | exception exn ->
           raise_if_cancelled exn;
-          let err = exn_with_backtrace exn in
-          t.last_error <- Some err;
-          Logs.warn (fun m -> m "gateway: recv error: %s" err);
-          notify_disconnected t ("recv error: " ^ Printexc.to_string exn)
+          if (t.disconnected_notified || t.shutdown)
+             && websocket_closed_error exn
+          then
+            ()
+          else begin
+            let err = exn_with_backtrace exn in
+            t.last_error <- Some err;
+            Logs.warn (fun m -> m "gateway: recv error: %s" err);
+            notify_disconnected t ("recv error: " ^ Printexc.to_string exn)
+          end
       in
-      recv_loop ();
-      Websocket.close ws;
-      t.ws <- None;
-      t.heartbeat_gen <- t.heartbeat_gen + 1;
-      if can_resume t then
-        t.resuming <- true;
-      Logs.info (fun m -> m "gateway: reconnecting in %.0fs..." !backoff);
-      Eio.Time.sleep clock !backoff;
-      backoff := min (!backoff *. 1.5) 60.0;
-      connect_loop ())
+      let cleanup_connection () =
+        Fun.protect
+          ~finally:(fun () ->
+            t.ws <- None;
+            t.heartbeat_gen <- t.heartbeat_gen + 1)
+          (fun () -> Websocket.close ws)
+      in
+      let recv_result =
+        try recv_loop (); Ok ()
+        with exn -> Error exn
+      in
+      let cleanup_result =
+        try cleanup_connection (); Ok ()
+        with exn -> Error exn
+      in
+      (match recv_result with
+       | Error exn -> raise exn
+       | Ok () ->
+         (match cleanup_result with
+          | Error exn -> raise_if_cancelled exn
+          | Ok () -> ());
+         if t.shutdown then
+           Logs.info (fun m -> m "gateway: shutdown requested, not reconnecting")
+         else begin
+           if can_resume t then
+             t.resuming <- true;
+           Logs.info (fun m -> m "gateway: reconnecting in %.0fs..." !backoff);
+           Eio.Time.sleep clock !backoff;
+           backoff := min (!backoff *. 1.5) 60.0;
+           connect_loop ()
+         end))
   in
   connect_loop ()

--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -105,6 +105,11 @@ let read_exactly reader n =
 (** Maximum payload size we'll accept (100MB). Prevents OOM from malicious frames. *)
 let max_payload_size = 100 * 1024 * 1024
 
+(** Keep Eio's buffered-reader cap aligned with the explicit frame cap.
+    [Eio.Buf_read.take] raises [Buffer_limit_exceeded] before our own
+    payload-length checks if this is smaller than [max_payload_size]. *)
+let reader_max_size = max_payload_size
+
 let recv_frame t =
   if t.closed then failwith "websocket: connection closed";
   let acc_buf = Buffer.create 4096 in
@@ -172,6 +177,10 @@ let send_close t =
     t.closed <- true
   end
 
+let close t =
+  t.closed <- true;
+  try Eio.Flow.shutdown t.flow `All with _ -> ()
+
 (** Perform the WebSocket upgrade handshake over an existing TLS connection. *)
 let handshake t ~host ~path =
   let key = generate_ws_key () in
@@ -229,7 +238,7 @@ let connect ~sw ~net ~host ~port ~path =
   match
     let tls_flow = Tls_eio.client_of_flow tls_config ?host:host_dn tcp_flow in
     let flow = (tls_flow :> Eio.Flow.two_way_ty Eio.Resource.t) in
-    let reader = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) flow in
+    let reader = Eio.Buf_read.of_flow ~max_size:reader_max_size flow in
     let t = { flow; reader; closed = false } in
     handshake t ~host ~path;
     t

--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -49,6 +49,23 @@ let int_of_opcode = function
   | Pong -> 10
   | Unknown n -> n
 
+let raise_if_cancelled exn =
+  match exn with
+  | Eio.Cancel.Cancelled _
+  | Out_of_memory
+  | Stack_overflow
+  | Sys.Break -> raise exn
+  | _ -> ()
+
+let record_cancelled slot exn =
+  match exn with
+  | Eio.Cancel.Cancelled _
+  | Out_of_memory
+  | Stack_overflow
+  | Sys.Break ->
+    if !slot = None then slot := Some exn
+  | _ -> ()
+
 (** Generate 4 random bytes for WebSocket client masking.
     Uses mirage-crypto-rng (already initialized by discord_rest). *)
 let generate_mask_key () =
@@ -114,6 +131,20 @@ let max_payload_size = 16 * 1024 * 1024
     payload-length checks if this is smaller than [max_payload_size]. *)
 let reader_max_size = max_payload_size
 
+let read_64bit_payload_len reader =
+  let len = ref 0 in
+  for _ = 0 to 7 do
+    let byte = Char.code (Eio.Buf_read.any_char reader) in
+    if !len > max_payload_size lsr 8
+       || (!len = max_payload_size lsr 8
+           && byte > (max_payload_size land 0xff))
+    then
+      failwith (Printf.sprintf "websocket: payload too large: >%d bytes"
+        max_payload_size);
+    len := (!len lsl 8) lor byte
+  done;
+  !len
+
 let recv_frame t =
   if t.closed then failwith "websocket: connection closed";
   let acc_buf = Buffer.create 4096 in
@@ -131,13 +162,7 @@ let recv_frame t =
         let lo = Char.code (Eio.Buf_read.any_char t.reader) in
         (hi lsl 8) lor lo
       end else begin
-        let len = ref 0 in
-        for _ = 0 to 7 do
-          len := (!len lsl 8) lor Char.code (Eio.Buf_read.any_char t.reader)
-        done;
-        if !len > max_payload_size then
-          failwith (Printf.sprintf "websocket: payload too large: %d bytes" !len);
-        !len
+        read_64bit_payload_len t.reader
       end
     in
     if payload_len > max_payload_size then
@@ -158,7 +183,8 @@ let recv_frame t =
       read_fragments ~first_opcode
     | Close ->
       (* Send close reply BEFORE setting closed flag *)
-      (try send_frame t ~opcode:Close "" with _ -> ());
+      (try send_frame t ~opcode:Close "" with exn ->
+         raise_if_cancelled exn);
       t.closed <- true;
       { opcode = Close; payload }
     | _ ->
@@ -174,24 +200,28 @@ let recv_frame t =
 
 let send_text t text = send_frame t ~opcode:Text text
 
-let send_close t =
-  if not t.closed then begin
-    (* Send close frame BEFORE setting flag, otherwise send_frame rejects it *)
-    (try send_frame t ~opcode:Close "" with _ -> ());
-    t.closed <- true
-  end
-
-let raise_if_cancelled exn =
-  match exn with
-  | Eio.Cancel.Cancelled _ -> raise exn
-  | _ -> ()
-
 let close t =
+  let cancelled = ref None in
   t.closed <- true;
   (try Eio.Flow.shutdown t.flow `All with exn ->
-     raise_if_cancelled exn);
-  try Eio.Flow.close t.flow with exn ->
-    raise_if_cancelled exn
+     record_cancelled cancelled exn);
+  (try Eio.Flow.close t.flow with exn ->
+     record_cancelled cancelled exn);
+  match !cancelled with
+  | Some exn -> raise exn
+  | None -> ()
+
+let send_close t =
+  let cancelled = ref None in
+  if not t.closed then
+    (* Send close frame BEFORE setting flag, otherwise send_frame rejects it. *)
+    (try send_frame t ~opcode:Close "" with exn ->
+       record_cancelled cancelled exn);
+  (try close t with exn ->
+     record_cancelled cancelled exn);
+  match !cancelled with
+  | Some exn -> raise exn
+  | None -> ()
 
 (** Perform the WebSocket upgrade handshake over an existing TLS connection. *)
 let handshake t ~host ~path =

--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -23,8 +23,10 @@ type frame = {
   payload : string;
 }
 
+type closable_flow = [ Eio.Flow.two_way_ty | Eio.Resource.close_ty ]
+
 type t = {
-  flow : Eio.Flow.two_way_ty Eio.Resource.t;
+  flow : closable_flow Eio.Resource.t;
   reader : Eio.Buf_read.t;
   mutable closed : bool;
 }
@@ -179,7 +181,8 @@ let send_close t =
 
 let close t =
   t.closed <- true;
-  try Eio.Flow.shutdown t.flow `All with _ -> ()
+  (try Eio.Flow.shutdown t.flow `All with _ -> ());
+  try Eio.Flow.close t.flow with _ -> ()
 
 (** Perform the WebSocket upgrade handshake over an existing TLS connection. *)
 let handshake t ~host ~path =
@@ -237,7 +240,7 @@ let connect ~sw ~net ~host ~port ~path =
   (* If TLS or handshake fails, close the TCP flow to avoid leaking it *)
   match
     let tls_flow = Tls_eio.client_of_flow tls_config ?host:host_dn tcp_flow in
-    let flow = (tls_flow :> Eio.Flow.two_way_ty Eio.Resource.t) in
+    let flow = (tls_flow :> closable_flow Eio.Resource.t) in
     let reader = Eio.Buf_read.of_flow ~max_size:reader_max_size flow in
     let t = { flow; reader; closed = false } in
     handshake t ~host ~path;

--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -104,8 +104,10 @@ let read_exactly reader n =
 (** Read a WebSocket frame from the connection.
     Handles fragmented incoming messages by accumulating continuation frames.
     Server frames are NOT masked per the spec. *)
-(** Maximum payload size we'll accept (100MB). Prevents OOM from malicious frames. *)
-let max_payload_size = 100 * 1024 * 1024
+(** Discord gateway payloads are typically far smaller than this. Keep the
+    cap comfortably above observed sizes, but low enough that a malicious
+    peer can't force an outsized buffer allocation before we reject. *)
+let max_payload_size = 16 * 1024 * 1024
 
 (** Keep Eio's buffered-reader cap aligned with the explicit frame cap.
     [Eio.Buf_read.take] raises [Buffer_limit_exceeded] before our own
@@ -179,10 +181,17 @@ let send_close t =
     t.closed <- true
   end
 
+let raise_if_cancelled exn =
+  match exn with
+  | Eio.Cancel.Cancelled _ -> raise exn
+  | _ -> ()
+
 let close t =
   t.closed <- true;
-  (try Eio.Flow.shutdown t.flow `All with _ -> ());
-  try Eio.Flow.close t.flow with _ -> ()
+  (try Eio.Flow.shutdown t.flow `All with exn ->
+     raise_if_cancelled exn);
+  try Eio.Flow.close t.flow with exn ->
+    raise_if_cancelled exn
 
 (** Perform the WebSocket upgrade handshake over an existing TLS connection. *)
 let handshake t ~host ~path =

--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -162,9 +162,9 @@ let recv_frame t =
       t.closed <- true;
       { opcode = Close; payload }
     | _ ->
-      Buffer.add_string acc_buf payload;
-      if Buffer.length acc_buf > max_payload_size then
+      if Buffer.length acc_buf + String.length payload > max_payload_size then
         failwith "websocket: accumulated fragments too large";
+      Buffer.add_string acc_buf payload;
       if fin then
         { opcode = effective_opcode; payload = Buffer.contents acc_buf }
       else

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,4 @@
 (tests
  (names test_formatting test_project test_agent_contracts test_discord_rest test_gateway)
- (libraries discord_agents alcotest str unix yojson eio_main cohttp-eio uri
-  mirage-crypto-rng.unix))
+ (libraries discord_agents alcotest str unix yojson eio.mock eio_main cohttp-eio
+  uri mirage-crypto-rng.unix))

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,4 @@
 (tests
- (names test_formatting test_project test_agent_contracts test_discord_rest)
+ (names test_formatting test_project test_agent_contracts test_discord_rest test_gateway)
  (libraries discord_agents alcotest str unix yojson eio_main cohttp-eio uri
   mirage-crypto-rng.unix))

--- a/test/test_gateway.ml
+++ b/test/test_gateway.ml
@@ -1,0 +1,33 @@
+let test_payload_diagnostics_valid () =
+  let payload = {|{"op":0,"t":"MESSAGE_CREATE","s":123,"d":{}}|} in
+  let expected =
+    Printf.sprintf "bytes=%d op=Dispatch event=MESSAGE_CREATE seq=123"
+      (String.length payload)
+  in
+  Alcotest.(check string) "valid payload summary"
+    expected (Discord_agents.Discord_gateway.payload_diagnostics payload)
+
+let test_payload_diagnostics_invalid_json () =
+  let payload = "{not json" in
+  let expected =
+    Printf.sprintf "bytes=%d invalid_json" (String.length payload)
+  in
+  Alcotest.(check string) "invalid payload summary"
+    expected (Discord_agents.Discord_gateway.payload_diagnostics payload)
+
+let test_websocket_reader_limit_tracks_payload_limit () =
+  Alcotest.(check int) "reader limit matches payload cap"
+    Discord_agents.Websocket.max_payload_size
+    Discord_agents.Websocket.reader_max_size
+
+let () =
+  Alcotest.run "gateway" [
+    ("gateway", [
+      Alcotest.test_case "payload diagnostics valid" `Quick
+        test_payload_diagnostics_valid;
+      Alcotest.test_case "payload diagnostics invalid json" `Quick
+        test_payload_diagnostics_invalid_json;
+      Alcotest.test_case "reader limit tracks payload cap" `Quick
+        test_websocket_reader_limit_tracks_payload_limit;
+    ]);
+  ]

--- a/test/test_gateway.ml
+++ b/test/test_gateway.ml
@@ -24,16 +24,6 @@ let test_payload_diagnostics_wrong_types () =
   Alcotest.(check string) "wrong-typed payload summary"
     expected (Discord_agents.Discord_gateway.payload_diagnostics payload)
 
-let test_websocket_closed_error_classification () =
-  Alcotest.(check bool) "closed websocket failure"
-    true
-    (Discord_agents.Discord_gateway.websocket_closed_error
-      (Failure "websocket: connection closed"));
-  Alcotest.(check bool) "other failure"
-    false
-    (Discord_agents.Discord_gateway.websocket_closed_error
-      (Failure "connection reset by peer"))
-
 let test_websocket_reader_limit_tracks_payload_limit () =
   Alcotest.(check int) "reader limit matches payload cap"
     Discord_agents.Websocket.max_payload_size
@@ -128,8 +118,6 @@ let () =
         test_payload_diagnostics_invalid_json;
       Alcotest.test_case "payload diagnostics wrong types" `Quick
         test_payload_diagnostics_wrong_types;
-      Alcotest.test_case "websocket closed error classification" `Quick
-        test_websocket_closed_error_classification;
       Alcotest.test_case "reader limit tracks payload cap" `Quick
         test_websocket_reader_limit_tracks_payload_limit;
       Alcotest.test_case "websocket rejects oversized frame header" `Quick

--- a/test/test_gateway.ml
+++ b/test/test_gateway.ml
@@ -24,6 +24,16 @@ let test_payload_diagnostics_wrong_types () =
   Alcotest.(check string) "wrong-typed payload summary"
     expected (Discord_agents.Discord_gateway.payload_diagnostics payload)
 
+let test_websocket_closed_error_classification () =
+  Alcotest.(check bool) "closed websocket failure"
+    true
+    (Discord_agents.Discord_gateway.websocket_closed_error
+      (Failure "websocket: connection closed"));
+  Alcotest.(check bool) "other failure"
+    false
+    (Discord_agents.Discord_gateway.websocket_closed_error
+      (Failure "connection reset by peer"))
+
 let test_websocket_reader_limit_tracks_payload_limit () =
   Alcotest.(check int) "reader limit matches payload cap"
     Discord_agents.Websocket.max_payload_size
@@ -45,6 +55,14 @@ let websocket_frame_header ~fin ~opcode payload_len =
       Buffer.add_char buf (Char.chr ((payload_len lsr (i * 8)) land 0xff))
     done
   end;
+  Buffer.contents buf
+
+let websocket_frame_header_64 ~fin ~opcode bytes =
+  let b0 = (if fin then 0x80 else 0x00) lor opcode in
+  let buf = Buffer.create 10 in
+  Buffer.add_char buf (Char.chr b0);
+  Buffer.add_char buf (Char.chr 127);
+  List.iter (fun byte -> Buffer.add_char buf (Char.chr byte)) bytes;
   Buffer.contents buf
 
 let websocket_frame ~fin ~opcode payload =
@@ -78,6 +96,16 @@ let test_websocket_rejects_oversized_frame_header () =
   check_failure_contains "oversized frame" "websocket: payload too large"
     (fun () -> ignore (Discord_agents.Websocket.recv_frame ws))
 
+let test_websocket_rejects_oversized_64bit_frame_header () =
+  let ws =
+    websocket_of_input
+      (websocket_frame_header_64 ~fin:true ~opcode:1
+        [0x80; 0x00; 0x00; 0x00; 0x00; 0x00; 0x00; 0x00])
+  in
+  check_failure_contains "oversized 64-bit frame"
+    "websocket: payload too large"
+    (fun () -> ignore (Discord_agents.Websocket.recv_frame ws))
+
 let test_websocket_rejects_fragment_accumulation_overflow () =
   let first_payload =
     String.make Discord_agents.Websocket.max_payload_size 'a'
@@ -100,10 +128,14 @@ let () =
         test_payload_diagnostics_invalid_json;
       Alcotest.test_case "payload diagnostics wrong types" `Quick
         test_payload_diagnostics_wrong_types;
+      Alcotest.test_case "websocket closed error classification" `Quick
+        test_websocket_closed_error_classification;
       Alcotest.test_case "reader limit tracks payload cap" `Quick
         test_websocket_reader_limit_tracks_payload_limit;
       Alcotest.test_case "websocket rejects oversized frame header" `Quick
         test_websocket_rejects_oversized_frame_header;
+      Alcotest.test_case "websocket rejects oversized 64-bit frame header" `Quick
+        test_websocket_rejects_oversized_64bit_frame_header;
       Alcotest.test_case "websocket rejects fragment accumulation overflow" `Quick
         test_websocket_rejects_fragment_accumulation_overflow;
     ]);

--- a/test/test_gateway.ml
+++ b/test/test_gateway.ml
@@ -29,6 +29,68 @@ let test_websocket_reader_limit_tracks_payload_limit () =
     Discord_agents.Websocket.max_payload_size
     Discord_agents.Websocket.reader_max_size
 
+let websocket_frame_header ~fin ~opcode payload_len =
+  let b0 = (if fin then 0x80 else 0x00) lor opcode in
+  let buf = Buffer.create 10 in
+  Buffer.add_char buf (Char.chr b0);
+  if payload_len < 126 then
+    Buffer.add_char buf (Char.chr payload_len)
+  else if payload_len < 65536 then begin
+    Buffer.add_char buf (Char.chr 126);
+    Buffer.add_char buf (Char.chr (payload_len lsr 8));
+    Buffer.add_char buf (Char.chr (payload_len land 0xff))
+  end else begin
+    Buffer.add_char buf (Char.chr 127);
+    for i = 7 downto 0 do
+      Buffer.add_char buf (Char.chr ((payload_len lsr (i * 8)) land 0xff))
+    done
+  end;
+  Buffer.contents buf
+
+let websocket_frame ~fin ~opcode payload =
+  websocket_frame_header ~fin ~opcode (String.length payload) ^ payload
+
+let websocket_of_input input =
+  let flow = Eio_mock.Flow.make "websocket-test" in
+  {
+    Discord_agents.Websocket.flow =
+      (flow :> Discord_agents.Websocket.closable_flow Eio.Resource.t);
+    reader = Eio.Buf_read.of_string input;
+    closed = false;
+  }
+
+let check_failure_contains name needle f =
+  match f () with
+  | exception Failure msg ->
+    Alcotest.(check bool) name true
+      (String.starts_with ~prefix:needle msg)
+  | exception exn ->
+    Alcotest.failf "%s: unexpected exception %s" name (Printexc.to_string exn)
+  | _ ->
+    Alcotest.failf "%s: expected Failure" name
+
+let test_websocket_rejects_oversized_frame_header () =
+  let oversized_len = Discord_agents.Websocket.max_payload_size + 1 in
+  let ws =
+    websocket_of_input
+      (websocket_frame_header ~fin:true ~opcode:1 oversized_len)
+  in
+  check_failure_contains "oversized frame" "websocket: payload too large"
+    (fun () -> ignore (Discord_agents.Websocket.recv_frame ws))
+
+let test_websocket_rejects_fragment_accumulation_overflow () =
+  let first_payload =
+    String.make Discord_agents.Websocket.max_payload_size 'a'
+  in
+  let input =
+    websocket_frame ~fin:false ~opcode:1 first_payload
+    ^ websocket_frame ~fin:true ~opcode:0 "b"
+  in
+  let ws = websocket_of_input input in
+  check_failure_contains "fragment overflow"
+    "websocket: accumulated fragments too large"
+    (fun () -> ignore (Discord_agents.Websocket.recv_frame ws))
+
 let () =
   Alcotest.run "gateway" [
     ("gateway", [
@@ -40,5 +102,9 @@ let () =
         test_payload_diagnostics_wrong_types;
       Alcotest.test_case "reader limit tracks payload cap" `Quick
         test_websocket_reader_limit_tracks_payload_limit;
+      Alcotest.test_case "websocket rejects oversized frame header" `Quick
+        test_websocket_rejects_oversized_frame_header;
+      Alcotest.test_case "websocket rejects fragment accumulation overflow" `Quick
+        test_websocket_rejects_fragment_accumulation_overflow;
     ]);
   ]

--- a/test/test_gateway.ml
+++ b/test/test_gateway.ml
@@ -15,6 +15,15 @@ let test_payload_diagnostics_invalid_json () =
   Alcotest.(check string) "invalid payload summary"
     expected (Discord_agents.Discord_gateway.payload_diagnostics payload)
 
+let test_payload_diagnostics_wrong_types () =
+  let payload = {|{"op":"x","t":42,"s":"oops"}|} in
+  let expected =
+    Printf.sprintf "bytes=%d op=? event=? seq=?"
+      (String.length payload)
+  in
+  Alcotest.(check string) "wrong-typed payload summary"
+    expected (Discord_agents.Discord_gateway.payload_diagnostics payload)
+
 let test_websocket_reader_limit_tracks_payload_limit () =
   Alcotest.(check int) "reader limit matches payload cap"
     Discord_agents.Websocket.max_payload_size
@@ -27,6 +36,8 @@ let () =
         test_payload_diagnostics_valid;
       Alcotest.test_case "payload diagnostics invalid json" `Quick
         test_payload_diagnostics_invalid_json;
+      Alcotest.test_case "payload diagnostics wrong types" `Quick
+        test_payload_diagnostics_wrong_types;
       Alcotest.test_case "reader limit tracks payload cap" `Quick
         test_websocket_reader_limit_tracks_payload_limit;
     ]);


### PR DESCRIPTION
## Summary
- enable backtraces and add websocket/gateway payload diagnostics
- align websocket reader limits with the configured max payload size
- re-raise Eio cancellation instead of swallowing it in gateway/control loops
- expose gateway state and last error details via the control health endpoint

## Validation
- nix develop --command dune build
- nix develop --command dune runtest

## Follow-up
- #37 Isolate control API supervision from gateway cancellations
- #38 Run discord-agents under a supervised user service
- #39 Make bot restart crash-only and replayable
- #40 Harden disk-pressure handling and fault-injection coverage