### PR TITLE
Add persisted default-agent switching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,14 +70,16 @@ test/test_formatting.ml  — Tests for formatting, wrapping, escaping, command p
 
 Commands require a `!` prefix:
 
-- `start <project> [agent]` — start a session (agent ∈ {claude, codex, gemini}; defaults to claude)
+- `start <project> [agent]` — start a session (agent ∈ {claude, codex, gemini}; defaults to the current default agent)
 - `start` — show numbered project list
-- `resume [agent] <session_id>` — resume an existing session (agent defaults to none; tries Claude → Codex → Gemini)
+- `resume [agent] <session_id>` — resume an existing session (agent defaults to none; tries the current default agent first, then the others)
 - `projects` — list discovered projects with numbers
 - `sessions` — list active bot sessions
 - `claude-sessions` — list recent Claude Code sessions on this machine
 - `codex-sessions` — list recent Codex CLI sessions on this machine
 - `gemini-sessions` — list recent Gemini CLI sessions on this machine
+- `default-agent [agent]` — show or set the default agent for new top-level sessions
+- `session-agent [agent]` — show or set the current channel session agent
 - `stop <thread_id>` — stop a session
 - `rename [thread_id] <name>` — rename a thread
 - `desktop` — set wrapping to desktop width (120 chars)
@@ -89,7 +91,7 @@ Commands require a `!` prefix:
 - `restart` — rebuild and restart the bot
 - `help` — command reference
 
-Non-command messages in control/project channels are routed to a Claude session automatically.
+Non-command messages in control/project channels are routed to the channel's current session automatically. New top-level sessions start with the current default agent unless overridden with `session-agent`.
 
 ## Key behaviors
 
@@ -162,7 +164,7 @@ Per-session system prompts (set via `Session_store.session.system_prompt`) tell 
 - **Claude** — `--append-system-prompt <text>` flag (persistent across all turns).
 - **Codex / Gemini** — neither CLI exposes a system-instruction flag, so the bot prepends the prompt as a `<bot-context>...</bot-context>` block to the user's first-turn message. The conversation history carries it forward on subsequent turns. See `Agent_process.compose_session_prompt`.
 
-Today only the control/project channel sessions (created by `ensure_channel_session`) set a system prompt, and those are hardcoded to Claude. The Codex/Gemini paths are wired and tested so a future feature could back a control/project channel with a different agent without further plumbing.
+Today only the control/project channel sessions (created by `ensure_channel_session`) set a system prompt. Those sessions now start with the current default agent rather than being hardcoded to Claude, and the Codex/Gemini paths are wired and tested for that flow.
 
 ## Bare repo / worktree setup
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Commands require a `!` prefix:
 - `restart` — rebuild and restart the bot
 - `help` — command reference
 
-Non-command messages in control/project channels are routed to the channel's current session automatically. New top-level sessions start with the current default agent unless overridden with `session-agent`.
+Non-command messages in control/project channels are routed to the channel's current session automatically. New top-level sessions start with the current default agent unless you set a `session-agent` override on that session.
 
 ## Key behaviors
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ All commands use a `!` prefix:
 
 | Command | Description |
 |---------|-------------|
-| `!start <project>` | Start a session (fuzzy-matches project name) |
+| `!start <project>` | Start a session with the current default agent |
+| `!default-agent [agent]` | Show or set the default agent (`claude`, `codex`, `gemini`) |
 | `!start` | Show numbered project list |
-| `!resume <session_id>` | Resume an existing Claude Code session |
+| `!resume [agent] <session_id>` | Resume an existing session |
 | `!projects` | List discovered projects |
 | `!sessions` | List active bot sessions |
 | `!claude-sessions` | List recent Claude Code sessions on this machine |
@@ -63,7 +64,7 @@ All commands use a `!` prefix:
 | `!restart` | Rebuild and restart the bot |
 | `!help` | Command reference |
 
-All channels -- control and project -- have the same capabilities. The agent knows which channel it's in and has context about the associated project. Non-command messages are routed to the channel's Claude session automatically.
+All channels -- control and project -- have the same capabilities. The agent knows which channel it's in and has context about the associated project. Non-command messages are routed to the channel's current default-agent session automatically.
 
 File attachments (screenshots, code, logs, PDFs, etc.) are downloaded and passed to the agent, which can read them directly.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 discord-agents is a Discord server interface for coding agents. Every channel is a project, and every agent session is a thread. Channels are connected to their own management agent sessions that can spawn new threads conversationally. You can drop in your existing projects or resume the sessions that are already on your machine. New sessions automatically get their own worktrees.
 
-There is a `!command` interface to server management, but control channels also have access to an MCP that can perform all commands. See the commands section for a full list or ask your agent.
+There is a `!command` interface to server management, and control channels also have access to an MCP for session and project operations, including changing the default agent. Per-channel session overrides remain command-driven via `!session-agent`.
 
 discord-agents is intended to be a simple interface to agentic coding on your personal machines and is not intended to be used in shared Discord servers. There is no authentication, and it has the full capabilities of a coding agent launched as the user you started it as. There is no sandboxing in discord-agents itself; use Unix and Claude sandboxing if you require it.
 
@@ -66,6 +66,10 @@ All commands use a `!` prefix:
 | `!help` | Command reference |
 
 All channels -- control and project -- have the same capabilities. The agent knows which channel it's in and has context about the associated project. Non-command messages are routed to the channel's current session automatically; new top-level channel sessions start with the current default agent unless you override that channel with `!session-agent`.
+
+`!default_agent` and `!session_agent` are accepted as underscore aliases.
+
+Changing an agent starts a fresh backend session for that channel. It does not migrate conversation state between Claude, Codex, and Gemini.
 
 File attachments (screenshots, code, logs, PDFs, etc.) are downloaded and passed to the agent, which can read them directly.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ All commands use a `!` prefix:
 |---------|-------------|
 | `!start <project>` | Start a session with the current default agent |
 | `!default-agent [agent]` | Show or set the default agent (`claude`, `codex`, `gemini`) |
+| `!session-agent [agent]` | Show or set the current channel's session agent |
 | `!start` | Show numbered project list |
 | `!resume [agent] <session_id>` | Resume an existing session |
 | `!projects` | List discovered projects |
@@ -64,7 +65,7 @@ All commands use a `!` prefix:
 | `!restart` | Rebuild and restart the bot |
 | `!help` | Command reference |
 
-All channels -- control and project -- have the same capabilities. The agent knows which channel it's in and has context about the associated project. Non-command messages are routed to the channel's current default-agent session automatically.
+All channels -- control and project -- have the same capabilities. The agent knows which channel it's in and has context about the associated project. Non-command messages are routed to the channel's current session automatically; new top-level channel sessions start with the current default agent unless you override that channel with `!session-agent`.
 
 File attachments (screenshots, code, logs, PDFs, etc.) are downloaded and passed to the agent, which can read them directly.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ All commands use a `!` prefix:
 
 | Command | Description |
 |---------|-------------|
-| `!start <project>` | Start a session with the current default agent |
+| `!start <project> [agent]` | Start a session with the current default agent or explicit agent |
 | `!default-agent [agent]` | Show or set the default agent (`claude`, `codex`, `gemini`) |
 | `!session-agent [agent]` | Show or set the current channel's session agent |
 | `!start` | Show numbered project list |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 discord-agents is a Discord server interface for coding agents. Every channel is a project, and every agent session is a thread. Channels are connected to their own management agent sessions that can spawn new threads conversationally. You can drop in your existing projects or resume the sessions that are already on your machine. New sessions automatically get their own worktrees.
 
-There is a `!command` interface to server management, and control channels also have access to an MCP for session and project operations, including changing the default agent. Per-channel session overrides remain command-driven via `!session-agent`.
+There is a `!command` interface to server management, and control channels also have access to an MCP for session and project operations, including changing the default agent. Session-level overrides inside a channel remain command-driven via `!session-agent`.
 
 discord-agents is intended to be a simple interface to agentic coding on your personal machines and is not intended to be used in shared Discord servers. There is no authentication, and it has the full capabilities of a coding agent launched as the user you started it as. There is no sandboxing in discord-agents itself; use Unix and Claude sandboxing if you require it.
 
@@ -65,7 +65,7 @@ All commands use a `!` prefix:
 | `!restart` | Rebuild and restart the bot |
 | `!help` | Command reference |
 
-All channels -- control and project -- have the same capabilities. The agent knows which channel it's in and has context about the associated project. Non-command messages are routed to the channel's current session automatically; new top-level channel sessions start with the current default agent unless you override that channel with `!session-agent`.
+All channels -- control and project -- have the same capabilities. The agent knows which channel it's in and has context about the associated project. Non-command messages are routed to the channel's current session automatically; new top-level channel sessions start with the current default agent unless you set a `!session-agent` override on that session.
 
 `!default_agent` and `!session_agent` are accepted as underscore aliases.
 

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1215,7 +1215,7 @@ let contains_substring text needle =
 (** Claude: write the MCP config to a well-known location and return
     the path for [--mcp-config]. *)
 let claude_mcp_config_path () =
-  let config_dir = Filename.concat (Sys.getenv "HOME") ".config/discord-agents" in
+  let config_dir = Resource.app_config_dir () in
   let config_path = Filename.concat config_dir "mcp-generated.json" in
   write_file_safely ~path:config_path (Lazy.force mcp_json);
   config_path

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -397,6 +397,20 @@ let maybe_apply_pending_session_agent_change t (session : Session_store.session)
          Logs.warn (fun m ->
            m "bot: failed to clear pending agent change for %s: %s"
              session.thread_id err))
+    else if Config.equal_agent_kind session.agent_kind pending.kind
+            && pending.origin = Session_store.Session_override
+    then
+      (match Session_store.set_override_and_pending_agent_change t.sessions session
+               ~session_override_kind:(Some pending.kind)
+               ~pending_agent_change:None with
+       | Ok () ->
+         Logs.info (fun m ->
+           m "bot: pinned channel %s to existing %s session after pending agent change"
+             session.thread_id (Config.string_of_agent_kind pending.kind))
+       | Error err ->
+         Logs.warn (fun m ->
+           m "bot: failed to pin existing session for %s: %s"
+             session.thread_id err))
     else if not session.processing
             && Queue.is_empty session.pending_queue then begin
       let session_override_kind =
@@ -982,9 +996,18 @@ let handle_command t msg cmd =
     let kind_str = Config.string_of_agent_kind kind in
     (match Session_store.find_opt t.sessions ~thread_id:channel_id with
      | Some session when Config.equal_agent_kind session.agent_kind kind
-                         && Option.is_none session.pending_agent_change
-                         && session.session_override_kind = Some kind ->
-       reply (Printf.sprintf "Session agent is already `%s`." kind_str)
+                         && Option.is_none session.pending_agent_change ->
+       (match session.session_override_kind with
+        | Some override_kind when Config.equal_agent_kind override_kind kind ->
+          reply (Printf.sprintf "Session agent is already `%s`." kind_str)
+        | _ ->
+          (match Session_store.set_session_override_kind t.sessions session
+                   (Some kind) with
+           | Ok () ->
+             reply (Printf.sprintf "Session agent pinned to `%s`." kind_str)
+           | Error err ->
+             reply (Printf.sprintf "Failed to persist session agent pin: %s"
+               err)))
      | Some session when session.processing || not (Queue.is_empty session.pending_queue) ->
        (match Session_store.set_pending_agent_change t.sessions session
                 (Some (pending_session_override kind)) with

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -868,9 +868,13 @@ let handle_command t msg cmd =
     (match Session_store.find_opt t.sessions ~thread_id with
      | None -> reply "Session not found."
      | Some session ->
-       Session_store.remove t.sessions ~thread_id;
-       Hashtbl.remove t.scroll_states thread_id;
-       reply (Printf.sprintf "Stopped session for **%s**." session.project_name))
+       if session.processing || not (Queue.is_empty session.pending_queue) then
+         reply "Session is still running or has queued work. Wait for it to go idle before stopping it."
+       else begin
+         Session_store.remove t.sessions ~thread_id;
+         Hashtbl.remove t.scroll_states thread_id;
+         reply (Printf.sprintf "Stopped session for **%s**." session.project_name)
+       end)
   | Command.Default_agent None ->
     reply (Printf.sprintf "Default agent: `%s`."
       (Config.string_of_agent_kind (default_agent t)))

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -68,6 +68,7 @@ type t = {
   mutable refreshing : bool;
   mutable output_lines : int;
   scroll_states : (Discord_types.channel_id, scroll_state) Hashtbl.t;
+  pending_persistent_resets : (Discord_types.channel_id, unit) Hashtbl.t;
 }
 
 (** Convenience accessors for the current project state snapshot. *)
@@ -85,6 +86,55 @@ let is_project_channel t ~(channel_id : Discord_types.channel_id) =
 
 let is_persistent_channel t ~(channel_id : Discord_types.channel_id) =
   is_control_channel t ~channel_id || is_project_channel t ~channel_id
+
+type persistent_rotation = {
+  reset_count : int;
+  busy_count : int;
+  current_busy_kind : Config.agent_kind option;
+}
+
+let rotate_persistent_idle_sessions t ~current_channel_id ~new_agent =
+  let stale_sessions =
+    Session_store.bindings t.sessions
+    |> List.filter (fun (thread_id, (session : Session_store.session)) ->
+      is_persistent_channel t ~channel_id:thread_id
+      && not (Config.equal_agent_kind session.agent_kind new_agent))
+  in
+  let current_busy_kind = ref None in
+  let reset_count = ref 0 in
+  let busy_count = ref 0 in
+  List.iter (fun (thread_id, (session : Session_store.session)) ->
+    if session.processing || not (Queue.is_empty session.pending_queue) then begin
+      incr busy_count;
+      Hashtbl.replace t.pending_persistent_resets thread_id ();
+      if thread_id = current_channel_id then
+        current_busy_kind := Some session.agent_kind
+    end else begin
+      Session_store.remove t.sessions ~thread_id;
+      Hashtbl.remove t.scroll_states thread_id;
+      Hashtbl.remove t.pending_persistent_resets thread_id;
+      incr reset_count
+    end
+  ) stale_sessions;
+  { reset_count = !reset_count;
+    busy_count = !busy_count;
+    current_busy_kind = !current_busy_kind; }
+
+let maybe_reset_persistent_channel_session t session =
+  let channel_id = session.Session_store.thread_id in
+  if Hashtbl.mem t.pending_persistent_resets channel_id then
+    if Config.equal_agent_kind session.agent_kind (default_agent t) then
+      Hashtbl.remove t.pending_persistent_resets channel_id
+    else if is_persistent_channel t ~channel_id
+            && not session.processing
+            && Queue.is_empty session.pending_queue then begin
+      Session_store.remove t.sessions ~thread_id:channel_id;
+      Hashtbl.remove t.scroll_states channel_id;
+      Hashtbl.remove t.pending_persistent_resets channel_id;
+      Logs.info (fun m ->
+        m "bot: reset persistent channel %s after default-agent change"
+          channel_id)
+    end
 
 (** Drop scroll-state entries for threads that no longer have an active
     session.  Called when sessions are removed wholesale (e.g. after
@@ -598,15 +648,7 @@ let handle_command t msg cmd =
          current default first, then the remaining stores. *)
       let found = match kind with
         | Some k -> try_kind k
-        | None ->
-          let rec first_found = function
-            | [] -> None
-            | k :: rest ->
-              match try_kind k with
-              | Some _ as found -> found
-              | None -> first_found rest
-          in
-          first_found (Config.preferred_agent_order (default_agent t))
+        | None -> Config.find_with_preferred_agent (default_agent t) try_kind
       in
       match found with
       | None ->
@@ -670,24 +712,40 @@ let handle_command t msg cmd =
      | Error err ->
        reply (Printf.sprintf "Failed to save default agent: %s" err)
      | Ok () ->
-       if is_persistent_channel t ~channel_id then
-         (match Session_store.find_opt t.sessions ~thread_id:channel_id with
-          | Some session when session.processing ->
-            reply (Printf.sprintf
-              "Default agent set to `%s`. This channel is still running `%s`; send the next message after it finishes."
-              kind_str (Config.string_of_agent_kind session.agent_kind))
-          | Some session when not (Config.equal_agent_kind session.agent_kind kind) ->
-            Session_store.remove t.sessions ~thread_id:channel_id;
-            Hashtbl.remove t.scroll_states channel_id;
-            reply (Printf.sprintf
-              "Default agent set to `%s`. Reset this channel's idle `%s` session; your next message will start `%s`."
-              kind_str
-              (Config.string_of_agent_kind session.agent_kind)
-              kind_str)
-          | _ ->
-            reply (Printf.sprintf "Default agent set to `%s`." kind_str))
-       else
-         reply (Printf.sprintf "Default agent set to `%s`." kind_str))
+       let rotation =
+         rotate_persistent_idle_sessions t
+           ~current_channel_id:channel_id ~new_agent:kind
+       in
+       let reset_suffix =
+         if rotation.reset_count = 0 then ""
+         else
+           Printf.sprintf " Reset %d idle persistent session%s."
+             rotation.reset_count
+             (if rotation.reset_count = 1 then "" else "s")
+       in
+       let busy_suffix =
+         match rotation.current_busy_kind with
+         | Some current_kind ->
+           let other_busy = rotation.busy_count - 1 in
+           let others =
+             if other_busy <= 0 then ""
+             else
+               Printf.sprintf " %d other busy persistent session%s will switch after finishing."
+                 other_busy
+                 (if other_busy = 1 then "" else "s")
+           in
+           Printf.sprintf
+             " This channel is still running `%s`; it will switch after the current run finishes.%s"
+             (Config.string_of_agent_kind current_kind) others
+         | None ->
+           if rotation.busy_count = 0 then ""
+           else
+             Printf.sprintf " %d busy persistent session%s will switch after finishing."
+               rotation.busy_count
+               (if rotation.busy_count = 1 then "" else "s")
+       in
+       reply (Printf.sprintf "Default agent set to `%s`.%s%s"
+         kind_str reset_suffix busy_suffix))
   | Command.Cleanup_channels ->
     Eio.Fiber.fork ~sw:t.sw (fun () ->
       match Channel_manager.cleanup ~rest:t.rest
@@ -1094,7 +1152,8 @@ let handle_thread_message t msg ?channel_info () =
       session.processing <- true;
       Eio.Fiber.fork ~sw:t.sw (fun () ->
         Fun.protect ~finally:(fun () ->
-          session.processing <- false
+          session.processing <- false;
+          maybe_reset_persistent_channel_session t session
         ) (fun () ->
           process_session_message t session msg channel_info))
     end
@@ -1114,7 +1173,8 @@ let handle_thread_message t msg ?channel_info () =
 let fork_initial_prompt_run t ~session ~msg =
   Eio.Fiber.fork ~sw:t.sw (fun () ->
     Fun.protect ~finally:(fun () ->
-      session.Session_store.processing <- false
+      session.Session_store.processing <- false;
+      maybe_reset_persistent_channel_session t session
     ) (fun () ->
       process_session_message t session msg None))
 
@@ -1275,7 +1335,8 @@ let create ~sw ~(env : Eio_unix.Stdenv.base) config =
                wrap_width = Agent_process.desktop_width;
                refreshing = false;
                output_lines = Agent_process.default_output_lines;
-               scroll_states = Hashtbl.create 64 } in
+               scroll_states = Hashtbl.create 64;
+               pending_persistent_resets = Hashtbl.create 16 } in
   bot.gateway.handler <- (fun event ->
     match event with
     | Discord_gateway.Connected user ->

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -2,8 +2,8 @@
 
     Routes Discord messages to the appropriate handler:
     - Commands (! prefix) → Command module → handlers
-    - Control channel chat → Claude session with MCP tools
-    - Project channel chat → Claude session scoped to project
+    - Control channel chat → default-agent session with MCP tools
+    - Project channel chat → default-agent session scoped to project
     - Thread messages → Agent_runner
 
     Owns no mutable state directly — delegates to Session_store
@@ -54,6 +54,7 @@ type scroll_state = {
 
 type t = {
   config : Config.t;
+  settings : Runtime_settings.t;
   rest : Discord_rest.t;
   gateway : Discord_gateway.t;
   mutable project_state : project_state;
@@ -72,6 +73,18 @@ type t = {
 (** Convenience accessors for the current project state snapshot. *)
 let projects t = t.project_state.projects
 let channels t = t.project_state.channels
+let default_agent t = t.settings.default_agent
+
+let is_control_channel t ~(channel_id : Discord_types.channel_id) =
+  match t.config.control_channel_id with
+  | Some ctl_id -> channel_id = ctl_id
+  | None -> false
+
+let is_project_channel t ~(channel_id : Discord_types.channel_id) =
+  Option.is_some (Channel_manager.project_for_channel (channels t) ~channel_id)
+
+let is_persistent_channel t ~(channel_id : Discord_types.channel_id) =
+  is_control_channel t ~channel_id || is_project_channel t ~channel_id
 
 (** Drop scroll-state entries for threads that no longer have an active
     session.  Called when sessions are removed wholesale (e.g. after
@@ -141,7 +154,7 @@ You have MCP tools available:
 - list_claude_sessions: Find recent Claude Code sessions to resume
 - list_codex_sessions: Find recent Codex CLI sessions to resume
 - list_gemini_sessions: Find recent Gemini CLI sessions to resume
-- resume_session: Resume an existing session (pass kind=codex or kind=gemini to disambiguate; default tries Claude → Codex → Gemini)
+- resume_session: Resume an existing session (pass kind=codex or kind=gemini to disambiguate; default tries the current default agent first)
 - restart_bot: Rebuild and restart the bot
 - rename_thread: Rename a Discord thread
 - cleanup_channels: Delete stale Discord channels
@@ -166,7 +179,7 @@ IMPORTANT: When linking to GitHub PRs, issues, or commits, always use full URLs 
 Discord does not render GitHub shorthand as clickable links."
   session_starting_instructions project_list
 
-(** System prompt for project channel Claude — scoped to one project. *)
+(** System prompt for the project overview session — scoped to one project. *)
 let project_system_prompt (project : Project.t) =
   Printf.sprintf
 "You are the project overview agent for **%s** (at `%s`).
@@ -178,7 +191,7 @@ You have MCP tools available:
 - list_claude_sessions: Find recent Claude Code sessions to resume
 - list_codex_sessions: Find recent Codex CLI sessions to resume
 - list_gemini_sessions: Find recent Gemini CLI sessions to resume
-- resume_session: Resume an existing session (pass kind=codex or kind=gemini to disambiguate; default tries Claude → Codex → Gemini)
+- resume_session: Resume an existing session (pass kind=codex or kind=gemini to disambiguate; default tries the current default agent first)
 - rename_thread: Rename a Discord thread
 - restart_bot: Rebuild and restart the bot
 - cleanup_channels: Delete stale Discord channels
@@ -477,6 +490,7 @@ let handle_command t msg cmd =
       reply (format_session_listing ~label:"Claude"
         ~resume_hint:"!resume <session_id_prefix>" entries))
   | Command.Start_agent { project; kind } ->
+    let kind = Option.value kind ~default:(default_agent t) in
     let proj = Command.find_project_fuzzy (projects t) project in
     (match proj with
      | None ->
@@ -558,8 +572,8 @@ let handle_command t msg cmd =
         ~resume_hint:"!resume gemini <session_id_prefix>" entries))
   | Command.Resume_session { session_id; kind } ->
     Eio.Fiber.fork ~sw:t.sw (fun () ->
-      (* Locate the session in the requested store, or try
-         Claude → Codex → Gemini in order if [kind] is unspecified. *)
+      (* Locate the session in the requested store, or try the
+         current default first if [kind] is unspecified. *)
       let try_claude () =
         match Claude_sessions.find_by_prefix session_id with
         | Some (sid, wd) -> Some (Config.Claude, sid, wd)
@@ -575,19 +589,24 @@ let handle_command t msg cmd =
         | Some (sid, wd) -> Some (Config.Gemini, sid, wd)
         | None -> None
       in
-      (* Explicit kind hits exactly one store; an unspecified kind
-         tries Claude → Codex → Gemini in order. *)
+      let try_kind = function
+        | Config.Claude -> try_claude ()
+        | Config.Codex -> try_codex ()
+        | Config.Gemini -> try_gemini ()
+      in
+      (* Explicit kind hits exactly one store; otherwise try the
+         current default first, then the remaining stores. *)
       let found = match kind with
-        | Some Config.Claude -> try_claude ()
-        | Some Config.Codex -> try_codex ()
-        | Some Config.Gemini -> try_gemini ()
+        | Some k -> try_kind k
         | None ->
-          (match try_claude () with
-           | Some _ as r -> r
-           | None ->
-             match try_codex () with
-             | Some _ as r -> r
-             | None -> try_gemini ())
+          let rec first_found = function
+            | [] -> None
+            | k :: rest ->
+              match try_kind k with
+              | Some _ as found -> found
+              | None -> first_found rest
+          in
+          first_found (Config.preferred_agent_order (default_agent t))
       in
       match found with
       | None ->
@@ -642,6 +661,33 @@ let handle_command t msg cmd =
        Session_store.remove t.sessions ~thread_id;
        Hashtbl.remove t.scroll_states thread_id;
        reply (Printf.sprintf "Stopped session for **%s**." session.project_name))
+  | Command.Default_agent None ->
+    reply (Printf.sprintf "Default agent: `%s`."
+      (Config.string_of_agent_kind (default_agent t)))
+  | Command.Default_agent (Some kind) ->
+    let kind_str = Config.string_of_agent_kind kind in
+    (match Runtime_settings.set_default_agent t.settings kind with
+     | Error err ->
+       reply (Printf.sprintf "Failed to save default agent: %s" err)
+     | Ok () ->
+       if is_persistent_channel t ~channel_id then
+         (match Session_store.find_opt t.sessions ~thread_id:channel_id with
+          | Some session when session.processing ->
+            reply (Printf.sprintf
+              "Default agent set to `%s`. This channel is still running `%s`; send the next message after it finishes."
+              kind_str (Config.string_of_agent_kind session.agent_kind))
+          | Some session when not (Config.equal_agent_kind session.agent_kind kind) ->
+            Session_store.remove t.sessions ~thread_id:channel_id;
+            Hashtbl.remove t.scroll_states channel_id;
+            reply (Printf.sprintf
+              "Default agent set to `%s`. Reset this channel's idle `%s` session; your next message will start `%s`."
+              kind_str
+              (Config.string_of_agent_kind session.agent_kind)
+              kind_str)
+          | _ ->
+            reply (Printf.sprintf "Default agent set to `%s`." kind_str))
+       else
+         reply (Printf.sprintf "Default agent set to `%s`." kind_str))
   | Command.Cleanup_channels ->
     Eio.Fiber.fork ~sw:t.sw (fun () ->
       match Channel_manager.cleanup ~rest:t.rest
@@ -766,6 +812,8 @@ let handle_command t msg cmd =
         in
         let lines = [
           Printf.sprintf "**%s** (pid %d, up %s)" (Build_info.version_string ()) pid uptime_str;
+          Printf.sprintf "Default agent: %s"
+            (Config.string_of_agent_kind (default_agent t));
           Printf.sprintf "Sessions: %d (%d processing)"
             (Session_store.count t.sessions)
             (List.length (List.filter (fun (_, (s : Session_store.session)) ->
@@ -791,8 +839,9 @@ let handle_command t msg cmd =
       "`!claude-sessions` — list recent Claude sessions";
       "`!codex-sessions` — list recent Codex sessions";
       "`!gemini-sessions` — list recent Gemini sessions";
-      "`!start <project> [agent]` — start a session (claude|codex|gemini; defaults to claude)";
-      "`!resume [agent] <session_id>` — resume a session (agent defaults to none; tries Claude → Codex → Gemini)";
+      "`!start <project> [agent]` — start a session (defaults to the current default agent)";
+      "`!default-agent [agent]` — show or set the default agent (claude|codex|gemini)";
+      "`!resume [agent] <session_id>` — resume a session (no agent = try the current default first)";
       "`!stop <thread_id>` — stop a session";
       "`!rename [thread_id] <name>` — rename a thread";
       "`!status` — bot status and running processes";
@@ -1070,13 +1119,13 @@ let fork_initial_prompt_run t ~session ~msg =
       process_session_message t session msg None))
 
 (** Ensure a session exists for a channel (control or project channels).
-    Creates a persistent Claude session so the channel can handle chat directly. *)
+    Creates a persistent session using the current default agent. *)
 let ensure_channel_session t ~channel_id ~project_name ~working_dir ~system_prompt =
   match Session_store.find_opt t.sessions ~thread_id:channel_id with
   | Some _ -> ()
   | None ->
     let session = Session_store.make_session
-      ~project_name ~working_dir ~agent_kind:Config.Claude
+      ~project_name ~working_dir ~agent_kind:(default_agent t)
       ~session_id:(Resource.generate_uuid ())
       ~thread_id:channel_id
       ~system_prompt ~initial_prompt:None () in
@@ -1219,7 +1268,8 @@ let create ~sw ~(env : Eio_unix.Stdenv.base) config =
     ~handler:(fun _event -> ())
   in
   let project_state = { projects = discovered_projects; channels = initial_channels } in
-  let bot = { config; rest; gateway; project_state; sessions; env; sw;
+  let bot = { config; settings = Runtime_settings.load ();
+               rest; gateway; project_state; sessions; env; sw;
                started_at = Unix.gettimeofday ();
                draining = false; child_pids = (ref Pid_set.empty, Mutex.create ());
                wrap_width = Agent_process.desktop_width;

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -68,14 +68,16 @@ type t = {
   mutable refreshing : bool;
   mutable output_lines : int;
   scroll_states : (Discord_types.channel_id, scroll_state) Hashtbl.t;
-  pending_session_agent_changes :
-    (Discord_types.channel_id, Config.agent_kind) Hashtbl.t;
 }
 
 (** Convenience accessors for the current project state snapshot. *)
 let projects t = t.project_state.projects
 let channels t = t.project_state.channels
 let default_agent t = t.settings.default_agent
+let pending_default_rotation kind =
+  Session_store.{ kind; origin = Default_rotation }
+let pending_session_override kind =
+  Session_store.{ kind; origin = Session_override }
 
 let is_control_channel t ~(channel_id : Discord_types.channel_id) =
   match t.config.control_channel_id with
@@ -103,52 +105,6 @@ let fresh_session_like (session : Session_store.session) ~agent_kind =
     ~thread_id:session.thread_id
     ~system_prompt:session.system_prompt
     ~initial_prompt:None ()
-
-let replace_session_agent t (session : Session_store.session) ~agent_kind =
-  let replacement = fresh_session_like session ~agent_kind in
-  Session_store.add t.sessions ~thread_id:session.thread_id replacement;
-  Hashtbl.remove t.scroll_states session.thread_id;
-  Hashtbl.remove t.pending_session_agent_changes session.thread_id
-
-let align_persistent_sessions_to_default t ~current_channel_id ~new_agent =
-  let stale_sessions =
-    Session_store.bindings t.sessions
-    |> List.filter (fun (thread_id, (session : Session_store.session)) ->
-      is_persistent_channel t ~channel_id:thread_id
-      && not (Config.equal_agent_kind session.agent_kind new_agent))
-  in
-  let current_busy_kind = ref None in
-  let reset_count = ref 0 in
-  let busy_count = ref 0 in
-  List.iter (fun (thread_id, (session : Session_store.session)) ->
-    if session.processing || not (Queue.is_empty session.pending_queue) then begin
-      incr busy_count;
-      Hashtbl.replace t.pending_session_agent_changes thread_id new_agent;
-      if thread_id = current_channel_id then
-        current_busy_kind := Some session.agent_kind
-    end else begin
-      replace_session_agent t session ~agent_kind:new_agent;
-      incr reset_count
-    end
-  ) stale_sessions;
-  { reset_count = !reset_count;
-    busy_count = !busy_count;
-    current_busy_kind = !current_busy_kind; }
-
-let maybe_apply_pending_session_agent_change t (session : Session_store.session) =
-  let channel_id = session.Session_store.thread_id in
-  match Hashtbl.find_opt t.pending_session_agent_changes channel_id with
-  | None -> ()
-  | Some target_kind ->
-    if Config.equal_agent_kind session.agent_kind target_kind then
-      Hashtbl.remove t.pending_session_agent_changes channel_id
-    else if not session.processing
-            && Queue.is_empty session.pending_queue then begin
-      replace_session_agent t session ~agent_kind:target_kind;
-      Logs.info (fun m ->
-        m "bot: switched channel %s to %s after pending agent change"
-          channel_id (Config.string_of_agent_kind target_kind))
-    end
 
 (** Drop scroll-state entries for threads that no longer have an active
     session.  Called when sessions are removed wholesale (e.g. after
@@ -218,7 +174,8 @@ You have MCP tools available:
 - list_claude_sessions: Find recent Claude Code sessions to resume
 - list_codex_sessions: Find recent Codex CLI sessions to resume
 - list_gemini_sessions: Find recent Gemini CLI sessions to resume
-- resume_session: Resume an existing session (pass kind=codex or kind=gemini to disambiguate; default tries the current default agent first)
+- resume_session: Resume an existing session (pass kind=claude, kind=codex, or kind=gemini to disambiguate; default tries the current default agent first)
+- default_agent: Show or set the default agent used for new top-level sessions
 - restart_bot: Rebuild and restart the bot
 - rename_thread: Rename a Discord thread
 - cleanup_channels: Delete stale Discord channels
@@ -255,7 +212,8 @@ You have MCP tools available:
 - list_claude_sessions: Find recent Claude Code sessions to resume
 - list_codex_sessions: Find recent Codex CLI sessions to resume
 - list_gemini_sessions: Find recent Gemini CLI sessions to resume
-- resume_session: Resume an existing session (pass kind=codex or kind=gemini to disambiguate; default tries the current default agent first)
+- resume_session: Resume an existing session (pass kind=claude, kind=codex, or kind=gemini to disambiguate; default tries the current default agent first)
+- default_agent: Show or set the default agent used for new top-level sessions
 - rename_thread: Rename a Discord thread
 - restart_bot: Rebuild and restart the bot
 - cleanup_channels: Delete stale Discord channels
@@ -282,6 +240,123 @@ Discord does not render GitHub shorthand as clickable links.
 IMPORTANT: When starting sessions, always create a fresh worktree so agents don't \
 stomp on each other's work."
   project.name project.path session_starting_instructions
+
+let refreshed_system_prompt t (session : Session_store.session) =
+  if is_control_channel t ~channel_id:session.thread_id then
+    Some (control_system_prompt (projects t))
+  else
+    match Channel_manager.project_for_channel (channels t)
+            ~channel_id:session.thread_id with
+    | Some project_name ->
+      (match List.find_opt (fun (p : Project.t) -> p.name = project_name)
+               (projects t) with
+       | Some project -> Some (project_system_prompt project)
+       | None -> session.system_prompt)
+    | None -> session.system_prompt
+
+let replace_session_agent t (session : Session_store.session) ~agent_kind =
+  let replacement = {
+    (fresh_session_like session ~agent_kind) with
+    system_prompt = refreshed_system_prompt t session;
+  } in
+  Session_store.add t.sessions ~thread_id:session.thread_id replacement;
+  Hashtbl.remove t.scroll_states session.thread_id
+
+let align_persistent_sessions_to_default t ~current_channel_id ~new_agent =
+  let dirty = ref false in
+  let prior_pending = ref [] in
+  let record_prior session =
+    prior_pending := (session, session.Session_store.pending_agent_change) :: !prior_pending
+  in
+  Session_store.bindings t.sessions
+  |> List.iter (fun (thread_id, (session : Session_store.session)) ->
+    if is_persistent_channel t ~channel_id:thread_id
+       && Config.equal_agent_kind session.agent_kind new_agent
+    then
+      match session.pending_agent_change with
+      | Some { origin = Session_store.Default_rotation; _ } ->
+        record_prior session;
+        session.pending_agent_change <- None;
+        dirty := true
+      | _ -> ());
+  let stale_sessions =
+    Session_store.bindings t.sessions
+    |> List.filter (fun (thread_id, (session : Session_store.session)) ->
+      is_persistent_channel t ~channel_id:thread_id
+      && not (Config.equal_agent_kind session.agent_kind new_agent))
+  in
+  let current_busy_kind = ref None in
+  let reset_count = ref 0 in
+  let busy_count = ref 0 in
+  List.iter (fun (thread_id, (session : Session_store.session)) ->
+    if session.processing || not (Queue.is_empty session.pending_queue) then begin
+      match session.pending_agent_change with
+      | Some { origin = Session_store.Session_override; _ } -> ()
+      | _ ->
+        incr busy_count;
+        let target = pending_default_rotation new_agent in
+        if session.pending_agent_change <> Some target then begin
+          record_prior session;
+          session.pending_agent_change <- Some target;
+          dirty := true
+        end;
+        (match current_channel_id with
+         | Some current_channel_id when thread_id = current_channel_id ->
+           current_busy_kind := Some session.agent_kind
+         | _ -> ())
+    end else begin
+      replace_session_agent t session ~agent_kind:new_agent;
+      incr reset_count
+    end
+  ) stale_sessions;
+  if !dirty then
+    (try Session_store.save t.sessions with exn ->
+       List.iter (fun (session, prior) ->
+         session.Session_store.pending_agent_change <- prior
+       ) !prior_pending;
+       raise exn);
+  { reset_count = !reset_count;
+    busy_count = !busy_count;
+    current_busy_kind = !current_busy_kind; }
+
+let set_default_agent t ?(current_channel_id=None) kind =
+  match Runtime_settings.set_default_agent t.settings kind with
+  | Error _ as err -> err
+  | Ok () ->
+    Ok (align_persistent_sessions_to_default t ~current_channel_id ~new_agent:kind)
+
+let maybe_apply_pending_session_agent_change t (session : Session_store.session) =
+  match session.pending_agent_change with
+  | None -> ()
+  | Some pending ->
+    if Config.equal_agent_kind session.agent_kind pending.kind then
+      (match Session_store.set_pending_agent_change t.sessions session None with
+       | Ok () -> ()
+       | Error err ->
+         Logs.warn (fun m ->
+           m "bot: failed to clear pending agent change for %s: %s"
+             session.thread_id err))
+    else if not session.processing
+            && Queue.is_empty session.pending_queue then begin
+      (try
+         replace_session_agent t session ~agent_kind:pending.kind;
+         Logs.info (fun m ->
+           m "bot: switched channel %s to %s after pending agent change"
+             session.thread_id (Config.string_of_agent_kind pending.kind))
+       with exn ->
+         Logs.warn (fun m ->
+           m "bot: failed to switch channel %s to %s: %s"
+             session.thread_id
+             (Config.string_of_agent_kind pending.kind)
+             (Printexc.to_string exn)))
+    end
+
+let reconcile_persisted_pending_agent_changes t =
+  Session_store.bindings t.sessions
+  |> List.iter (fun (_thread_id, (session : Session_store.session)) ->
+    maybe_apply_pending_session_agent_change t session);
+  ignore (align_persistent_sessions_to_default t
+    ~current_channel_id:None ~new_agent:(default_agent t))
 
 (** Trigger a graceful restart: drain → reap → build → spawn.
     Callable from command handler or signal handler.
@@ -527,8 +602,7 @@ let create_persistent_channel_session t ~channel_id ~project_name ~working_dir
     ~session_id:(Resource.generate_uuid ())
     ~thread_id:channel_id
     ~system_prompt ~initial_prompt:None () in
-  Session_store.add t.sessions ~thread_id:channel_id session;
-  Hashtbl.remove t.pending_session_agent_changes channel_id
+  Session_store.add t.sessions ~thread_id:channel_id session
 
 (** Ensure or create a persistent top-level channel session for an
     explicit agent. Returns [true] if the channel context was known and
@@ -754,7 +828,6 @@ let handle_command t msg cmd =
      | None -> reply "Session not found."
      | Some session ->
        Session_store.remove t.sessions ~thread_id;
-       Hashtbl.remove t.pending_session_agent_changes thread_id;
        Hashtbl.remove t.scroll_states thread_id;
        reply (Printf.sprintf "Stopped session for **%s**." session.project_name))
   | Command.Default_agent None ->
@@ -762,14 +835,10 @@ let handle_command t msg cmd =
       (Config.string_of_agent_kind (default_agent t)))
   | Command.Default_agent (Some kind) ->
     let kind_str = Config.string_of_agent_kind kind in
-    (match Runtime_settings.set_default_agent t.settings kind with
+    (match set_default_agent t ~current_channel_id:(Some channel_id) kind with
      | Error err ->
        reply (Printf.sprintf "Failed to save default agent: %s" err)
-     | Ok () ->
-       let rotation =
-         align_persistent_sessions_to_default t
-           ~current_channel_id:channel_id ~new_agent:kind
-       in
+     | Ok rotation ->
        let reset_suffix =
          if rotation.reset_count = 0 then ""
          else
@@ -784,31 +853,31 @@ let handle_command t msg cmd =
            let others =
              if other_busy <= 0 then ""
              else
-               Printf.sprintf " %d other busy top-level session%s will switch after finishing."
+               Printf.sprintf " %d other busy top-level session%s will switch after their queued work finishes."
                  other_busy
                  (if other_busy = 1 then "" else "s")
            in
            Printf.sprintf
-             " This channel is still running `%s`; it will switch after the current run finishes.%s"
+             " This channel is still running `%s`; it will reset to the new default after its queued work finishes.%s"
              (Config.string_of_agent_kind current_kind) others
          | None ->
            if rotation.busy_count = 0 then ""
            else
-             Printf.sprintf " %d busy top-level session%s will switch after finishing."
+             Printf.sprintf " %d busy top-level session%s will switch after their queued work finishes."
                rotation.busy_count
                (if rotation.busy_count = 1 then "" else "s")
-       in
+      in
        reply (Printf.sprintf "Default agent set to `%s`.%s%s"
          kind_str reset_suffix busy_suffix))
   | Command.Session_agent None ->
     (match Session_store.find_opt t.sessions ~thread_id:channel_id with
      | Some session ->
-       (match Hashtbl.find_opt t.pending_session_agent_changes channel_id with
-        | Some target when not (Config.equal_agent_kind target session.agent_kind) ->
+       (match session.pending_agent_change with
+        | Some pending when not (Config.equal_agent_kind pending.kind session.agent_kind) ->
           reply (Printf.sprintf
-            "Session agent: `%s` (will switch to `%s` after current work finishes)."
+            "Session agent: `%s` (will start a fresh `%s` session after queued work finishes)."
             (Config.string_of_agent_kind session.agent_kind)
-            (Config.string_of_agent_kind target))
+            (Config.string_of_agent_kind pending.kind))
         | _ ->
           reply (Printf.sprintf "Session agent: `%s`."
             (Config.string_of_agent_kind session.agent_kind)))
@@ -822,19 +891,23 @@ let handle_command t msg cmd =
     let kind_str = Config.string_of_agent_kind kind in
     (match Session_store.find_opt t.sessions ~thread_id:channel_id with
      | Some session when Config.equal_agent_kind session.agent_kind kind
-                         && not (Hashtbl.mem t.pending_session_agent_changes channel_id) ->
+                         && Option.is_none session.pending_agent_change ->
        reply (Printf.sprintf "Session agent is already `%s`." kind_str)
      | Some session when session.processing || not (Queue.is_empty session.pending_queue) ->
-       Hashtbl.replace t.pending_session_agent_changes channel_id kind;
-       reply (Printf.sprintf
-         "Session agent will switch to `%s` after the current work finishes."
-         kind_str)
+       (match Session_store.set_pending_agent_change t.sessions session
+                (Some (pending_session_override kind)) with
+        | Ok () ->
+          reply (Printf.sprintf
+            "A fresh `%s` session will start for this channel after queued work finishes."
+            kind_str)
+        | Error err ->
+          reply (Printf.sprintf "Failed to persist session agent change: %s" err))
      | Some session ->
        replace_session_agent t session ~agent_kind:kind;
-       reply (Printf.sprintf "Session agent set to `%s` for this channel."
+       reply (Printf.sprintf "Started a fresh `%s` session for this channel."
          kind_str)
      | None when create_explicit_channel_session t ~channel_id ~agent_kind:kind ->
-       reply (Printf.sprintf "Session agent set to `%s` for this channel."
+       reply (Printf.sprintf "Started a fresh `%s` session for this channel."
          kind_str)
      | None ->
        reply "No session exists in this channel. Use `!start` or `!resume`.")
@@ -990,8 +1063,8 @@ let handle_command t msg cmd =
       "`!codex-sessions` — list recent Codex sessions";
       "`!gemini-sessions` — list recent Gemini sessions";
       "`!start <project> [agent]` — start a session (defaults to the current default agent)";
-      "`!default-agent [agent]` — show or set the default agent (claude|codex|gemini)";
-      "`!session-agent [agent]` — show or set the current channel session agent";
+      "`!default-agent [agent]` / `!default_agent [agent]` — show or set the default agent (claude|codex|gemini)";
+      "`!session-agent [agent]` / `!session_agent [agent]` — show or set the current channel session agent";
       "`!resume [agent] <session_id>` — resume a session (no agent = try the current default first)";
       "`!stop <thread_id>` — stop a session";
       "`!rename [thread_id] <name>` — rename a thread";
@@ -1193,8 +1266,14 @@ let rec process_session_message t session
       state.current_block <- 1;
       Hashtbl.replace t.scroll_states channel_id state in
     let on_session_id sid =
-      Session_store.set_session_id t.sessions session
-        ~session_id:sid in
+      try
+        Session_store.set_session_id t.sessions session
+          ~session_id:sid
+      with exn ->
+        Logs.warn (fun m ->
+          m "bot: failed to persist session id for %s: %s"
+            session.thread_id (Printexc.to_string exn))
+    in
     let result = Agent_runner.run ~sw:t.sw ~env:t.env ~rest:t.rest
             ~session ~channel_id ~prompt
             ~attachments:msg.attachments
@@ -1208,12 +1287,19 @@ let rec process_session_message t session
     | Ok () ->
       ignore (Discord_rest.create_reaction t.rest ~channel_id
         ~message_id ~emoji:"\xE2\x9C\x85" ());
-      (* Clear initial_prompt only after successful run so it
-         survives failures and retries. Cleared before
-         increment_message_count to persist in a single save. *)
+      let prior_message_count = session.message_count in
+      let prior_initial_prompt = session.initial_prompt in
       if had_initial_prompt then
         session.initial_prompt <- None;
-      Session_store.increment_message_count t.sessions session
+      session.message_count <- session.message_count + 1;
+      (try
+         Session_store.save t.sessions
+       with exn ->
+         session.message_count <- prior_message_count;
+         session.initial_prompt <- prior_initial_prompt;
+         Logs.warn (fun m ->
+           m "bot: failed to persist message completion for %s: %s"
+             session.thread_id (Printexc.to_string exn)))
     | Error _ ->
       ignore (Discord_rest.create_reaction t.rest ~channel_id
         ~message_id ~emoji:"\xE2\x9D\x8C" ())));
@@ -1281,6 +1367,17 @@ let ensure_channel_session t ~channel_id ~project_name ~working_dir ~system_prom
       ~working_dir ~system_prompt ~agent_kind:(default_agent t);
     Logs.info (fun m -> m "bot: auto-created session for %s" project_name)
 
+let handle_command_safely t msg cmd =
+  try
+    handle_command t msg cmd
+  with exn ->
+    Logs.warn (fun m ->
+      m "bot: command failed in %s: %s"
+        msg.Discord_types.channel_id (Printexc.to_string exn));
+    ignore (Discord_rest.create_message t.rest
+      ~channel_id:msg.Discord_types.channel_id
+      ~content:(Printf.sprintf "Command failed: %s" (Printexc.to_string exn)) ())
+
 (** Route an incoming Discord message. *)
 let handle_message t (msg : Discord_types.message) =
   Session_store.maybe_reload t.sessions;
@@ -1294,7 +1391,7 @@ let handle_message t (msg : Discord_types.message) =
       | Command.List_claude_sessions | Command.List_codex_sessions
       | Command.List_gemini_sessions
       | Command.Help ->
-        handle_command t msg cmd
+        handle_command_safely t msg cmd
       | _ ->
         ignore (Discord_rest.create_message t.rest
           ~channel_id:msg.Discord_types.channel_id
@@ -1305,7 +1402,7 @@ let handle_message t (msg : Discord_types.message) =
         ~content:"Bot is restarting. Try again shortly." ())
   end else
   if Command.is_command msg.content then
-    handle_command t msg (Command.parse msg.content)
+    handle_command_safely t msg (Command.parse msg.content)
   else begin
     let is_control = match t.config.control_channel_id with
       | Some ctl_id -> msg.channel_id = ctl_id | None -> false in
@@ -1424,8 +1521,8 @@ let create ~sw ~(env : Eio_unix.Stdenv.base) config =
                wrap_width = Agent_process.desktop_width;
                refreshing = false;
                output_lines = Agent_process.default_output_lines;
-               scroll_states = Hashtbl.create 64;
-               pending_session_agent_changes = Hashtbl.create 16 } in
+               scroll_states = Hashtbl.create 64 } in
+  reconcile_persisted_pending_agent_changes bot;
   bot.gateway.handler <- (fun event ->
     match event with
     | Discord_gateway.Connected user ->

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -97,11 +97,13 @@ type persistent_rotation = {
   current_override_kind : Config.agent_kind option;
 }
 
-let fresh_session_like (session : Session_store.session) ~agent_kind =
+let fresh_session_like (session : Session_store.session)
+    ~agent_kind ~session_override_kind =
   Session_store.make_session
     ~project_name:session.project_name
     ~working_dir:session.working_dir
     ~agent_kind
+    ~session_override_kind
     ~session_id:(Resource.generate_uuid ())
     ~thread_id:session.thread_id
     ~system_prompt:session.system_prompt
@@ -255,9 +257,10 @@ let refreshed_system_prompt t (session : Session_store.session) =
        | None -> session.system_prompt)
     | None -> session.system_prompt
 
-let replace_session_agent t (session : Session_store.session) ~agent_kind =
+let replace_session_agent t (session : Session_store.session)
+    ~agent_kind ~session_override_kind =
   let replacement = {
-    (fresh_session_like session ~agent_kind) with
+    (fresh_session_like session ~agent_kind ~session_override_kind) with
     system_prompt = refreshed_system_prompt t session;
   } in
   try
@@ -270,7 +273,8 @@ let replace_session_agent t (session : Session_store.session) ~agent_kind =
 let align_persistent_sessions_to_default t ~current_channel_id ~new_agent =
   let clear_redundant_default_rotation thread_id (session : Session_store.session) =
     if is_persistent_channel t ~channel_id:thread_id
-       && Config.equal_agent_kind session.agent_kind new_agent
+       && (Config.equal_agent_kind session.agent_kind new_agent
+           || Option.is_some session.session_override_kind)
     then
       match session.pending_agent_change with
       | Some { origin = Session_store.Default_rotation; _ } ->
@@ -287,10 +291,18 @@ let align_persistent_sessions_to_default t ~current_channel_id ~new_agent =
     Session_store.bindings t.sessions
     |> List.filter (fun (thread_id, (session : Session_store.session)) ->
       is_persistent_channel t ~channel_id:thread_id
+      && Option.is_none session.session_override_kind
       && not (Config.equal_agent_kind session.agent_kind new_agent))
   in
   let current_busy_kind = ref None in
-  let current_override_kind = ref None in
+  let current_override_kind =
+    match current_channel_id with
+    | Some current_channel_id ->
+      (match Session_store.find_opt t.sessions ~thread_id:current_channel_id with
+       | Some session -> ref session.session_override_kind
+       | None -> ref None)
+    | None -> ref None
+  in
   let reset_count = ref 0 in
   let busy_count = ref 0 in
   let rec clear_redundant = function
@@ -336,7 +348,8 @@ let align_persistent_sessions_to_default t ~current_channel_id ~new_agent =
             incr busy_count;
             align rest
       end else
-        match replace_session_agent t session ~agent_kind:new_agent with
+        match replace_session_agent t session ~agent_kind:new_agent
+                ~session_override_kind:None with
         | Error err ->
           Error (Printf.sprintf
             "failed to start a fresh %s session for channel %s: %s"
@@ -366,7 +379,18 @@ let maybe_apply_pending_session_agent_change t (session : Session_store.session)
   match session.pending_agent_change with
   | None -> ()
   | Some pending ->
-    if Config.equal_agent_kind session.agent_kind pending.kind then
+    if pending.origin = Session_store.Default_rotation
+       && Option.is_some session.session_override_kind
+    then
+      (match Session_store.set_pending_agent_change t.sessions session None with
+       | Ok () -> ()
+       | Error err ->
+         Logs.warn (fun m ->
+           m "bot: failed to clear stale default-agent rotation for override %s: %s"
+             session.thread_id err))
+    else if Config.equal_agent_kind session.agent_kind pending.kind
+            && pending.origin = Session_store.Default_rotation
+    then
       (match Session_store.set_pending_agent_change t.sessions session None with
        | Ok () -> ()
        | Error err ->
@@ -375,7 +399,14 @@ let maybe_apply_pending_session_agent_change t (session : Session_store.session)
              session.thread_id err))
     else if not session.processing
             && Queue.is_empty session.pending_queue then begin
-      match replace_session_agent t session ~agent_kind:pending.kind with
+      let session_override_kind =
+        match pending.origin with
+        | Session_store.Session_override -> Some pending.kind
+        | Session_store.Default_rotation -> None
+      in
+      match replace_session_agent t session
+              ~agent_kind:pending.kind
+              ~session_override_kind with
       | Ok () ->
          Logs.info (fun m ->
            m "bot: switched channel %s to %s after pending agent change"
@@ -637,9 +668,10 @@ let resolve_resume_target t ~raw_working_dir ~kind_label ~fallback_channel =
 
 (** Create a fresh persistent channel session with an explicit agent kind. *)
 let create_persistent_channel_session t ~channel_id ~project_name ~working_dir
-    ~system_prompt ~agent_kind =
+    ~system_prompt ~agent_kind ~session_override_kind =
   let session = Session_store.make_session
     ~project_name ~working_dir ~agent_kind
+    ~session_override_kind
     ~session_id:(Resource.generate_uuid ())
     ~thread_id:channel_id
     ~system_prompt ~initial_prompt:None () in
@@ -653,7 +685,7 @@ let create_explicit_channel_session t ~channel_id ~agent_kind =
     create_persistent_channel_session t ~channel_id
       ~project_name:"control" ~working_dir:(Sys.getcwd ())
       ~system_prompt:(Some (control_system_prompt (projects t)))
-      ~agent_kind;
+      ~agent_kind ~session_override_kind:(Some agent_kind);
     true
   end else
     match Channel_manager.project_for_channel (channels t) ~channel_id with
@@ -670,7 +702,7 @@ let create_explicit_channel_session t ~channel_id ~agent_kind =
         create_persistent_channel_session t ~channel_id
           ~project_name:p.name ~working_dir
           ~system_prompt:(Some (project_system_prompt p))
-          ~agent_kind;
+          ~agent_kind ~session_override_kind:(Some agent_kind);
         true
 
 (** Handle a parsed command. *)
@@ -929,11 +961,14 @@ let handle_command t msg cmd =
     (match Session_store.find_opt t.sessions ~thread_id:channel_id with
      | Some session ->
        (match session.pending_agent_change with
-        | Some pending when not (Config.equal_agent_kind pending.kind session.agent_kind) ->
+       | Some pending when not (Config.equal_agent_kind pending.kind session.agent_kind) ->
           reply (Printf.sprintf
             "Session agent: `%s` (will start a fresh `%s` session after queued work finishes)."
             (Config.string_of_agent_kind session.agent_kind)
             (Config.string_of_agent_kind pending.kind))
+        | _ when Option.is_some session.session_override_kind ->
+          reply (Printf.sprintf "Session agent: `%s` (session override)."
+            (Config.string_of_agent_kind session.agent_kind))
         | _ ->
           reply (Printf.sprintf "Session agent: `%s`."
             (Config.string_of_agent_kind session.agent_kind)))
@@ -947,7 +982,8 @@ let handle_command t msg cmd =
     let kind_str = Config.string_of_agent_kind kind in
     (match Session_store.find_opt t.sessions ~thread_id:channel_id with
      | Some session when Config.equal_agent_kind session.agent_kind kind
-                         && Option.is_none session.pending_agent_change ->
+                         && Option.is_none session.pending_agent_change
+                         && session.session_override_kind = Some kind ->
        reply (Printf.sprintf "Session agent is already `%s`." kind_str)
      | Some session when session.processing || not (Queue.is_empty session.pending_queue) ->
        (match Session_store.set_pending_agent_change t.sessions session
@@ -959,7 +995,8 @@ let handle_command t msg cmd =
         | Error err ->
           reply (Printf.sprintf "Failed to persist session agent change: %s" err))
      | Some session ->
-       (match replace_session_agent t session ~agent_kind:kind with
+       (match replace_session_agent t session ~agent_kind:kind
+                ~session_override_kind:(Some kind) with
         | Ok () ->
           reply (Printf.sprintf "Started a fresh `%s` session for this channel."
             kind_str)
@@ -1425,7 +1462,8 @@ let ensure_channel_session t ~channel_id ~project_name ~working_dir ~system_prom
   | Some _ -> ()
   | None ->
     create_persistent_channel_session t ~channel_id ~project_name
-      ~working_dir ~system_prompt ~agent_kind:(default_agent t);
+      ~working_dir ~system_prompt ~agent_kind:(default_agent t)
+      ~session_override_kind:None;
     Logs.info (fun m -> m "bot: auto-created session for %s" project_name)
 
 let handle_command_safely t msg cmd =

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -94,6 +94,7 @@ type persistent_rotation = {
   reset_count : int;
   busy_count : int;
   current_busy_kind : Config.agent_kind option;
+  current_override_kind : Config.agent_kind option;
 }
 
 let fresh_session_like (session : Session_store.session) ~agent_kind =
@@ -259,26 +260,29 @@ let replace_session_agent t (session : Session_store.session) ~agent_kind =
     (fresh_session_like session ~agent_kind) with
     system_prompt = refreshed_system_prompt t session;
   } in
-  Session_store.add t.sessions ~thread_id:session.thread_id replacement;
-  Hashtbl.remove t.scroll_states session.thread_id
+  try
+    Session_store.add t.sessions ~thread_id:session.thread_id replacement;
+    Hashtbl.remove t.scroll_states session.thread_id;
+    Ok ()
+  with exn ->
+    Error (Printexc.to_string exn)
 
 let align_persistent_sessions_to_default t ~current_channel_id ~new_agent =
-  let dirty = ref false in
-  let prior_pending = ref [] in
-  let record_prior session =
-    prior_pending := (session, session.Session_store.pending_agent_change) :: !prior_pending
-  in
-  Session_store.bindings t.sessions
-  |> List.iter (fun (thread_id, (session : Session_store.session)) ->
+  let clear_redundant_default_rotation thread_id (session : Session_store.session) =
     if is_persistent_channel t ~channel_id:thread_id
        && Config.equal_agent_kind session.agent_kind new_agent
     then
       match session.pending_agent_change with
       | Some { origin = Session_store.Default_rotation; _ } ->
-        record_prior session;
-        session.pending_agent_change <- None;
-        dirty := true
-      | _ -> ());
+        Session_store.set_pending_agent_change t.sessions session None
+        |> Result.map_error (fun err ->
+          Printf.sprintf
+            "failed to clear a completed default-agent rotation for channel %s: %s"
+            thread_id err)
+      | _ -> Ok ()
+    else
+      Ok ()
+  in
   let stale_sessions =
     Session_store.bindings t.sessions
     |> List.filter (fun (thread_id, (session : Session_store.session)) ->
@@ -286,44 +290,77 @@ let align_persistent_sessions_to_default t ~current_channel_id ~new_agent =
       && not (Config.equal_agent_kind session.agent_kind new_agent))
   in
   let current_busy_kind = ref None in
+  let current_override_kind = ref None in
   let reset_count = ref 0 in
   let busy_count = ref 0 in
-  List.iter (fun (thread_id, (session : Session_store.session)) ->
-    if session.processing || not (Queue.is_empty session.pending_queue) then begin
-      match session.pending_agent_change with
-      | Some { origin = Session_store.Session_override; _ } -> ()
-      | _ ->
-        incr busy_count;
-        let target = pending_default_rotation new_agent in
-        if session.pending_agent_change <> Some target then begin
-          record_prior session;
-          session.pending_agent_change <- Some target;
-          dirty := true
-        end;
-        (match current_channel_id with
-         | Some current_channel_id when thread_id = current_channel_id ->
-           current_busy_kind := Some session.agent_kind
-         | _ -> ())
-    end else begin
-      replace_session_agent t session ~agent_kind:new_agent;
-      incr reset_count
-    end
-  ) stale_sessions;
-  if !dirty then
-    (try Session_store.save t.sessions with exn ->
-       List.iter (fun (session, prior) ->
-         session.Session_store.pending_agent_change <- prior
-       ) !prior_pending;
-       raise exn);
-  { reset_count = !reset_count;
-    busy_count = !busy_count;
-    current_busy_kind = !current_busy_kind; }
+  let rec clear_redundant = function
+    | [] -> Ok ()
+    | (thread_id, session) :: rest ->
+      (match clear_redundant_default_rotation thread_id session with
+       | Error _ as err -> err
+       | Ok () -> clear_redundant rest)
+  in
+  let rec align = function
+    | [] ->
+      Ok {
+        reset_count = !reset_count;
+        busy_count = !busy_count;
+        current_busy_kind = !current_busy_kind;
+        current_override_kind = !current_override_kind;
+      }
+    | (thread_id, (session : Session_store.session)) :: rest ->
+      if session.processing || not (Queue.is_empty session.pending_queue) then begin
+        match session.pending_agent_change with
+        | Some { origin = Session_store.Session_override; kind } ->
+          (match current_channel_id with
+           | Some current_channel_id when thread_id = current_channel_id ->
+             current_override_kind := Some kind
+           | _ -> ());
+          align rest
+        | _ ->
+          let target = pending_default_rotation new_agent in
+          let scheduled =
+            Session_store.set_pending_agent_change t.sessions session (Some target)
+            |> Result.map_error (fun err ->
+              Printf.sprintf
+                "failed to persist a deferred default-agent rotation for channel %s: %s"
+                thread_id err)
+          in
+          (match current_channel_id with
+           | Some current_channel_id when thread_id = current_channel_id ->
+             current_busy_kind := Some session.agent_kind
+           | _ -> ());
+          match scheduled with
+          | Error _ as err -> err
+          | Ok () ->
+            incr busy_count;
+            align rest
+      end else
+        match replace_session_agent t session ~agent_kind:new_agent with
+        | Error err ->
+          Error (Printf.sprintf
+            "failed to start a fresh %s session for channel %s: %s"
+            (Config.string_of_agent_kind new_agent) thread_id err)
+        | Ok () ->
+          incr reset_count;
+          align rest
+  in
+  match clear_redundant (Session_store.bindings t.sessions) with
+  | Error _ as err -> err
+  | Ok () -> align stale_sessions
 
 let set_default_agent t ?(current_channel_id=None) kind =
   match Runtime_settings.set_default_agent t.settings kind with
-  | Error _ as err -> err
+  | Error err ->
+    Error (Printf.sprintf "Failed to persist the default agent setting: %s" err)
   | Ok () ->
-    Ok (align_persistent_sessions_to_default t ~current_channel_id ~new_agent:kind)
+    (match align_persistent_sessions_to_default t
+             ~current_channel_id ~new_agent:kind with
+     | Ok rotation -> Ok rotation
+     | Error err ->
+       Error (Printf.sprintf
+         "Default agent is now `%s`, but top-level session rotation was incomplete: %s"
+         (Config.string_of_agent_kind kind) err))
 
 let maybe_apply_pending_session_agent_change t (session : Session_store.session) =
   match session.pending_agent_change with
@@ -338,25 +375,29 @@ let maybe_apply_pending_session_agent_change t (session : Session_store.session)
              session.thread_id err))
     else if not session.processing
             && Queue.is_empty session.pending_queue then begin
-      (try
-         replace_session_agent t session ~agent_kind:pending.kind;
+      match replace_session_agent t session ~agent_kind:pending.kind with
+      | Ok () ->
          Logs.info (fun m ->
            m "bot: switched channel %s to %s after pending agent change"
              session.thread_id (Config.string_of_agent_kind pending.kind))
-       with exn ->
-         Logs.warn (fun m ->
-           m "bot: failed to switch channel %s to %s: %s"
-             session.thread_id
-             (Config.string_of_agent_kind pending.kind)
-             (Printexc.to_string exn)))
+      | Error err ->
+        Logs.warn (fun m ->
+          m "bot: failed to switch channel %s to %s: %s"
+            session.thread_id
+            (Config.string_of_agent_kind pending.kind)
+            err)
     end
 
 let reconcile_persisted_pending_agent_changes t =
   Session_store.bindings t.sessions
   |> List.iter (fun (_thread_id, (session : Session_store.session)) ->
     maybe_apply_pending_session_agent_change t session);
-  ignore (align_persistent_sessions_to_default t
-    ~current_channel_id:None ~new_agent:(default_agent t))
+  match align_persistent_sessions_to_default t
+          ~current_channel_id:None ~new_agent:(default_agent t) with
+  | Ok _ -> ()
+  | Error err ->
+    Logs.warn (fun m ->
+      m "bot: failed to reconcile top-level default agent sessions: %s" err)
 
 (** Trigger a graceful restart: drain → reap → build → spawn.
     Callable from command handler or signal handler.
@@ -836,8 +877,7 @@ let handle_command t msg cmd =
   | Command.Default_agent (Some kind) ->
     let kind_str = Config.string_of_agent_kind kind in
     (match set_default_agent t ~current_channel_id:(Some channel_id) kind with
-     | Error err ->
-       reply (Printf.sprintf "Failed to save default agent: %s" err)
+     | Error err -> reply err
      | Ok rotation ->
        let reset_suffix =
          if rotation.reset_count = 0 then ""
@@ -847,8 +887,20 @@ let handle_command t msg cmd =
              (if rotation.reset_count = 1 then "" else "s")
        in
        let busy_suffix =
-         match rotation.current_busy_kind with
-         | Some current_kind ->
+         match rotation.current_override_kind, rotation.current_busy_kind with
+         | Some override_kind, _ ->
+           let others =
+             if rotation.busy_count = 0 then ""
+             else
+               Printf.sprintf
+                 " %d other busy top-level session%s will switch after their queued work finishes."
+                 rotation.busy_count
+                 (if rotation.busy_count = 1 then "" else "s")
+           in
+           Printf.sprintf
+             " This channel keeps its session override on `%s`.%s"
+             (Config.string_of_agent_kind override_kind) others
+         | None, Some current_kind ->
            let other_busy = rotation.busy_count - 1 in
            let others =
              if other_busy <= 0 then ""
@@ -860,7 +912,7 @@ let handle_command t msg cmd =
            Printf.sprintf
              " This channel is still running `%s`; it will reset to the new default after its queued work finishes.%s"
              (Config.string_of_agent_kind current_kind) others
-         | None ->
+         | None, None ->
            if rotation.busy_count = 0 then ""
            else
              Printf.sprintf " %d busy top-level session%s will switch after their queued work finishes."
@@ -903,9 +955,14 @@ let handle_command t msg cmd =
         | Error err ->
           reply (Printf.sprintf "Failed to persist session agent change: %s" err))
      | Some session ->
-       replace_session_agent t session ~agent_kind:kind;
-       reply (Printf.sprintf "Started a fresh `%s` session for this channel."
-         kind_str)
+       (match replace_session_agent t session ~agent_kind:kind with
+        | Ok () ->
+          reply (Printf.sprintf "Started a fresh `%s` session for this channel."
+            kind_str)
+        | Error err ->
+          reply (Printf.sprintf
+            "Failed to start a fresh `%s` session for this channel: %s"
+            kind_str err))
      | None when create_explicit_channel_session t ~channel_id ~agent_kind:kind ->
        reply (Printf.sprintf "Started a fresh `%s` session for this channel."
          kind_str)

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -68,7 +68,8 @@ type t = {
   mutable refreshing : bool;
   mutable output_lines : int;
   scroll_states : (Discord_types.channel_id, scroll_state) Hashtbl.t;
-  pending_persistent_resets : (Discord_types.channel_id, unit) Hashtbl.t;
+  pending_session_agent_changes :
+    (Discord_types.channel_id, Config.agent_kind) Hashtbl.t;
 }
 
 (** Convenience accessors for the current project state snapshot. *)
@@ -93,7 +94,23 @@ type persistent_rotation = {
   current_busy_kind : Config.agent_kind option;
 }
 
-let rotate_persistent_idle_sessions t ~current_channel_id ~new_agent =
+let fresh_session_like (session : Session_store.session) ~agent_kind =
+  Session_store.make_session
+    ~project_name:session.project_name
+    ~working_dir:session.working_dir
+    ~agent_kind
+    ~session_id:(Resource.generate_uuid ())
+    ~thread_id:session.thread_id
+    ~system_prompt:session.system_prompt
+    ~initial_prompt:None ()
+
+let replace_session_agent t (session : Session_store.session) ~agent_kind =
+  let replacement = fresh_session_like session ~agent_kind in
+  Session_store.add t.sessions ~thread_id:session.thread_id replacement;
+  Hashtbl.remove t.scroll_states session.thread_id;
+  Hashtbl.remove t.pending_session_agent_changes session.thread_id
+
+let align_persistent_sessions_to_default t ~current_channel_id ~new_agent =
   let stale_sessions =
     Session_store.bindings t.sessions
     |> List.filter (fun (thread_id, (session : Session_store.session)) ->
@@ -106,13 +123,11 @@ let rotate_persistent_idle_sessions t ~current_channel_id ~new_agent =
   List.iter (fun (thread_id, (session : Session_store.session)) ->
     if session.processing || not (Queue.is_empty session.pending_queue) then begin
       incr busy_count;
-      Hashtbl.replace t.pending_persistent_resets thread_id ();
+      Hashtbl.replace t.pending_session_agent_changes thread_id new_agent;
       if thread_id = current_channel_id then
         current_busy_kind := Some session.agent_kind
     end else begin
-      Session_store.remove t.sessions ~thread_id;
-      Hashtbl.remove t.scroll_states thread_id;
-      Hashtbl.remove t.pending_persistent_resets thread_id;
+      replace_session_agent t session ~agent_kind:new_agent;
       incr reset_count
     end
   ) stale_sessions;
@@ -120,20 +135,19 @@ let rotate_persistent_idle_sessions t ~current_channel_id ~new_agent =
     busy_count = !busy_count;
     current_busy_kind = !current_busy_kind; }
 
-let maybe_reset_persistent_channel_session t session =
+let maybe_apply_pending_session_agent_change t (session : Session_store.session) =
   let channel_id = session.Session_store.thread_id in
-  if Hashtbl.mem t.pending_persistent_resets channel_id then
-    if Config.equal_agent_kind session.agent_kind (default_agent t) then
-      Hashtbl.remove t.pending_persistent_resets channel_id
-    else if is_persistent_channel t ~channel_id
-            && not session.processing
+  match Hashtbl.find_opt t.pending_session_agent_changes channel_id with
+  | None -> ()
+  | Some target_kind ->
+    if Config.equal_agent_kind session.agent_kind target_kind then
+      Hashtbl.remove t.pending_session_agent_changes channel_id
+    else if not session.processing
             && Queue.is_empty session.pending_queue then begin
-      Session_store.remove t.sessions ~thread_id:channel_id;
-      Hashtbl.remove t.scroll_states channel_id;
-      Hashtbl.remove t.pending_persistent_resets channel_id;
+      replace_session_agent t session ~agent_kind:target_kind;
       Logs.info (fun m ->
-        m "bot: reset persistent channel %s after default-agent change"
-          channel_id)
+        m "bot: switched channel %s to %s after pending agent change"
+          channel_id (Config.string_of_agent_kind target_kind))
     end
 
 (** Drop scroll-state entries for threads that no longer have an active
@@ -505,6 +519,45 @@ let resolve_resume_target t ~raw_working_dir ~kind_label ~fallback_channel =
   in
   { thread_parent; working_dir; project_name }
 
+(** Create a fresh persistent channel session with an explicit agent kind. *)
+let create_persistent_channel_session t ~channel_id ~project_name ~working_dir
+    ~system_prompt ~agent_kind =
+  let session = Session_store.make_session
+    ~project_name ~working_dir ~agent_kind
+    ~session_id:(Resource.generate_uuid ())
+    ~thread_id:channel_id
+    ~system_prompt ~initial_prompt:None () in
+  Session_store.add t.sessions ~thread_id:channel_id session;
+  Hashtbl.remove t.pending_session_agent_changes channel_id
+
+(** Ensure or create a persistent top-level channel session for an
+    explicit agent. Returns [true] if the channel context was known and
+    a session was created. *)
+let create_explicit_channel_session t ~channel_id ~agent_kind =
+  if is_control_channel t ~channel_id then begin
+    create_persistent_channel_session t ~channel_id
+      ~project_name:"control" ~working_dir:(Sys.getcwd ())
+      ~system_prompt:(Some (control_system_prompt (projects t)))
+      ~agent_kind;
+    true
+  end else
+    match Channel_manager.project_for_channel (channels t) ~channel_id with
+    | None -> false
+    | Some proj_name ->
+      match List.find_opt (fun (p : Project.t) -> p.name = proj_name) (projects t) with
+      | None -> false
+      | Some p ->
+        let working_dir =
+          match working_dir_of_project p with
+          | Ok d -> d
+          | Error _ -> p.path
+        in
+        create_persistent_channel_session t ~channel_id
+          ~project_name:p.name ~working_dir
+          ~system_prompt:(Some (project_system_prompt p))
+          ~agent_kind;
+        true
+
 (** Handle a parsed command. *)
 let handle_command t msg cmd =
   let channel_id = msg.Discord_types.channel_id in
@@ -701,6 +754,7 @@ let handle_command t msg cmd =
      | None -> reply "Session not found."
      | Some session ->
        Session_store.remove t.sessions ~thread_id;
+       Hashtbl.remove t.pending_session_agent_changes thread_id;
        Hashtbl.remove t.scroll_states thread_id;
        reply (Printf.sprintf "Stopped session for **%s**." session.project_name))
   | Command.Default_agent None ->
@@ -713,13 +767,13 @@ let handle_command t msg cmd =
        reply (Printf.sprintf "Failed to save default agent: %s" err)
      | Ok () ->
        let rotation =
-         rotate_persistent_idle_sessions t
+         align_persistent_sessions_to_default t
            ~current_channel_id:channel_id ~new_agent:kind
        in
        let reset_suffix =
          if rotation.reset_count = 0 then ""
          else
-           Printf.sprintf " Reset %d idle persistent session%s."
+           Printf.sprintf " Reset %d top-level session%s immediately."
              rotation.reset_count
              (if rotation.reset_count = 1 then "" else "s")
        in
@@ -730,7 +784,7 @@ let handle_command t msg cmd =
            let others =
              if other_busy <= 0 then ""
              else
-               Printf.sprintf " %d other busy persistent session%s will switch after finishing."
+               Printf.sprintf " %d other busy top-level session%s will switch after finishing."
                  other_busy
                  (if other_busy = 1 then "" else "s")
            in
@@ -740,12 +794,50 @@ let handle_command t msg cmd =
          | None ->
            if rotation.busy_count = 0 then ""
            else
-             Printf.sprintf " %d busy persistent session%s will switch after finishing."
+             Printf.sprintf " %d busy top-level session%s will switch after finishing."
                rotation.busy_count
                (if rotation.busy_count = 1 then "" else "s")
        in
        reply (Printf.sprintf "Default agent set to `%s`.%s%s"
          kind_str reset_suffix busy_suffix))
+  | Command.Session_agent None ->
+    (match Session_store.find_opt t.sessions ~thread_id:channel_id with
+     | Some session ->
+       (match Hashtbl.find_opt t.pending_session_agent_changes channel_id with
+        | Some target when not (Config.equal_agent_kind target session.agent_kind) ->
+          reply (Printf.sprintf
+            "Session agent: `%s` (will switch to `%s` after current work finishes)."
+            (Config.string_of_agent_kind session.agent_kind)
+            (Config.string_of_agent_kind target))
+        | _ ->
+          reply (Printf.sprintf "Session agent: `%s`."
+            (Config.string_of_agent_kind session.agent_kind)))
+     | None when is_persistent_channel t ~channel_id ->
+       reply (Printf.sprintf
+         "No session exists in this channel yet. It will start with default agent `%s`."
+         (Config.string_of_agent_kind (default_agent t)))
+     | None ->
+       reply "No session exists in this channel.")
+  | Command.Session_agent (Some kind) ->
+    let kind_str = Config.string_of_agent_kind kind in
+    (match Session_store.find_opt t.sessions ~thread_id:channel_id with
+     | Some session when Config.equal_agent_kind session.agent_kind kind
+                         && not (Hashtbl.mem t.pending_session_agent_changes channel_id) ->
+       reply (Printf.sprintf "Session agent is already `%s`." kind_str)
+     | Some session when session.processing || not (Queue.is_empty session.pending_queue) ->
+       Hashtbl.replace t.pending_session_agent_changes channel_id kind;
+       reply (Printf.sprintf
+         "Session agent will switch to `%s` after the current work finishes."
+         kind_str)
+     | Some session ->
+       replace_session_agent t session ~agent_kind:kind;
+       reply (Printf.sprintf "Session agent set to `%s` for this channel."
+         kind_str)
+     | None when create_explicit_channel_session t ~channel_id ~agent_kind:kind ->
+       reply (Printf.sprintf "Session agent set to `%s` for this channel."
+         kind_str)
+     | None ->
+       reply "No session exists in this channel. Use `!start` or `!resume`.")
   | Command.Cleanup_channels ->
     Eio.Fiber.fork ~sw:t.sw (fun () ->
       match Channel_manager.cleanup ~rest:t.rest
@@ -899,6 +991,7 @@ let handle_command t msg cmd =
       "`!gemini-sessions` — list recent Gemini sessions";
       "`!start <project> [agent]` — start a session (defaults to the current default agent)";
       "`!default-agent [agent]` — show or set the default agent (claude|codex|gemini)";
+      "`!session-agent [agent]` — show or set the current channel session agent";
       "`!resume [agent] <session_id>` — resume a session (no agent = try the current default first)";
       "`!stop <thread_id>` — stop a session";
       "`!rename [thread_id] <name>` — rename a thread";
@@ -1153,7 +1246,7 @@ let handle_thread_message t msg ?channel_info () =
       Eio.Fiber.fork ~sw:t.sw (fun () ->
         Fun.protect ~finally:(fun () ->
           session.processing <- false;
-          maybe_reset_persistent_channel_session t session
+          maybe_apply_pending_session_agent_change t session
         ) (fun () ->
           process_session_message t session msg channel_info))
     end
@@ -1174,7 +1267,7 @@ let fork_initial_prompt_run t ~session ~msg =
   Eio.Fiber.fork ~sw:t.sw (fun () ->
     Fun.protect ~finally:(fun () ->
       session.Session_store.processing <- false;
-      maybe_reset_persistent_channel_session t session
+      maybe_apply_pending_session_agent_change t session
     ) (fun () ->
       process_session_message t session msg None))
 
@@ -1184,12 +1277,8 @@ let ensure_channel_session t ~channel_id ~project_name ~working_dir ~system_prom
   match Session_store.find_opt t.sessions ~thread_id:channel_id with
   | Some _ -> ()
   | None ->
-    let session = Session_store.make_session
-      ~project_name ~working_dir ~agent_kind:(default_agent t)
-      ~session_id:(Resource.generate_uuid ())
-      ~thread_id:channel_id
-      ~system_prompt ~initial_prompt:None () in
-    Session_store.add t.sessions ~thread_id:channel_id session;
+    create_persistent_channel_session t ~channel_id ~project_name
+      ~working_dir ~system_prompt ~agent_kind:(default_agent t);
     Logs.info (fun m -> m "bot: auto-created session for %s" project_name)
 
 (** Route an incoming Discord message. *)
@@ -1336,7 +1425,7 @@ let create ~sw ~(env : Eio_unix.Stdenv.base) config =
                refreshing = false;
                output_lines = Agent_process.default_output_lines;
                scroll_states = Hashtbl.create 64;
-               pending_persistent_resets = Hashtbl.create 16 } in
+               pending_session_agent_changes = Hashtbl.create 16 } in
   bot.gateway.handler <- (fun event ->
     match event with
     | Discord_gateway.Connected user ->

--- a/lib/command.ml
+++ b/lib/command.ml
@@ -10,6 +10,8 @@ type t =
   | List_codex_sessions
   | List_gemini_sessions
   | Start_agent of { project : string; kind : Config.agent_kind option }
+  (** [kind = None] means "try the current default agent first, then
+      the remaining agent stores". *)
   | Resume_session of { session_id : string; kind : Config.agent_kind option }
   | Stop_session of { thread_id : string }
   | Cleanup_channels

--- a/lib/command.ml
+++ b/lib/command.ml
@@ -9,12 +9,11 @@ type t =
   | List_claude_sessions
   | List_codex_sessions
   | List_gemini_sessions
-  | Start_agent of { project : string; kind : Config.agent_kind }
-  (* [kind] disambiguates which session store to search. None = the
-     handler tries Claude → Codex → Gemini in that order. *)
+  | Start_agent of { project : string; kind : Config.agent_kind option }
   | Resume_session of { session_id : string; kind : Config.agent_kind option }
   | Stop_session of { thread_id : string }
   | Cleanup_channels
+  | Default_agent of Config.agent_kind option
   | Restart
   | Refresh
   | Rename_thread of { thread_id : string option; name : string }
@@ -46,17 +45,22 @@ let parse content =
   | ["codex-sessions"] -> List_codex_sessions
   | ["gemini-sessions"] -> List_gemini_sessions
   | "start" :: project :: kind_str :: _ ->
-    let kind = match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with
-      | Ok k -> k | Error _ -> Config.Claude in
-    Start_agent { project; kind }
+    (match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with
+     | Ok kind -> Start_agent { project; kind = Some kind }
+     | Error _ -> Unknown content)
   | ["start"; project] ->
-    Start_agent { project; kind = Config.Claude }
+    Start_agent { project; kind = None }
   | ["start"] ->
     List_projects
   | ["resume"; session_id] -> Resume_session { session_id; kind = None }
   | ["resume"; kind_str; session_id] ->
     (match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with
      | Ok k -> Resume_session { session_id; kind = Some k }
+     | Error _ -> Unknown content)
+  | ["default-agent"] | ["default_agent"] -> Default_agent None
+  | ["default-agent"; kind_str] | ["default_agent"; kind_str] ->
+    (match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with
+     | Ok k -> Default_agent (Some k)
      | Error _ -> Unknown content)
   | ["stop"; thread_id] -> Stop_session { thread_id }
   | ["cleanup-channels"] | ["cleanup"] -> Cleanup_channels

--- a/lib/command.ml
+++ b/lib/command.ml
@@ -14,6 +14,7 @@ type t =
   | Stop_session of { thread_id : string }
   | Cleanup_channels
   | Default_agent of Config.agent_kind option
+  | Session_agent of Config.agent_kind option
   | Restart
   | Refresh
   | Rename_thread of { thread_id : string option; name : string }
@@ -61,6 +62,11 @@ let parse content =
   | ["default-agent"; kind_str] | ["default_agent"; kind_str] ->
     (match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with
      | Ok k -> Default_agent (Some k)
+     | Error _ -> Unknown content)
+  | ["session-agent"] | ["session_agent"] -> Session_agent None
+  | ["session-agent"; kind_str] | ["session_agent"; kind_str] ->
+    (match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with
+     | Ok k -> Session_agent (Some k)
      | Error _ -> Unknown content)
   | ["stop"; thread_id] -> Stop_session { thread_id }
   | ["cleanup-channels"] | ["cleanup"] -> Cleanup_channels

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -24,6 +24,16 @@ let preferred_agent_order preferred =
   :: List.filter (fun kind -> not (equal_agent_kind kind preferred))
        [Claude; Codex; Gemini]
 
+let find_with_preferred_agent preferred f =
+  let rec first_found = function
+    | [] -> None
+    | kind :: rest ->
+      match f kind with
+      | Some _ as found -> found
+      | None -> first_found rest
+  in
+  first_found (preferred_agent_order preferred)
+
 (** Whether this agent accepts a caller-supplied session id at startup
     (Claude's [--session-id]) or allocates its own server-side and
     emits it on first run (Codex's [thread.started], Gemini's [init]).

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -77,8 +77,7 @@ let default = {
 }
 
 let config_path () =
-  let home = Sys.getenv "HOME" in
-  Filename.concat home ".config/discord-agents/config.json"
+  Filename.concat (Resource.app_config_dir ()) "config.json"
 
 let load_file path =
   let ic = open_in path in
@@ -106,9 +105,7 @@ let load () =
 
 let save config =
   let path = config_path () in
-  let dir = Filename.dirname path in
-  if not (Sys.file_exists dir) then
-    Sys.mkdir dir 0o700;
+  Resource.ensure_parent_dir path;
   let json = yojson_of_t config in
   (* Write with restricted permissions — file contains discord token *)
   let fd = Unix.openfile path [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o600 in

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -19,6 +19,11 @@ let string_of_agent_kind = function
   | Codex -> "codex"
   | Gemini -> "gemini"
 
+let preferred_agent_order preferred =
+  preferred
+  :: List.filter (fun kind -> not (equal_agent_kind kind preferred))
+       [Claude; Codex; Gemini]
+
 (** Whether this agent accepts a caller-supplied session id at startup
     (Claude's [--session-id]) or allocates its own server-side and
     emits it on first run (Codex's [thread.started], Gemini's [init]).

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -11,8 +11,7 @@
     Replaces the MCP server's direct session file / Discord REST access. *)
 
 let socket_path () =
-  let home = Sys.getenv "HOME" in
-  Filename.concat home ".config/discord-agents/control.sock"
+  Filename.concat (Resource.app_config_dir ()) "control.sock"
 
 let raise_if_cancelled exn =
   match exn with
@@ -483,6 +482,35 @@ let handle_resume_session (bot : Bot.t) params =
           ("agent_kind", `String kind_label);
         ])
 
+let handle_default_agent (bot : Bot.t) params =
+  let open Yojson.Safe.Util in
+  let requested =
+    match params with
+    | Some p ->
+      (match p |> member "agent" |> to_string_option with
+       | None -> None
+       | Some s ->
+         (match Config.agent_kind_of_string (String.lowercase_ascii s) with
+          | Ok kind -> Some kind
+          | Error msg -> failwith msg))
+    | None -> None
+  in
+  match requested with
+  | None ->
+    ok_response [
+      ("agent",
+       `String (Config.string_of_agent_kind bot.settings.default_agent));
+    ]
+  | Some kind ->
+    (match Bot.set_default_agent bot kind with
+     | Error err -> error_response err
+     | Ok rotation ->
+       ok_response [
+         ("agent", `String (Config.string_of_agent_kind kind));
+         ("reset_count", `Int rotation.Bot.reset_count);
+         ("busy_count", `Int rotation.Bot.busy_count);
+       ])
+
 let handle_restart (bot : Bot.t) =
   Bot.trigger_restart bot ~notify:(fun msg ->
     Logs.info (fun m -> m "control_api restart: %s" msg));
@@ -528,6 +556,7 @@ let dispatch (bot : Bot.t) method_ params =
     | "list_gemini_sessions" -> handle_list_gemini_sessions bot params
     | "start_session" -> handle_start_session bot params
     | "resume_session" -> handle_resume_session bot params
+    | "default_agent" -> handle_default_agent bot params
     | "restart" -> handle_restart bot
     | "rename_thread" -> handle_rename_thread bot params
     | "cleanup_channels" -> handle_cleanup_channels bot
@@ -571,6 +600,7 @@ let handle_connection bot flow =
 
 let start ~(bot : Bot.t) ~sw ~(env : Eio_unix.Stdenv.base) =
   let path = socket_path () in
+  Resource.ensure_parent_dir path;
   (* Remove stale socket from a previous run *)
   (try Unix.unlink path with Unix.Unix_error _ -> ());
   let net = Eio.Stdenv.net env in

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -106,6 +106,8 @@ let handle_health (bot : Bot.t) =
   in
   ok_response ([
     ("uptime_seconds", `Int uptime);
+    ("default_agent",
+     `String (Config.string_of_agent_kind bot.settings.default_agent));
     ("sessions", `Int (Session_store.count bot.sessions));
     ("projects", `Int (List.length (Bot.projects bot)));
     ("channels", `Int (Channel_manager.count (Bot.channels bot)));
@@ -209,7 +211,10 @@ let handle_start_session (bot : Bot.t) params =
   else
   let project_str = params |> member "project" |> to_string in
   let kind_str = match params |> member "agent" |> to_string_option with
-    | Some s -> s | None -> "claude" in
+    | Some s -> s
+    | None ->
+      Config.string_of_agent_kind bot.settings.default_agent
+  in
   let kind = match Config.agent_kind_of_string kind_str with
     | Ok k -> k | Error _ -> failwith ("unknown agent: " ^ kind_str) in
   let thread_name = params |> member "thread_name" |> to_string_option in
@@ -401,7 +406,8 @@ let handle_resume_session (bot : Bot.t) params =
        | Ok k -> Some k | Error _ -> None)
   in
   (* Mirror Bot.handle_command's Resume_session dispatch: explicit
-     kind looks up its own store; None tries Claude then Gemini. *)
+     kind looks up its own store; None tries the current default
+     first, then the remaining stores. *)
   let try_claude () =
     match Claude_sessions.find_by_prefix sid_prefix with
     | Some (sid, wd) -> Some (Config.Claude, sid, wd) | None -> None
@@ -414,17 +420,24 @@ let handle_resume_session (bot : Bot.t) params =
     match Gemini_sessions.find_by_prefix sid_prefix with
     | Some (sid, wd) -> Some (Config.Gemini, sid, wd) | None -> None
   in
+  let try_kind = function
+    | Config.Claude -> try_claude ()
+    | Config.Codex -> try_codex ()
+    | Config.Gemini -> try_gemini ()
+  in
   let found = match kind with
-    | Some Config.Claude -> try_claude ()
-    | Some Config.Codex -> try_codex ()
-    | Some Config.Gemini -> try_gemini ()
+    | Some k -> try_kind k
     | None ->
-      (match try_claude () with
-       | Some _ as r -> r
-       | None ->
-         match try_codex () with
-         | Some _ as r -> r
-         | None -> try_gemini ())
+      let rec first_found = function
+        | [] -> None
+        | k :: rest ->
+          match try_kind k with
+          | Some _ as found -> found
+          | None -> first_found rest
+      in
+      first_found
+        (Config.preferred_agent_order
+           bot.settings.default_agent)
   in
   match found with
   | None ->

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -428,16 +428,7 @@ let handle_resume_session (bot : Bot.t) params =
   let found = match kind with
     | Some k -> try_kind k
     | None ->
-      let rec first_found = function
-        | [] -> None
-        | k :: rest ->
-          match try_kind k with
-          | Some _ as found -> found
-          | None -> first_found rest
-      in
-      first_found
-        (Config.preferred_agent_order
-           bot.settings.default_agent)
+      Config.find_with_preferred_agent bot.settings.default_agent try_kind
   in
   match found with
   | None ->

--- a/lib/discord_agents.ml
+++ b/lib/discord_agents.ml
@@ -2,6 +2,7 @@
 
 module Resource = Resource
 module Config = Config
+module Runtime_settings = Runtime_settings
 module Project = Project
 module Agent_process = Agent_process
 module Agent_runner = Agent_runner

--- a/lib/resource.ml
+++ b/lib/resource.ml
@@ -9,6 +9,47 @@ let with_file_out path f =
   let oc = open_out path in
   Fun.protect ~finally:(fun () -> close_out oc) (fun () -> f oc)
 
+(** Environment variable lookup that treats empty values as absent. *)
+let getenv_nonempty name =
+  match Sys.getenv_opt name with
+  | Some "" | None -> None
+  | Some value -> Some value
+
+(** Application config directory, preferring XDG and falling back to a
+    uid-specific temp dir if neither XDG nor HOME is set. *)
+let app_config_dir () =
+  match getenv_nonempty "XDG_CONFIG_HOME" with
+  | Some xdg_config_home -> Filename.concat xdg_config_home "discord-agents"
+  | None ->
+    match getenv_nonempty "HOME" with
+    | Some home -> Filename.concat home ".config/discord-agents"
+    | None ->
+      let fallback =
+        Filename.concat (Filename.get_temp_dir_name ())
+          (Printf.sprintf "discord-agents-%d" (Unix.getuid ()))
+      in
+      Logs.warn (fun m ->
+        m "resource: HOME/XDG_CONFIG_HOME unset; using %s" fallback);
+      fallback
+
+(** Ensure the parent directory of [path] exists. *)
+let ensure_parent_dir path =
+  let rec mkdir_p dir =
+    if Sys.file_exists dir then begin
+      if not (Sys.is_directory dir) then
+        failwith (Printf.sprintf "parent is not a directory: %s" dir)
+    end else begin
+      let parent = Filename.dirname dir in
+      if parent <> dir then mkdir_p parent;
+      try Unix.mkdir dir 0o700 with
+      | Unix.Unix_error ((Unix.EEXIST | Unix.EISDIR), _, _) ->
+        if not (Sys.is_directory dir) then
+          failwith (Printf.sprintf "parent is not a directory: %s" dir)
+      | exn -> raise exn
+    end
+  in
+  mkdir_p (Filename.dirname path)
+
 (** Read entire file contents safely. *)
 let read_file path =
   with_file_in path (fun ic ->
@@ -21,6 +62,7 @@ let read_file path =
 let write_file_atomic path content =
   let tmp = path ^ ".tmp" in
   (try
+    ensure_parent_dir path;
     with_file_out tmp (fun oc ->
       output_string oc content;
       output_char oc '\n');
@@ -32,6 +74,7 @@ let write_file_atomic path content =
 (** Execute f while holding an exclusive flock on lock_path.
     Used for cross-process synchronization (bot + MCP server). *)
 let with_flock lock_path f =
+  ensure_parent_dir lock_path;
   let fd = Unix.openfile lock_path [Unix.O_WRONLY; Unix.O_CREAT] 0o600 in
   Fun.protect ~finally:(fun () ->
     (try Unix.lockf fd Unix.F_ULOCK 0 with _ -> ());

--- a/lib/resource.ml
+++ b/lib/resource.ml
@@ -15,14 +15,35 @@ let getenv_nonempty name =
   | Some "" | None -> None
   | Some value -> Some value
 
-(** Application config directory, preferring XDG and falling back to a
-    uid-specific temp dir if neither XDG nor HOME is set. *)
+(** Legacy pre-XDG config directory. *)
+let legacy_home_config_dir () =
+  match getenv_nonempty "HOME" with
+  | Some home -> Some (Filename.concat home ".config/discord-agents")
+  | None -> None
+
+let config_dir_has_state dir =
+  Sys.file_exists dir
+  && List.exists
+       (fun name -> Sys.file_exists (Filename.concat dir name))
+       ["config.json"; "settings.json"; "sessions.json"; "control.sock"]
+
+(** Application config directory, preferring XDG for new installs while
+    preserving pre-XDG HOME-based installs. If XDG_CONFIG_HOME appears
+    later but its app directory has no bot state yet, use the legacy
+    directory when it already exists so settings, sessions, and the
+    control socket remain discoverable. *)
 let app_config_dir () =
   match getenv_nonempty "XDG_CONFIG_HOME" with
-  | Some xdg_config_home -> Filename.concat xdg_config_home "discord-agents"
+  | Some xdg_config_home ->
+    let xdg_dir = Filename.concat xdg_config_home "discord-agents" in
+    (match legacy_home_config_dir () with
+     | Some legacy_dir
+       when (not (config_dir_has_state xdg_dir)) && Sys.file_exists legacy_dir ->
+       legacy_dir
+     | _ -> xdg_dir)
   | None ->
-    match getenv_nonempty "HOME" with
-    | Some home -> Filename.concat home ".config/discord-agents"
+    match legacy_home_config_dir () with
+    | Some legacy_dir -> legacy_dir
     | None ->
       let fallback =
         Filename.concat (Filename.get_temp_dir_name ())

--- a/lib/runtime_settings.ml
+++ b/lib/runtime_settings.ml
@@ -1,0 +1,71 @@
+(** Mutable runtime settings that are safe to change from Discord.
+
+    These live separately from [config.json] so operational commands
+    do not rewrite credentials or project discovery config. *)
+
+type t = {
+  mutable default_agent : Config.agent_kind;
+}
+
+let settings_path () =
+  let home = Sys.getenv "HOME" in
+  Filename.concat home ".config/discord-agents/settings.json"
+
+let lock_path () = settings_path () ^ ".lock"
+
+let default () = {
+  default_agent = Config.Claude;
+}
+
+let ensure_parent_dir path =
+  let rec mkdir_p dir =
+    if not (Sys.file_exists dir) then begin
+      let parent = Filename.dirname dir in
+      if parent <> dir then mkdir_p parent;
+      Unix.mkdir dir 0o700
+    end
+  in
+  mkdir_p (Filename.dirname path)
+
+let to_yojson t =
+  `Assoc [("default_agent", Config.yojson_of_agent_kind t.default_agent)]
+
+let of_yojson = function
+  | `Assoc fields ->
+    (match List.assoc_opt "default_agent" fields with
+     | Some (`String _ as json) ->
+       { default_agent = Config.agent_kind_of_yojson json }
+     | Some _ -> failwith "default_agent: expected string"
+     | None -> default ())
+  | _ -> failwith "runtime settings: expected object"
+
+let load () =
+  let path = settings_path () in
+  if not (Sys.file_exists path) then default ()
+  else
+    try
+      let contents = Resource.read_file path in
+      of_yojson (Yojson.Safe.from_string contents)
+    with exn ->
+      Logs.warn (fun m ->
+        m "runtime_settings: load error: %s" (Printexc.to_string exn));
+      default ()
+
+let save t =
+  let path = settings_path () in
+  try
+    ensure_parent_dir path;
+    Resource.with_flock (lock_path ()) (fun () ->
+      Resource.write_file_atomic path (Yojson.Safe.pretty_to_string (to_yojson t)));
+    Ok ()
+  with exn ->
+    Error (Printexc.to_string exn)
+
+let set_default_agent t agent =
+  let prior = t.default_agent in
+  t.default_agent <- agent;
+  match save t with
+  | Ok () as ok -> ok
+  | Error _ as err ->
+    t.default_agent <- prior;
+    err

--- a/lib/runtime_settings.ml
+++ b/lib/runtime_settings.ml
@@ -8,24 +8,14 @@ type t = {
 }
 
 let settings_path () =
-  let home = Sys.getenv "HOME" in
-  Filename.concat home ".config/discord-agents/settings.json"
+  Filename.concat (Resource.app_config_dir ()) "settings.json"
 
 let lock_path () = settings_path () ^ ".lock"
+let backup_path () = settings_path () ^ ".bak"
 
 let default () = {
   default_agent = Config.Claude;
 }
-
-let ensure_parent_dir path =
-  let rec mkdir_p dir =
-    if not (Sys.file_exists dir) then begin
-      let parent = Filename.dirname dir in
-      if parent <> dir then mkdir_p parent;
-      Unix.mkdir dir 0o700
-    end
-  in
-  mkdir_p (Filename.dirname path)
 
 let to_yojson t =
   `Assoc [("default_agent", Config.yojson_of_agent_kind t.default_agent)]
@@ -39,24 +29,55 @@ let of_yojson = function
      | None -> default ())
   | _ -> failwith "runtime settings: expected object"
 
+let load_file path =
+  let contents = Resource.read_file path in
+  of_yojson (Yojson.Safe.from_string contents)
+
 let load () =
   let path = settings_path () in
-  if not (Sys.file_exists path) then default ()
-  else
-    try
-      let contents = Resource.read_file path in
-      of_yojson (Yojson.Safe.from_string contents)
-    with exn ->
+  let backup = backup_path () in
+  match Sys.file_exists path, Sys.file_exists backup with
+  | false, false -> default ()
+  | false, true ->
+    (match load_file backup with
+     | settings ->
+       Logs.warn (fun m ->
+         m "runtime_settings: primary missing; recovered from backup %s" backup);
+       settings
+     | exception backup_exn ->
+       Logs.warn (fun m ->
+         m "runtime_settings: backup load error from %s: %s"
+           backup (Printexc.to_string backup_exn));
+       default ())
+  | true, _ ->
+    match load_file path with
+    | settings -> settings
+    | exception exn ->
       Logs.warn (fun m ->
-        m "runtime_settings: load error: %s" (Printexc.to_string exn));
-      default ()
+        m "runtime_settings: load error from %s: %s"
+          path (Printexc.to_string exn));
+      (match load_file backup with
+       | settings ->
+         Logs.warn (fun m ->
+           m "runtime_settings: recovered from backup %s" backup);
+         settings
+       | exception backup_exn ->
+         Logs.warn (fun m ->
+           m "runtime_settings: backup load error from %s: %s"
+             backup (Printexc.to_string backup_exn));
+         default ())
 
 let save t =
   let path = settings_path () in
+  let backup = backup_path () in
+  let rendered = Yojson.Safe.pretty_to_string (to_yojson t) in
   try
-    ensure_parent_dir path;
     Resource.with_flock (lock_path ()) (fun () ->
-      Resource.write_file_atomic path (Yojson.Safe.pretty_to_string (to_yojson t)));
+      Resource.write_file_atomic path rendered;
+      (try Resource.write_file_atomic backup rendered with exn ->
+         Logs.warn (fun m ->
+           m "runtime_settings: failed to update backup %s: %s"
+             backup (Printexc.to_string exn))));
     Ok ()
   with exn ->
     Error (Printexc.to_string exn)

--- a/lib/runtime_settings.ml
+++ b/lib/runtime_settings.ml
@@ -62,10 +62,13 @@ let save t =
     Error (Printexc.to_string exn)
 
 let set_default_agent t agent =
-  let prior = t.default_agent in
-  t.default_agent <- agent;
-  match save t with
-  | Ok () as ok -> ok
-  | Error _ as err ->
-    t.default_agent <- prior;
-    err
+  if Config.equal_agent_kind t.default_agent agent then
+    Ok ()
+  else
+    let next = { default_agent = agent } in
+    match save next with
+    | Ok () as ok ->
+      t.default_agent <- agent;
+      ok
+    | Error _ as err ->
+      err

--- a/lib/session_store.ml
+++ b/lib/session_store.ml
@@ -11,6 +11,24 @@ type pending_message = {
   channel_info : Discord_types.channel option;
 }
 
+type pending_agent_origin =
+  | Default_rotation
+  | Session_override
+
+type pending_agent_change = {
+  kind : Config.agent_kind;
+  origin : pending_agent_origin;
+}
+
+let string_of_pending_agent_origin = function
+  | Default_rotation -> "default_rotation"
+  | Session_override -> "session_override"
+
+let pending_agent_origin_of_string = function
+  | "default_rotation" -> Some Default_rotation
+  | "session_override" -> Some Session_override
+  | _ -> None
+
 type session = {
   project_name : string;
   working_dir : string;
@@ -33,6 +51,7 @@ type session = {
   mutable message_count : int;
   mutable processing : bool;
   pending_queue : pending_message Queue.t;
+  mutable pending_agent_change : pending_agent_change option;
   mutable initial_prompt : string option;  (* One-shot context for the first message *)
 }
 
@@ -42,8 +61,7 @@ type t = {
 }
 
 let sessions_file () =
-  let home = Sys.getenv "HOME" in
-  Filename.concat home ".config/discord-agents/sessions.json"
+  Filename.concat (Resource.app_config_dir ()) "sessions.json"
 
 let lock_file () = sessions_file () ^ ".lock"
 
@@ -61,6 +79,13 @@ let sessions_to_json sessions =
       ("message_count", `Int s.message_count);
     ] @ (match s.system_prompt with
          | Some sp -> [("system_prompt", `String sp)]
+         | None -> [])
+      @ (match s.pending_agent_change with
+         | Some pending ->
+           [ ("pending_agent_kind",
+              `String (Config.string_of_agent_kind pending.kind));
+             ("pending_agent_origin",
+              `String (string_of_pending_agent_origin pending.origin)) ]
          | None -> [])
       @ (match s.initial_prompt with
          | Some ip -> [("initial_prompt", `String ip)]
@@ -84,6 +109,21 @@ let sessions_of_json json =
       let session_id_confirmed = match j |> member "session_id_confirmed" with
         | `Bool b -> b
         | _ -> Config.caller_pinned_session_id agent_kind in
+      let pending_agent_change =
+        match j |> member "pending_agent_kind" with
+        | `String s ->
+          (match Config.agent_kind_of_string s with
+           | Ok kind ->
+             let origin =
+               match j |> member "pending_agent_origin" with
+               | `String origin ->
+                 pending_agent_origin_of_string origin
+               | _ -> Some Default_rotation
+             in
+             Option.map (fun origin -> { kind; origin }) origin
+           | Error _ -> None)
+        | _ -> None
+      in
       let session = {
         project_name = j |> member "project_name" |> to_string;
         working_dir = j |> member "working_dir" |> to_string;
@@ -95,6 +135,7 @@ let sessions_of_json json =
         message_count = j |> member "message_count" |> to_int;
         processing = false;
         pending_queue = Queue.create ();
+        pending_agent_change;
         initial_prompt = j |> member "initial_prompt" |> to_string_option;
       } in
       (thread_id, session)
@@ -136,6 +177,7 @@ let create () =
 let make_session ~project_name ~working_dir ~agent_kind ~session_id
     ~thread_id ~system_prompt ~initial_prompt
     ?(message_count = 0)
+    ?(pending_agent_change = None)
     ?session_id_confirmed () =
   let session_id_confirmed = match session_id_confirmed with
     | Some b -> b
@@ -144,17 +186,31 @@ let make_session ~project_name ~working_dir ~agent_kind ~session_id
   { project_name; working_dir; agent_kind; session_id;
     session_id_confirmed; thread_id; system_prompt;
     message_count; processing = false;
-    pending_queue = Queue.create (); initial_prompt }
+    pending_queue = Queue.create (); pending_agent_change; initial_prompt }
+
+let persist_or_rollback rollback f =
+  try
+    let result = f () in
+    Ok result
+  with exn ->
+    rollback ();
+    Error (Printexc.to_string exn)
 
 (** Add a session and persist to disk. *)
 let add t ~(thread_id : Discord_types.channel_id) session =
+  let prior = t.sessions in
   t.sessions <- SessionMap.add thread_id session t.sessions;
-  save t
+  match persist_or_rollback (fun () -> t.sessions <- prior) (fun () -> save t) with
+  | Ok () -> ()
+  | Error err -> failwith err
 
 (** Remove a session and persist to disk. *)
 let remove t ~(thread_id : Discord_types.channel_id) =
+  let prior = t.sessions in
   t.sessions <- SessionMap.remove thread_id t.sessions;
-  save t
+  match persist_or_rollback (fun () -> t.sessions <- prior) (fun () -> save t) with
+  | Ok () -> ()
+  | Error err -> failwith err
 
 (** Find a session by thread ID. *)
 let find_opt t ~(thread_id : Discord_types.channel_id) =
@@ -168,8 +224,23 @@ let count t = SessionMap.cardinal t.sessions
 
 (** Increment message count for a session and persist. *)
 let increment_message_count t session =
+  let prior = session.message_count in
   session.message_count <- session.message_count + 1;
-  save t
+  match persist_or_rollback (fun () -> session.message_count <- prior)
+          (fun () -> save t) with
+  | Ok () -> ()
+  | Error err -> failwith err
+
+let set_pending_agent_change t session pending_agent_change =
+  let prior = session.pending_agent_change in
+  if prior = pending_agent_change then
+    Ok ()
+  else begin
+    session.pending_agent_change <- pending_agent_change;
+    persist_or_rollback
+      (fun () -> session.pending_agent_change <- prior)
+      (fun () -> save t)
+  end
 
 (** Update a session's id and mark it confirmed for resume.
     Used when an agent assigns its id server-side (Codex's
@@ -181,9 +252,17 @@ let set_session_id t session ~session_id =
   let already = session.session_id = session_id
                 && session.session_id_confirmed in
   if not already then begin
+    let prior_id = session.session_id in
+    let prior_confirmed = session.session_id_confirmed in
     session.session_id <- session_id;
     session.session_id_confirmed <- true;
-    save t
+    match persist_or_rollback
+            (fun () ->
+              session.session_id <- prior_id;
+              session.session_id_confirmed <- prior_confirmed)
+            (fun () -> save t) with
+    | Ok () -> ()
+    | Error err -> failwith err
   end
 
 (** Reload sessions from disk if the file changed.

--- a/lib/session_store.ml
+++ b/lib/session_store.ml
@@ -29,6 +29,17 @@ let pending_agent_origin_of_string = function
   | "session_override" -> Some Session_override
   | _ -> None
 
+let pending_agent_origin_of_json = function
+  | `String origin ->
+    (match pending_agent_origin_of_string origin with
+     | Some origin -> origin
+     | None ->
+       Logs.warn (fun m ->
+         m "session_store: unknown pending_agent_origin %S, defaulting to default_rotation"
+           origin);
+       Default_rotation)
+  | _ -> Default_rotation
+
 type session = {
   project_name : string;
   working_dir : string;
@@ -124,12 +135,9 @@ let sessions_of_json json =
           (match Config.agent_kind_of_string s with
            | Ok kind ->
              let origin =
-               match j |> member "pending_agent_origin" with
-               | `String origin ->
-                 pending_agent_origin_of_string origin
-               | _ -> Some Default_rotation
+               pending_agent_origin_of_json (j |> member "pending_agent_origin")
              in
-             Option.map (fun origin -> { kind; origin }) origin
+             Some { kind; origin }
            | Error _ -> None)
         | _ -> None
       in

--- a/lib/session_store.ml
+++ b/lib/session_store.ml
@@ -33,6 +33,10 @@ type session = {
   project_name : string;
   working_dir : string;
   agent_kind : Config.agent_kind;
+  (* Persisted top-level session pin set via [!session-agent]. When
+     present, default-agent rotations must leave this session on the
+     recorded agent kind. *)
+  mutable session_override_kind : Config.agent_kind option;
   (* Mutable because Codex and Gemini assign their session ids
      server-side: the pre-generated UUID is overwritten once the
      first event arrives (Codex's [thread.started] / Gemini's
@@ -79,6 +83,11 @@ let sessions_to_json sessions =
       ("message_count", `Int s.message_count);
     ] @ (match s.system_prompt with
          | Some sp -> [("system_prompt", `String sp)]
+         | None -> [])
+      @ (match s.session_override_kind with
+         | Some kind ->
+           [("session_override_kind",
+             `String (Config.string_of_agent_kind kind))]
          | None -> [])
       @ (match s.pending_agent_change with
          | Some pending ->
@@ -128,6 +137,13 @@ let sessions_of_json json =
         project_name = j |> member "project_name" |> to_string;
         working_dir = j |> member "working_dir" |> to_string;
         agent_kind;
+        session_override_kind =
+          (match j |> member "session_override_kind" with
+           | `String s ->
+             (match Config.agent_kind_of_string s with
+              | Ok kind -> Some kind
+              | Error _ -> None)
+           | _ -> None);
         session_id = j |> member "session_id" |> to_string;
         session_id_confirmed;
         thread_id;
@@ -177,13 +193,14 @@ let create () =
 let make_session ~project_name ~working_dir ~agent_kind ~session_id
     ~thread_id ~system_prompt ~initial_prompt
     ?(message_count = 0)
+    ?(session_override_kind = None)
     ?(pending_agent_change = None)
     ?session_id_confirmed () =
   let session_id_confirmed = match session_id_confirmed with
     | Some b -> b
     | None -> Config.caller_pinned_session_id agent_kind
   in
-  { project_name; working_dir; agent_kind; session_id;
+  { project_name; working_dir; agent_kind; session_override_kind; session_id;
     session_id_confirmed; thread_id; system_prompt;
     message_count; processing = false;
     pending_queue = Queue.create (); pending_agent_change; initial_prompt }

--- a/lib/session_store.ml
+++ b/lib/session_store.ml
@@ -267,6 +267,35 @@ let set_pending_agent_change t session pending_agent_change =
       (fun () -> save t)
   end
 
+let set_session_override_kind t session session_override_kind =
+  let prior = session.session_override_kind in
+  if prior = session_override_kind then
+    Ok ()
+  else begin
+    session.session_override_kind <- session_override_kind;
+    persist_or_rollback
+      (fun () -> session.session_override_kind <- prior)
+      (fun () -> save t)
+  end
+
+let set_override_and_pending_agent_change t session
+    ~session_override_kind ~pending_agent_change =
+  let prior_override = session.session_override_kind in
+  let prior_pending = session.pending_agent_change in
+  if prior_override = session_override_kind
+     && prior_pending = pending_agent_change
+  then
+    Ok ()
+  else begin
+    session.session_override_kind <- session_override_kind;
+    session.pending_agent_change <- pending_agent_change;
+    persist_or_rollback
+      (fun () ->
+        session.session_override_kind <- prior_override;
+        session.pending_agent_change <- prior_pending)
+      (fun () -> save t)
+  end
+
 (** Update a session's id and mark it confirmed for resume.
     Used when an agent assigns its id server-side (Codex's
     thread.started) so the pre-generated UUID is replaced before the

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -13,13 +13,24 @@ Protocol: JSON-RPC 2.0 over stdio (MCP standard).
 """
 
 import json
+import os
 import socket
 import sys
+import tempfile
 from pathlib import Path
 
 # --- Configuration ---
 
-CONFIG_DIR = Path.home() / ".config" / "discord-agents"
+def app_config_dir():
+    xdg = os.environ.get("XDG_CONFIG_HOME", "")
+    if xdg:
+        return Path(xdg) / "discord-agents"
+    home = os.environ.get("HOME", "")
+    if home:
+        return Path(home) / ".config" / "discord-agents"
+    return Path(tempfile.gettempdir()) / f"discord-agents-{os.getuid()}"
+
+CONFIG_DIR = app_config_dir()
 CONTROL_SOCKET = CONFIG_DIR / "control.sock"
 
 # --- Bot control API client ---
@@ -70,8 +81,7 @@ TOOLS = [
                 },
                 "agent": {
                     "type": "string",
-                    "description": "Agent type: claude, codex, or gemini",
-                    "default": "claude",
+                    "description": "Agent type: claude, codex, or gemini. If omitted, uses the bot's current default agent.",
                     "enum": ["claude", "codex", "gemini"]
                 },
                 "thread_name": {
@@ -147,8 +157,22 @@ TOOLS = [
         }
     },
     {
+        "name": "default_agent",
+        "description": "Show or set the default agent used for new top-level sessions. Existing idle top-level sessions reset to a fresh session immediately; busy ones reset after their queued work finishes.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent": {
+                    "type": "string",
+                    "description": "Agent type to make the default. Omit to read the current default.",
+                    "enum": ["claude", "codex", "gemini"]
+                }
+            }
+        }
+    },
+    {
         "name": "resume_session",
-        "description": "Resume an existing Claude, Codex, or Gemini session in a new Discord thread. Use list_claude_sessions / list_codex_sessions / list_gemini_sessions to find a session ID. With kind unspecified, the bot tries Claude → Codex → Gemini.",
+        "description": "Resume an existing Claude, Codex, or Gemini session in a new Discord thread. Use list_claude_sessions / list_codex_sessions / list_gemini_sessions to find a session ID. With kind unspecified, the bot tries the current default agent first, then the others.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -159,7 +183,7 @@ TOOLS = [
                 "kind": {
                     "type": "string",
                     "enum": ["claude", "codex", "gemini"],
-                    "description": "Which session store to search. Omit to try Claude → Codex → Gemini."
+                    "description": "Which session store to search. Omit to try the current default agent first, then the others."
                 }
             },
             "required": ["session_id"]
@@ -304,6 +328,24 @@ def handle_tool_call(name, arguments):
         kind = result.get("agent_kind", "")
         kind_label = f"{kind.capitalize()} " if kind else ""
         return f"Resumed {kind_label}session `{sid}` in <#{tid}>."
+
+    elif name == "default_agent":
+        result = control_request("default_agent", arguments)
+        if "error" in result:
+            return result["error"]
+        agent = result.get("agent", "")
+        if "agent" not in (arguments or {}):
+            return f"Default agent: `{agent}`."
+        reset_count = result.get("reset_count", 0)
+        busy_count = result.get("busy_count", 0)
+        parts = [f"Default agent set to `{agent}`."]
+        if reset_count:
+            noun = "session" if reset_count == 1 else "sessions"
+            parts.append(f"Reset {reset_count} idle top-level {noun} immediately.")
+        if busy_count:
+            noun = "session" if busy_count == 1 else "sessions"
+            parts.append(f"{busy_count} busy top-level {noun} will switch after queued work finishes.")
+        return " ".join(parts)
 
     elif name == "restart_bot":
         result = control_request("restart")

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -21,13 +21,29 @@ from pathlib import Path
 
 # --- Configuration ---
 
-def app_config_dir():
-    xdg = os.environ.get("XDG_CONFIG_HOME", "")
-    if xdg:
-        return Path(xdg) / "discord-agents"
+def legacy_config_dir():
     home = os.environ.get("HOME", "")
     if home:
         return Path(home) / ".config" / "discord-agents"
+    return None
+
+def config_dir_has_state(config_dir):
+    if not config_dir.exists():
+        return False
+    state_files = ("config.json", "settings.json", "sessions.json", "control.sock")
+    return any((config_dir / name).exists() for name in state_files)
+
+def app_config_dir():
+    xdg = os.environ.get("XDG_CONFIG_HOME", "")
+    if xdg:
+        xdg_dir = Path(xdg) / "discord-agents"
+        legacy_dir = legacy_config_dir()
+        if not config_dir_has_state(xdg_dir) and legacy_dir and legacy_dir.exists():
+            return legacy_dir
+        return xdg_dir
+    legacy_dir = legacy_config_dir()
+    if legacy_dir:
+        return legacy_dir
     return Path(tempfile.gettempdir()) / f"discord-agents-{os.getuid()}"
 
 CONFIG_DIR = app_config_dir()
@@ -334,7 +350,7 @@ def handle_tool_call(name, arguments):
         if "error" in result:
             return result["error"]
         agent = result.get("agent", "")
-        if "agent" not in (arguments or {}):
+        if (arguments or {}).get("agent") is None:
             return f"Default agent: `{agent}`."
         reset_count = result.get("reset_count", 0)
         busy_count = result.get("busy_count", 0)

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,5 @@
 (tests
  (names test_formatting test_project test_agent_contracts test_discord_rest test_gateway
-  test_runtime_settings)
+  test_runtime_settings test_bot_defaults)
  (libraries discord_agents alcotest str unix yojson eio.mock eio_main cohttp-eio
   uri mirage-crypto-rng.unix))

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,5 @@
 (tests
- (names test_formatting test_project test_agent_contracts test_discord_rest test_gateway)
+ (names test_formatting test_project test_agent_contracts test_discord_rest test_gateway
+  test_runtime_settings)
  (libraries discord_agents alcotest str unix yojson eio.mock eio_main cohttp-eio
   uri mirage-crypto-rng.unix))

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -74,11 +74,13 @@ let with_test_bot f =
 
 let kind_string = Discord_agents.Config.string_of_agent_kind
 
-let make_session ?(processing=false) ?pending_agent_change agent_kind =
+let make_session ?(processing=false) ?session_override_kind
+    ?pending_agent_change agent_kind =
   let session = Discord_agents.Session_store.make_session
     ~project_name:"control"
     ~working_dir:"/tmp/project"
     ~agent_kind
+    ?session_override_kind
     ~session_id:"session-1"
     ~thread_id:"control"
     ~system_prompt:(Some "prompt")
@@ -199,6 +201,34 @@ let test_apply_pending_session_override_when_idle () =
     Discord_agents.Bot.maybe_apply_pending_session_agent_change bot session;
     let saved = find_control_session bot in
     Alcotest.(check string) "agent switched" "gemini" (kind_string saved.agent_kind);
+    Alcotest.(check (option string)) "session override persisted"
+      (Some "gemini")
+      (Option.map kind_string saved.session_override_kind);
+    Alcotest.(check bool) "fresh session id allocated"
+      true (saved.session_id <> original_session_id);
+    Alcotest.(check (option string)) "pending cleared"
+      None
+      (Option.map
+         (fun pending -> kind_string pending.Discord_agents.Session_store.kind)
+         saved.pending_agent_change))
+
+let test_apply_pending_same_kind_session_override_starts_fresh_session () =
+  with_test_bot (fun bot ->
+    let pending = Discord_agents.Session_store.{
+      kind = Discord_agents.Config.Codex;
+      origin = Session_override;
+    } in
+    let session =
+      make_session ~pending_agent_change:pending Discord_agents.Config.Codex
+    in
+    let original_session_id = session.session_id in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    Discord_agents.Bot.maybe_apply_pending_session_agent_change bot session;
+    let saved = find_control_session bot in
+    Alcotest.(check string) "agent unchanged" "codex" (kind_string saved.agent_kind);
+    Alcotest.(check (option string)) "session override persisted"
+      (Some "codex")
+      (Option.map kind_string saved.session_override_kind);
     Alcotest.(check bool) "fresh session id allocated"
       true (saved.session_id <> original_session_id);
     Alcotest.(check (option string)) "pending cleared"
@@ -242,6 +272,26 @@ let test_apply_pending_busy_session_leaves_pending_intact () =
     expect_pending saved
       ~kind:Discord_agents.Config.Gemini
       ~origin:Discord_agents.Session_store.Session_override)
+
+let test_reconcile_preserves_idle_session_override () =
+  with_test_bot (fun bot ->
+    bot.settings.default_agent <- Discord_agents.Config.Codex;
+    let session =
+      make_session
+        ~session_override_kind:(Some Discord_agents.Config.Gemini)
+        Discord_agents.Config.Gemini
+    in
+    let original_session_id = session.session_id in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    Discord_agents.Bot.reconcile_persisted_pending_agent_changes bot;
+    let saved = find_control_session bot in
+    Alcotest.(check string) "override agent preserved"
+      "gemini" (kind_string saved.agent_kind);
+    Alcotest.(check (option string)) "override still marked"
+      (Some "gemini")
+      (Option.map kind_string saved.session_override_kind);
+    Alcotest.(check string) "session id unchanged"
+      original_session_id saved.session_id)
 
 let test_reconcile_rotates_idle_session_to_default_agent () =
   with_test_bot (fun bot ->
@@ -288,8 +338,12 @@ let () =
         test_apply_pending_session_override_when_idle;
       Alcotest.test_case "same-kind pending clears" `Quick
         test_apply_pending_same_kind_clears_pending;
+      Alcotest.test_case "same-kind session override starts fresh session" `Quick
+        test_apply_pending_same_kind_session_override_starts_fresh_session;
       Alcotest.test_case "busy pending change stays pending" `Quick
         test_apply_pending_busy_session_leaves_pending_intact;
+      Alcotest.test_case "reconcile preserves idle session override" `Quick
+        test_reconcile_preserves_idle_session_override;
       Alcotest.test_case "reconcile rotates idle session to default" `Quick
         test_reconcile_rotates_idle_session_to_default_agent;
       Alcotest.test_case "reconcile applies persisted default rotation" `Quick

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -212,7 +212,7 @@ let test_apply_pending_session_override_when_idle () =
          (fun pending -> kind_string pending.Discord_agents.Session_store.kind)
          saved.pending_agent_change))
 
-let test_apply_pending_same_kind_session_override_starts_fresh_session () =
+let test_apply_pending_same_kind_session_override_pins_existing_session () =
   with_test_bot (fun bot ->
     let pending = Discord_agents.Session_store.{
       kind = Discord_agents.Config.Codex;
@@ -229,8 +229,8 @@ let test_apply_pending_same_kind_session_override_starts_fresh_session () =
     Alcotest.(check (option string)) "session override persisted"
       (Some "codex")
       (Option.map kind_string saved.session_override_kind);
-    Alcotest.(check bool) "fresh session id allocated"
-      true (saved.session_id <> original_session_id);
+    Alcotest.(check string) "session id unchanged"
+      original_session_id saved.session_id;
     Alcotest.(check (option string)) "pending cleared"
       None
       (Option.map
@@ -338,8 +338,8 @@ let () =
         test_apply_pending_session_override_when_idle;
       Alcotest.test_case "same-kind pending clears" `Quick
         test_apply_pending_same_kind_clears_pending;
-      Alcotest.test_case "same-kind session override starts fresh session" `Quick
-        test_apply_pending_same_kind_session_override_starts_fresh_session;
+      Alcotest.test_case "same-kind session override pins existing session" `Quick
+        test_apply_pending_same_kind_session_override_pins_existing_session;
       Alcotest.test_case "busy pending change stays pending" `Quick
         test_apply_pending_busy_session_leaves_pending_intact;
       Alcotest.test_case "reconcile preserves idle session override" `Quick

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -1,0 +1,298 @@
+(** Behavioral tests for default-agent and session-agent session transitions. *)
+
+let rec rm_rf path =
+  match Unix.lstat path with
+  | exception Unix.Unix_error (ENOENT, _, _) -> ()
+  | { Unix.st_kind = S_DIR; _ } ->
+    Sys.readdir path
+    |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+    Unix.rmdir path
+  | _ ->
+    Unix.unlink path
+
+let make_tmp_dir prefix =
+  let base = Filename.temp_file prefix "" in
+  Sys.remove base;
+  Unix.mkdir base 0o755;
+  base
+
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> Unix.putenv name ""
+
+let with_tmp_home f =
+  let base = make_tmp_dir "discord_agents_bot_" in
+  let old_home = Sys.getenv_opt "HOME" in
+  let old_xdg_config_home = Sys.getenv_opt "XDG_CONFIG_HOME" in
+  Fun.protect
+    ~finally:(fun () ->
+      restore_env "HOME" old_home;
+      restore_env "XDG_CONFIG_HOME" old_xdg_config_home;
+      rm_rf base)
+    (fun () ->
+      Unix.putenv "HOME" base;
+      Unix.putenv "XDG_CONFIG_HOME" "";
+      f ())
+
+let with_test_bot f =
+  with_tmp_home (fun () ->
+    Eio_main.run @@ fun env ->
+    Eio.Switch.run @@ fun sw ->
+      let settings : Discord_agents.Runtime_settings.t = {
+        default_agent = Discord_agents.Config.Claude;
+      } in
+      let config : Discord_agents.Config.t = {
+        Discord_agents.Config.default with
+        discord_token = "test-token";
+        control_channel_id = Some "control";
+      } in
+      let project_state : Discord_agents.Bot.project_state = {
+        projects = [];
+        channels = Discord_agents.Channel_manager.create ();
+      } in
+      let bot : Discord_agents.Bot.t = {
+        config;
+        settings;
+        rest = Discord_agents.Discord_rest.create ~sw ~env ~token:"test-token";
+        gateway = Discord_agents.Discord_gateway.create
+          ~token:"test-token"
+          ~intents:Discord_agents.Discord_gateway.default_intents
+          ~handler:(fun _ -> ());
+        project_state;
+        sessions = Discord_agents.Session_store.create ();
+        env;
+        sw;
+        started_at = Unix.gettimeofday ();
+        draining = false;
+        child_pids = (ref Discord_agents.Bot.Pid_set.empty, Mutex.create ());
+        wrap_width = Discord_agents.Agent_process.desktop_width;
+        refreshing = false;
+        output_lines = Discord_agents.Agent_process.default_output_lines;
+        scroll_states = Hashtbl.create 8;
+      } in
+      f bot)
+
+let kind_string = Discord_agents.Config.string_of_agent_kind
+
+let make_session ?(processing=false) ?pending_agent_change agent_kind =
+  let session = Discord_agents.Session_store.make_session
+    ~project_name:"control"
+    ~working_dir:"/tmp/project"
+    ~agent_kind
+    ~session_id:"session-1"
+    ~thread_id:"control"
+    ~system_prompt:(Some "prompt")
+    ~initial_prompt:None
+    ()
+  in
+  session.processing <- processing;
+  session.pending_agent_change <- pending_agent_change;
+  session
+
+let expect_pending session ~kind ~origin =
+  match session.Discord_agents.Session_store.pending_agent_change with
+  | Some pending ->
+    Alcotest.(check string) "pending kind"
+      (kind_string kind) (kind_string pending.kind);
+    let actual_origin =
+      Discord_agents.Session_store.string_of_pending_agent_origin pending.origin
+    in
+    let expected_origin =
+      Discord_agents.Session_store.string_of_pending_agent_origin origin
+    in
+    Alcotest.(check string) "pending origin" expected_origin actual_origin
+  | None ->
+    Alcotest.fail "expected a pending agent change"
+
+let find_control_session bot =
+  match Discord_agents.Session_store.find_opt bot.Discord_agents.Bot.sessions
+          ~thread_id:"control" with
+  | Some session -> session
+  | None -> Alcotest.fail "expected a control-channel session"
+
+let test_set_default_agent_defers_busy_control_session () =
+  with_test_bot (fun bot ->
+    let session = make_session ~processing:true Discord_agents.Config.Claude in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    match Discord_agents.Bot.set_default_agent bot
+            ~current_channel_id:(Some "control")
+            Discord_agents.Config.Codex with
+    | Error err -> Alcotest.failf "set_default_agent failed: %s" err
+    | Ok rotation ->
+      Alcotest.(check int) "reset count" 0 rotation.reset_count;
+      Alcotest.(check int) "busy count" 1 rotation.busy_count;
+      (match rotation.current_busy_kind with
+       | Some kind ->
+         Alcotest.(check string) "current busy kind"
+           "claude" (kind_string kind)
+       | None -> Alcotest.fail "expected current busy kind");
+      Alcotest.(check string) "default agent persisted"
+        "codex" (kind_string bot.settings.default_agent);
+      let saved = find_control_session bot in
+      Alcotest.(check string) "session stays on current agent"
+        "claude" (kind_string saved.agent_kind);
+      expect_pending saved
+        ~kind:Discord_agents.Config.Codex
+        ~origin:Discord_agents.Session_store.Default_rotation)
+
+let test_set_default_agent_preserves_explicit_session_override () =
+  with_test_bot (fun bot ->
+    let pending = Discord_agents.Session_store.{
+      kind = Discord_agents.Config.Gemini;
+      origin = Session_override;
+    } in
+    let session =
+      make_session ~processing:true ~pending_agent_change:pending
+        Discord_agents.Config.Claude
+    in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    match Discord_agents.Bot.set_default_agent bot
+            ~current_channel_id:(Some "control")
+            Discord_agents.Config.Codex with
+    | Error err -> Alcotest.failf "set_default_agent failed: %s" err
+    | Ok rotation ->
+      Alcotest.(check int) "busy count unchanged" 0 rotation.busy_count;
+      (match rotation.current_override_kind with
+       | Some kind ->
+         Alcotest.(check string) "current override kind"
+           "gemini" (kind_string kind)
+       | None -> Alcotest.fail "expected current override kind");
+      let saved = find_control_session bot in
+      expect_pending saved
+        ~kind:Discord_agents.Config.Gemini
+        ~origin:Discord_agents.Session_store.Session_override)
+
+let test_set_default_agent_clears_completed_default_rotation () =
+  with_test_bot (fun bot ->
+    let pending = Discord_agents.Session_store.{
+      kind = Discord_agents.Config.Codex;
+      origin = Default_rotation;
+    } in
+    let session =
+      make_session ~pending_agent_change:pending Discord_agents.Config.Codex
+    in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    match Discord_agents.Bot.set_default_agent bot
+            Discord_agents.Config.Codex with
+    | Error err -> Alcotest.failf "set_default_agent failed: %s" err
+    | Ok rotation ->
+      Alcotest.(check int) "reset count" 0 rotation.reset_count;
+      Alcotest.(check int) "busy count" 0 rotation.busy_count;
+      let saved = find_control_session bot in
+      Alcotest.(check (option string)) "pending cleared"
+        None
+        (Option.map
+           (fun pending -> kind_string pending.Discord_agents.Session_store.kind)
+           saved.pending_agent_change))
+
+let test_apply_pending_session_override_when_idle () =
+  with_test_bot (fun bot ->
+    let pending = Discord_agents.Session_store.{
+      kind = Discord_agents.Config.Gemini;
+      origin = Session_override;
+    } in
+    let session =
+      make_session ~pending_agent_change:pending Discord_agents.Config.Claude
+    in
+    let original_session_id = session.session_id in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    Discord_agents.Bot.maybe_apply_pending_session_agent_change bot session;
+    let saved = find_control_session bot in
+    Alcotest.(check string) "agent switched" "gemini" (kind_string saved.agent_kind);
+    Alcotest.(check bool) "fresh session id allocated"
+      true (saved.session_id <> original_session_id);
+    Alcotest.(check (option string)) "pending cleared"
+      None
+      (Option.map
+         (fun pending -> kind_string pending.Discord_agents.Session_store.kind)
+         saved.pending_agent_change))
+
+let test_apply_pending_same_kind_clears_pending () =
+  with_test_bot (fun bot ->
+    let pending = Discord_agents.Session_store.{
+      kind = Discord_agents.Config.Codex;
+      origin = Default_rotation;
+    } in
+    let session =
+      make_session ~pending_agent_change:pending Discord_agents.Config.Codex
+    in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    Discord_agents.Bot.maybe_apply_pending_session_agent_change bot session;
+    let saved = find_control_session bot in
+    Alcotest.(check (option string)) "pending cleared"
+      None
+      (Option.map
+         (fun pending -> kind_string pending.Discord_agents.Session_store.kind)
+         saved.pending_agent_change))
+
+let test_apply_pending_busy_session_leaves_pending_intact () =
+  with_test_bot (fun bot ->
+    let pending = Discord_agents.Session_store.{
+      kind = Discord_agents.Config.Gemini;
+      origin = Session_override;
+    } in
+    let session =
+      make_session ~processing:true ~pending_agent_change:pending
+        Discord_agents.Config.Claude
+    in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    Discord_agents.Bot.maybe_apply_pending_session_agent_change bot session;
+    let saved = find_control_session bot in
+    Alcotest.(check string) "agent unchanged" "claude" (kind_string saved.agent_kind);
+    expect_pending saved
+      ~kind:Discord_agents.Config.Gemini
+      ~origin:Discord_agents.Session_store.Session_override)
+
+let test_reconcile_rotates_idle_session_to_default_agent () =
+  with_test_bot (fun bot ->
+    bot.settings.default_agent <- Discord_agents.Config.Codex;
+    let session = make_session Discord_agents.Config.Claude in
+    let original_session_id = session.session_id in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    Discord_agents.Bot.reconcile_persisted_pending_agent_changes bot;
+    let saved = find_control_session bot in
+    Alcotest.(check string) "agent rotated" "codex" (kind_string saved.agent_kind);
+    Alcotest.(check bool) "fresh session id allocated"
+      true (saved.session_id <> original_session_id))
+
+let test_reconcile_applies_persisted_pending_default_rotation () =
+  with_test_bot (fun bot ->
+    bot.settings.default_agent <- Discord_agents.Config.Codex;
+    let pending = Discord_agents.Session_store.{
+      kind = Discord_agents.Config.Codex;
+      origin = Default_rotation;
+    } in
+    let session =
+      make_session ~pending_agent_change:pending Discord_agents.Config.Claude
+    in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    Discord_agents.Bot.reconcile_persisted_pending_agent_changes bot;
+    let saved = find_control_session bot in
+    Alcotest.(check string) "agent rotated" "codex" (kind_string saved.agent_kind);
+    Alcotest.(check (option string)) "pending cleared"
+      None
+      (Option.map
+         (fun pending -> kind_string pending.Discord_agents.Session_store.kind)
+         saved.pending_agent_change))
+
+let () =
+  Alcotest.run "bot_defaults" [
+    ("default agent", [
+      Alcotest.test_case "busy control session defers default rotation" `Quick
+        test_set_default_agent_defers_busy_control_session;
+      Alcotest.test_case "explicit session override survives default rotation" `Quick
+        test_set_default_agent_preserves_explicit_session_override;
+      Alcotest.test_case "completed default rotation gets cleared" `Quick
+        test_set_default_agent_clears_completed_default_rotation;
+      Alcotest.test_case "idle pending session override starts fresh session" `Quick
+        test_apply_pending_session_override_when_idle;
+      Alcotest.test_case "same-kind pending clears" `Quick
+        test_apply_pending_same_kind_clears_pending;
+      Alcotest.test_case "busy pending change stays pending" `Quick
+        test_apply_pending_busy_session_leaves_pending_intact;
+      Alcotest.test_case "reconcile rotates idle session to default" `Quick
+        test_reconcile_rotates_idle_session_to_default_agent;
+      Alcotest.test_case "reconcile applies persisted default rotation" `Quick
+        test_reconcile_applies_persisted_pending_default_rotation;
+    ]);
+  ]

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -1608,6 +1608,77 @@ let test_make_session_default_claude_confirmed () =
     "Claude default is confirmed (--session-id pins it)"
     true s.session_id_confirmed
 
+let test_pending_agent_kind_roundtrip () =
+  let session = Discord_agents.Session_store.make_session
+    ~project_name:"foo" ~working_dir:"/tmp/foo"
+    ~agent_kind:Discord_agents.Config.Claude
+    ~session_id:"caller-pinned"
+    ~thread_id:"123" ~system_prompt:None ~initial_prompt:None
+    ~pending_agent_change:(Some
+      Discord_agents.Session_store.{
+        kind = Discord_agents.Config.Codex;
+        origin = Session_override;
+      }) ()
+  in
+  let map =
+    Discord_agents.Session_store.SessionMap.empty
+    |> Discord_agents.Session_store.SessionMap.add "123" session
+  in
+  let json = Discord_agents.Session_store.sessions_to_json map in
+  let reparsed = Discord_agents.Session_store.sessions_of_json json in
+  let sessions = Discord_agents.Session_store.SessionMap.bindings reparsed in
+  match sessions with
+  | [(_, s)] ->
+    let pending_kind =
+      Option.map
+        (fun (pending : Discord_agents.Session_store.pending_agent_change) ->
+          Discord_agents.Config.string_of_agent_kind pending.kind)
+        s.pending_agent_change
+    in
+    let pending_origin =
+      Option.map
+        (fun (pending : Discord_agents.Session_store.pending_agent_change) ->
+          match pending.origin with
+          | Discord_agents.Session_store.Default_rotation -> "default_rotation"
+          | Discord_agents.Session_store.Session_override -> "session_override")
+        s.pending_agent_change
+    in
+    Alcotest.(check (option string))
+      "pending agent kind survives roundtrip"
+      (Some "codex") pending_kind;
+    Alcotest.(check (option string))
+      "pending agent origin survives roundtrip"
+      (Some "session_override") pending_origin
+  | _ -> Alcotest.fail "expected exactly one session"
+
+let test_legacy_pending_agent_defaults_to_default_rotation () =
+  let json = Yojson.Safe.from_string {|[
+    {"project_name":"foo","working_dir":"/tmp/foo",
+     "agent_kind":"claude","session_id":"abc","thread_id":"123",
+     "message_count":1,
+     "pending_agent_kind":"codex"}
+  ]|} in
+  let map = Discord_agents.Session_store.sessions_of_json json in
+  let sessions = Discord_agents.Session_store.SessionMap.bindings map in
+  match sessions with
+  | [(_, s)] ->
+    let pending =
+      match s.pending_agent_change with
+      | None -> Alcotest.fail "expected pending agent change"
+      | Some pending -> pending
+    in
+    Alcotest.(check string)
+      "legacy pending kind parsed"
+      "codex"
+      (Discord_agents.Config.string_of_agent_kind pending.kind);
+    Alcotest.(check string)
+      "legacy pending defaults to default rotation"
+      "default_rotation"
+      (match pending.origin with
+       | Discord_agents.Session_store.Default_rotation -> "default_rotation"
+       | Discord_agents.Session_store.Session_override -> "session_override")
+  | _ -> Alcotest.fail "expected exactly one session"
+
 let session_store_tests = [
   Alcotest.test_case "legacy Codex session unconfirmed" `Quick
     test_legacy_codex_session_defaults_unconfirmed;
@@ -1625,6 +1696,10 @@ let session_store_tests = [
     test_make_session_default_gemini_unconfirmed;
   Alcotest.test_case "fresh Claude default confirmed" `Quick
     test_make_session_default_claude_confirmed;
+  Alcotest.test_case "pending agent kind roundtrip" `Quick
+    test_pending_agent_kind_roundtrip;
+  Alcotest.test_case "legacy pending agent defaults to default rotation" `Quick
+    test_legacy_pending_agent_defaults_to_default_rotation;
 ]
 
 (* ── Bot.resume_not_found_message + Bot.merge_gemini_settings ───── *)

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -1981,6 +1981,7 @@ let test_context_header_truncates_utf8_boundary () =
     project_name = String.make 99 'p' ^ "\xC3\xA9tail";
     working_dir = "/tmp/project";
     agent_kind = Discord_agents.Config.Claude;
+    session_override_kind = None;
     session_id = "sid";
     session_id_confirmed = true;
     thread_id = "thread";
@@ -1988,6 +1989,7 @@ let test_context_header_truncates_utf8_boundary () =
     message_count = 0;
     processing = false;
     pending_queue = Queue.create ();
+    pending_agent_change = None;
     initial_prompt = None;
   } in
   let header =

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -1614,6 +1614,7 @@ let test_pending_agent_kind_roundtrip () =
     ~agent_kind:Discord_agents.Config.Claude
     ~session_id:"caller-pinned"
     ~thread_id:"123" ~system_prompt:None ~initial_prompt:None
+    ~session_override_kind:(Some Discord_agents.Config.Gemini)
     ~pending_agent_change:(Some
       Discord_agents.Session_store.{
         kind = Discord_agents.Config.Codex;
@@ -1643,6 +1644,11 @@ let test_pending_agent_kind_roundtrip () =
           | Discord_agents.Session_store.Session_override -> "session_override")
         s.pending_agent_change
     in
+    Alcotest.(check (option string))
+      "session override kind survives roundtrip"
+      (Some "gemini")
+      (Option.map Discord_agents.Config.string_of_agent_kind
+         s.session_override_kind);
     Alcotest.(check (option string))
       "pending agent kind survives roundtrip"
       (Some "codex") pending_kind;
@@ -1679,6 +1685,35 @@ let test_legacy_pending_agent_defaults_to_default_rotation () =
        | Discord_agents.Session_store.Session_override -> "session_override")
   | _ -> Alcotest.fail "expected exactly one session"
 
+let test_unknown_pending_agent_origin_defaults_to_default_rotation () =
+  let json = Yojson.Safe.from_string {|[
+    {"project_name":"foo","working_dir":"/tmp/foo",
+     "agent_kind":"claude","session_id":"abc","thread_id":"123",
+     "message_count":1,
+     "pending_agent_kind":"codex",
+     "pending_agent_origin":"future_origin"}
+  ]|} in
+  let map = Discord_agents.Session_store.sessions_of_json json in
+  let sessions = Discord_agents.Session_store.SessionMap.bindings map in
+  match sessions with
+  | [(_, s)] ->
+    let pending =
+      match s.pending_agent_change with
+      | None -> Alcotest.fail "expected pending agent change"
+      | Some pending -> pending
+    in
+    Alcotest.(check string)
+      "pending kind survives unknown origin"
+      "codex"
+      (Discord_agents.Config.string_of_agent_kind pending.kind);
+    Alcotest.(check string)
+      "unknown origin defaults to default rotation"
+      "default_rotation"
+      (match pending.origin with
+       | Discord_agents.Session_store.Default_rotation -> "default_rotation"
+       | Discord_agents.Session_store.Session_override -> "session_override")
+  | _ -> Alcotest.fail "expected exactly one session"
+
 let session_store_tests = [
   Alcotest.test_case "legacy Codex session unconfirmed" `Quick
     test_legacy_codex_session_defaults_unconfirmed;
@@ -1700,6 +1735,8 @@ let session_store_tests = [
     test_pending_agent_kind_roundtrip;
   Alcotest.test_case "legacy pending agent defaults to default rotation" `Quick
     test_legacy_pending_agent_defaults_to_default_rotation;
+  Alcotest.test_case "unknown pending origin defaults to default rotation" `Quick
+    test_unknown_pending_agent_origin_defaults_to_default_rotation;
 ]
 
 (* ── Bot.resume_not_found_message + Bot.merge_gemini_settings ───── *)

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -666,7 +666,11 @@ let cmd_testable =
       | List_claude_sessions -> "List_claude_sessions"
       | List_codex_sessions -> "List_codex_sessions"
       | List_gemini_sessions -> "List_gemini_sessions"
-      | Start_agent { project; _ } -> "Start_agent(" ^ project ^ ")"
+      | Start_agent { project; kind = None } ->
+        "Start_agent(" ^ project ^ ")"
+      | Start_agent { project; kind = Some k } ->
+        Printf.sprintf "Start_agent(%s,%s)"
+          project (Discord_agents.Config.string_of_agent_kind k)
       | Resume_session { session_id; kind = None } ->
         "Resume_session(" ^ session_id ^ ")"
       | Resume_session { session_id; kind = Some k } ->
@@ -674,6 +678,10 @@ let cmd_testable =
           (Discord_agents.Config.string_of_agent_kind k) session_id
       | Stop_session { thread_id } -> "Stop_session(" ^ thread_id ^ ")"
       | Cleanup_channels -> "Cleanup_channels"
+      | Default_agent None -> "Default_agent"
+      | Default_agent (Some k) ->
+        Printf.sprintf "Default_agent(%s)"
+          (Discord_agents.Config.string_of_agent_kind k)
       | Restart -> "Restart"
       | Refresh -> "Refresh"
       | Rename_thread _ -> "Rename_thread"
@@ -826,8 +834,37 @@ let test_parse_gemini_sessions () =
 let test_parse_start_gemini () =
   Alcotest.(check cmd_testable) "start project gemini"
     (Discord_agents.Command.Start_agent
-       { project = "myproj"; kind = Discord_agents.Config.Gemini })
+       { project = "myproj"; kind = Some Discord_agents.Config.Gemini })
     (Discord_agents.Command.parse "!start myproj gemini")
+
+let test_parse_start_default_agent () =
+  Alcotest.(check cmd_testable) "start project default agent"
+    (Discord_agents.Command.Start_agent
+       { project = "myproj"; kind = None })
+    (Discord_agents.Command.parse "!start myproj")
+
+let test_parse_default_agent_no_arg () =
+  Alcotest.(check cmd_testable) "default-agent no arg"
+    (Discord_agents.Command.Default_agent None)
+    (Discord_agents.Command.parse "!default-agent")
+
+let test_parse_default_agent_set () =
+  Alcotest.(check cmd_testable) "default-agent codex"
+    (Discord_agents.Command.Default_agent
+       (Some Discord_agents.Config.Codex))
+    (Discord_agents.Command.parse "!default-agent codex")
+
+let test_parse_default_agent_underscore_alias () =
+  Alcotest.(check cmd_testable) "default_agent alias"
+    (Discord_agents.Command.Default_agent
+       (Some Discord_agents.Config.Gemini))
+    (Discord_agents.Command.parse "!default_agent gemini")
+
+let test_parse_default_agent_invalid_kind () =
+  match Discord_agents.Command.parse "!default-agent nonesuch" with
+  | Discord_agents.Command.Unknown _ ->
+    Alcotest.(check pass) "invalid default agent is Unknown" () ()
+  | _ -> Alcotest.fail "expected Unknown for invalid default agent kind"
 
 let command_tests = [
   Alcotest.test_case "desktop" `Quick test_parse_desktop;
@@ -853,6 +890,11 @@ let command_tests = [
   Alcotest.test_case "gemini-sessions" `Quick test_parse_gemini_sessions;
   Alcotest.test_case "resume with codex kind" `Quick test_parse_resume_with_codex_kind;
   Alcotest.test_case "start with gemini kind" `Quick test_parse_start_gemini;
+  Alcotest.test_case "start with default agent" `Quick test_parse_start_default_agent;
+  Alcotest.test_case "default-agent no arg" `Quick test_parse_default_agent_no_arg;
+  Alcotest.test_case "default-agent set" `Quick test_parse_default_agent_set;
+  Alcotest.test_case "default_agent alias" `Quick test_parse_default_agent_underscore_alias;
+  Alcotest.test_case "default-agent invalid kind" `Quick test_parse_default_agent_invalid_kind;
 ]
 
 (* ── tool detail formatting ────────────────────────────────────── *)

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -682,6 +682,10 @@ let cmd_testable =
       | Default_agent (Some k) ->
         Printf.sprintf "Default_agent(%s)"
           (Discord_agents.Config.string_of_agent_kind k)
+      | Session_agent None -> "Session_agent"
+      | Session_agent (Some k) ->
+        Printf.sprintf "Session_agent(%s)"
+          (Discord_agents.Config.string_of_agent_kind k)
       | Restart -> "Restart"
       | Refresh -> "Refresh"
       | Rename_thread _ -> "Rename_thread"
@@ -866,6 +870,29 @@ let test_parse_default_agent_invalid_kind () =
     Alcotest.(check pass) "invalid default agent is Unknown" () ()
   | _ -> Alcotest.fail "expected Unknown for invalid default agent kind"
 
+let test_parse_session_agent_no_arg () =
+  Alcotest.(check cmd_testable) "session-agent no arg"
+    (Discord_agents.Command.Session_agent None)
+    (Discord_agents.Command.parse "!session-agent")
+
+let test_parse_session_agent_set () =
+  Alcotest.(check cmd_testable) "session-agent claude"
+    (Discord_agents.Command.Session_agent
+       (Some Discord_agents.Config.Claude))
+    (Discord_agents.Command.parse "!session-agent claude")
+
+let test_parse_session_agent_underscore_alias () =
+  Alcotest.(check cmd_testable) "session_agent alias"
+    (Discord_agents.Command.Session_agent
+       (Some Discord_agents.Config.Codex))
+    (Discord_agents.Command.parse "!session_agent codex")
+
+let test_parse_session_agent_invalid_kind () =
+  match Discord_agents.Command.parse "!session-agent nonesuch" with
+  | Discord_agents.Command.Unknown _ ->
+    Alcotest.(check pass) "invalid session agent is Unknown" () ()
+  | _ -> Alcotest.fail "expected Unknown for invalid session agent kind"
+
 let command_tests = [
   Alcotest.test_case "desktop" `Quick test_parse_desktop;
   Alcotest.test_case "mobile" `Quick test_parse_mobile;
@@ -895,6 +922,10 @@ let command_tests = [
   Alcotest.test_case "default-agent set" `Quick test_parse_default_agent_set;
   Alcotest.test_case "default_agent alias" `Quick test_parse_default_agent_underscore_alias;
   Alcotest.test_case "default-agent invalid kind" `Quick test_parse_default_agent_invalid_kind;
+  Alcotest.test_case "session-agent no arg" `Quick test_parse_session_agent_no_arg;
+  Alcotest.test_case "session-agent set" `Quick test_parse_session_agent_set;
+  Alcotest.test_case "session_agent alias" `Quick test_parse_session_agent_underscore_alias;
+  Alcotest.test_case "session-agent invalid kind" `Quick test_parse_session_agent_invalid_kind;
 ]
 
 (* ── tool detail formatting ────────────────────────────────────── *)

--- a/test/test_runtime_settings.ml
+++ b/test/test_runtime_settings.ml
@@ -20,7 +20,7 @@ let with_tmp_home f =
     ~finally:(fun () ->
       (match old_home with
        | Some home -> Unix.putenv "HOME" home
-       | None -> Unix.unsetenv "HOME");
+       | None -> Unix.putenv "HOME" "");
       rm_rf base)
     (fun () -> f base)
 

--- a/test/test_runtime_settings.ml
+++ b/test/test_runtime_settings.ml
@@ -10,19 +10,37 @@ let rec rm_rf path =
   | _ ->
     Unix.unlink path
 
-let with_tmp_home f =
-  let base = Filename.temp_file "discord_agents_home_" "" in
+let make_tmp_dir prefix =
+  let base = Filename.temp_file prefix "" in
   Sys.remove base;
   Unix.mkdir base 0o755;
+  base
+
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> Unix.putenv name ""
+
+let with_tmp_env ?home ?xdg_config_home f =
   let old_home = Sys.getenv_opt "HOME" in
-  Unix.putenv "HOME" base;
+  let old_xdg_config_home = Sys.getenv_opt "XDG_CONFIG_HOME" in
+  (match home with
+   | Some value -> Unix.putenv "HOME" value
+   | None -> Unix.putenv "HOME" "");
+  (match xdg_config_home with
+   | Some value -> Unix.putenv "XDG_CONFIG_HOME" value
+   | None -> Unix.putenv "XDG_CONFIG_HOME" "");
   Fun.protect
     ~finally:(fun () ->
-      (match old_home with
-       | Some home -> Unix.putenv "HOME" home
-       | None -> Unix.putenv "HOME" "");
-      rm_rf base)
-    (fun () -> f base)
+      restore_env "HOME" old_home;
+      restore_env "XDG_CONFIG_HOME" old_xdg_config_home)
+    f
+
+let with_tmp_home f =
+  let base = make_tmp_dir "discord_agents_home_" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base)
+    (fun () ->
+      with_tmp_env ~home:base ~xdg_config_home:"" (fun () -> f base))
 
 let test_load_defaults_to_claude () =
   with_tmp_home (fun _home ->
@@ -43,6 +61,41 @@ let test_save_and_reload_roundtrip () =
         "codex"
         (Discord_agents.Config.string_of_agent_kind reloaded.default_agent))
 
+let test_load_uses_backup_when_primary_corrupt () =
+  with_tmp_home (fun home ->
+    let settings = Discord_agents.Runtime_settings.load () in
+    match Discord_agents.Runtime_settings.set_default_agent
+            settings Discord_agents.Config.Codex with
+    | Error err -> Alcotest.failf "save failed: %s" err
+    | Ok () ->
+      let settings_path =
+        Filename.concat home ".config/discord-agents/settings.json"
+      in
+      let oc = open_out settings_path in
+      output_string oc "{ definitely not json";
+      close_out oc;
+      let recovered = Discord_agents.Runtime_settings.load () in
+      Alcotest.(check string) "recovered default agent"
+        "codex"
+        (Discord_agents.Config.string_of_agent_kind recovered.default_agent))
+
+let test_xdg_config_home_without_home () =
+  let xdg_root = make_tmp_dir "discord_agents_xdg_" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf xdg_root)
+    (fun () ->
+      with_tmp_env ~home:"" ~xdg_config_home:xdg_root (fun () ->
+        let settings = Discord_agents.Runtime_settings.load () in
+        match Discord_agents.Runtime_settings.set_default_agent
+                settings Discord_agents.Config.Gemini with
+        | Error err -> Alcotest.failf "save failed: %s" err
+        | Ok () ->
+          let reloaded = Discord_agents.Runtime_settings.load () in
+          Alcotest.(check string) "saved default agent via xdg"
+            "gemini"
+            (Discord_agents.Config.string_of_agent_kind
+               reloaded.default_agent)))
+
 let () =
   Alcotest.run "runtime_settings" [
     ("settings", [
@@ -50,5 +103,9 @@ let () =
         test_load_defaults_to_claude;
       Alcotest.test_case "save and reload roundtrip" `Quick
         test_save_and_reload_roundtrip;
+      Alcotest.test_case "load uses backup when primary corrupt" `Quick
+        test_load_uses_backup_when_primary_corrupt;
+      Alcotest.test_case "xdg config home without home" `Quick
+        test_xdg_config_home_without_home;
     ]);
   ]

--- a/test/test_runtime_settings.ml
+++ b/test/test_runtime_settings.ml
@@ -1,0 +1,54 @@
+(** Tests for persisted runtime settings. *)
+
+let rec rm_rf path =
+  match Unix.lstat path with
+  | exception Unix.Unix_error (ENOENT, _, _) -> ()
+  | { Unix.st_kind = S_DIR; _ } ->
+    Sys.readdir path
+    |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+    Unix.rmdir path
+  | _ ->
+    Unix.unlink path
+
+let with_tmp_home f =
+  let base = Filename.temp_file "discord_agents_home_" "" in
+  Sys.remove base;
+  Unix.mkdir base 0o755;
+  let old_home = Sys.getenv_opt "HOME" in
+  Unix.putenv "HOME" base;
+  Fun.protect
+    ~finally:(fun () ->
+      (match old_home with
+       | Some home -> Unix.putenv "HOME" home
+       | None -> Unix.putenv "HOME" "");
+      rm_rf base)
+    (fun () -> f base)
+
+let test_load_defaults_to_claude () =
+  with_tmp_home (fun _home ->
+    let settings = Discord_agents.Runtime_settings.load () in
+    Alcotest.(check string) "default agent"
+      "claude"
+      (Discord_agents.Config.string_of_agent_kind settings.default_agent))
+
+let test_save_and_reload_roundtrip () =
+  with_tmp_home (fun _home ->
+    let settings = Discord_agents.Runtime_settings.load () in
+    match Discord_agents.Runtime_settings.set_default_agent
+            settings Discord_agents.Config.Codex with
+    | Error err -> Alcotest.failf "save failed: %s" err
+    | Ok () ->
+      let reloaded = Discord_agents.Runtime_settings.load () in
+      Alcotest.(check string) "saved default agent"
+        "codex"
+        (Discord_agents.Config.string_of_agent_kind reloaded.default_agent))
+
+let () =
+  Alcotest.run "runtime_settings" [
+    ("settings", [
+      Alcotest.test_case "load defaults to claude" `Quick
+        test_load_defaults_to_claude;
+      Alcotest.test_case "save and reload roundtrip" `Quick
+        test_save_and_reload_roundtrip;
+    ]);
+  ]

--- a/test/test_runtime_settings.ml
+++ b/test/test_runtime_settings.ml
@@ -96,6 +96,33 @@ let test_xdg_config_home_without_home () =
             (Discord_agents.Config.string_of_agent_kind
                reloaded.default_agent)))
 
+let test_xdg_falls_back_to_existing_legacy_home () =
+  let home = make_tmp_dir "discord_agents_home_" in
+  let xdg_root = make_tmp_dir "discord_agents_xdg_" in
+  Fun.protect
+    ~finally:(fun () ->
+      rm_rf xdg_root;
+      rm_rf home)
+    (fun () ->
+      with_tmp_env ~home ~xdg_config_home:xdg_root (fun () ->
+        let legacy_dir =
+          Filename.concat home ".config/discord-agents"
+        in
+        Unix.mkdir (Filename.concat xdg_root "discord-agents") 0o755;
+        let legacy_settings =
+          Filename.concat legacy_dir "settings.json"
+        in
+        Discord_agents.Resource.write_file_atomic legacy_settings
+          {|{"default_agent":"codex"}|};
+        Alcotest.(check string) "config dir"
+          legacy_dir
+          (Discord_agents.Resource.app_config_dir ());
+        let settings = Discord_agents.Runtime_settings.load () in
+        Alcotest.(check string) "legacy default agent"
+          "codex"
+          (Discord_agents.Config.string_of_agent_kind
+             settings.default_agent)))
+
 let () =
   Alcotest.run "runtime_settings" [
     ("settings", [
@@ -107,5 +134,7 @@ let () =
         test_load_uses_backup_when_primary_corrupt;
       Alcotest.test_case "xdg config home without home" `Quick
         test_xdg_config_home_without_home;
+      Alcotest.test_case "xdg falls back to existing legacy home" `Quick
+        test_xdg_falls_back_to_existing_legacy_home;
     ]);
   ]

--- a/test/test_runtime_settings.ml
+++ b/test/test_runtime_settings.ml
@@ -20,7 +20,7 @@ let with_tmp_home f =
     ~finally:(fun () ->
       (match old_home with
        | Some home -> Unix.putenv "HOME" home
-       | None -> Unix.putenv "HOME" "");
+       | None -> Unix.unsetenv "HOME");
       rm_rf base)
     (fun () -> f base)
 


### PR DESCRIPTION
## Summary
- add a persisted runtime settings store for the bot default agent
- add `!default-agent` / `!default_agent` and use the setting for new top-level sessions
- prefer the configured default when starting or resuming sessions without an explicit agent
- reset an idle control/project channel session when the default changes so the next message uses the new agent

## Validation
- nix develop --command dune build
- nix develop --command dune runtest

## Follow-up
- #39 Make bot restart crash-only and replayable
- #40 Harden disk-pressure handling and fault-injection coverage
- #42 Auto-switch to a rescue agent under disk pressure