### PR TITLE
Harden REST transport retries and health

### DIFF
--- a/lib/agent_runner.ml
+++ b/lib/agent_runner.ml
@@ -56,7 +56,12 @@ let format_tool_status (info : Agent_process.tool_info) =
     prompt injection via user-controlled fields like thread names. *)
 let sanitize_context_value s =
   let max_len = 100 in
-  let s = if String.length s > max_len then String.sub s 0 max_len else s in
+  let s =
+    if String.length s > max_len then
+      Resource.truncate_utf8 ~max_bytes:max_len s
+    else
+      s
+  in
   String.init (String.length s) (fun i ->
     match s.[i] with
     | '\n' | '\r' | '\t' -> ' '

--- a/lib/agent_runner.ml
+++ b/lib/agent_runner.ml
@@ -80,6 +80,12 @@ let build_context_header ~(session : Session_store.session) ~author_name
     channel_type
     (sanitize_context_value author_name)
 
+let prompt_preview prompt =
+  if String.length prompt > 80 then
+    Resource.truncate_utf8 ~max_bytes:80 prompt ^ "..."
+  else
+    prompt
+
 (** Download attachments to temp files in the working directory.
     Returns a list of (filename, local_path) for successfully downloaded files. *)
 let download_attachments ~rest ~working_dir
@@ -145,9 +151,7 @@ let run ~sw ~env ~rest ~session ~(channel_id : Discord_types.channel_id)
   Logs.info (fun m -> m "agent_runner: running %s for %s: %s"
     (Config.string_of_agent_kind session.Session_store.agent_kind)
     session.project_name
-    (if String.length prompt > 80
-     then String.sub prompt 0 80 ^ "..."
-     else prompt));
+    (prompt_preview prompt));
   let result_buf = Buffer.create 4096 in
   let current_msg_id = ref None in
   let current_msg_buf = Buffer.create 1900 in

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -42,12 +42,27 @@ let error_response msg =
 
 let handle_health (bot : Bot.t) =
   let uptime = int_of_float (Unix.gettimeofday () -. bot.started_at) in
-  ok_response [
+  let rest_fields = [
+    ("rest_degraded", `Bool (Discord_rest.transport_degraded bot.rest));
+    ("rest_consecutive_transport_failures",
+     `Int (Discord_rest.consecutive_transport_failures bot.rest));
+    ("rest_retry_delay_ms",
+     `Int (int_of_float (1000.0 *. Discord_rest.transport_retry_delay_s bot.rest)));
+  ] in
+  let optional_rest_fields =
+    match Discord_rest.last_transport_error bot.rest with
+    | Some err ->
+      [("last_rest_transport_error",
+        `String (Resource.truncate_utf8 ~max_bytes:1000
+          (Resource.single_line err)))]
+    | None -> []
+  in
+  ok_response ([
     ("uptime_seconds", `Int uptime);
     ("sessions", `Int (Session_store.count bot.sessions));
     ("projects", `Int (List.length (Bot.projects bot)));
     ("channels", `Int (Channel_manager.count (Bot.channels bot)));
-  ]
+  ] @ rest_fields @ optional_rest_fields)
 
 let handle_list_projects (bot : Bot.t) =
   let projects = List.map (fun (p : Project.t) ->

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -58,7 +58,7 @@ let handle_health (bot : Bot.t) =
   let optional_error_field key err =
     [
       (key, `String (Resource.truncate_utf8 ~max_bytes:1000
-        (Resource.single_line err)));
+        (Resource.sanitize_utf8 (Resource.single_line err))));
     ]
   in
   let optional_rest_fields =

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -228,7 +228,10 @@ let handle_start_session (bot : Bot.t) params =
       let thread_display_name = match thread_name with
         | Some n when String.length (String.trim n) > 0 ->
           let n = String.trim n in
-          if String.length n > 80 then String.sub n 0 80 else n
+          if String.length n > 80 then
+            Resource.truncate_utf8 ~max_bytes:80 n
+          else
+            n
         | _ -> Printf.sprintf "%s / %s" kind_str p.name
       in
       let thread_parent =

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -42,19 +42,25 @@ let error_response msg =
 
 let handle_health (bot : Bot.t) =
   let uptime = int_of_float (Unix.gettimeofday () -. bot.started_at) in
+  let rest_failures = Discord_rest.consecutive_rest_failures bot.rest in
   let rest_fields = [
-    ("rest_degraded", `Bool (Discord_rest.transport_degraded bot.rest));
-    ("rest_consecutive_transport_failures",
-     `Int (Discord_rest.consecutive_transport_failures bot.rest));
+    ("rest_degraded", `Bool (Discord_rest.rest_degraded bot.rest));
+    ("rest_consecutive_failures", `Int rest_failures);
+    ("rest_consecutive_transport_failures", `Int rest_failures);
     ("rest_retry_delay_ms",
-     `Int (int_of_float (1000.0 *. Discord_rest.transport_retry_delay_s bot.rest)));
+     `Int (int_of_float (1000.0 *. Discord_rest.rest_retry_delay_s bot.rest)));
   ] in
   let optional_rest_fields =
-    match Discord_rest.last_transport_error bot.rest with
+    match Discord_rest.last_rest_error bot.rest with
     | Some err ->
-      [("last_rest_transport_error",
+      let err =
         `String (Resource.truncate_utf8 ~max_bytes:1000
-          (Resource.single_line err)))]
+          (Resource.single_line err))
+      in
+      [
+        ("last_rest_error", err);
+        ("last_rest_transport_error", err);
+      ]
     | None -> []
   in
   ok_response ([

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -43,24 +43,32 @@ let error_response msg =
 let handle_health (bot : Bot.t) =
   let uptime = int_of_float (Unix.gettimeofday () -. bot.started_at) in
   let rest_failures = Discord_rest.consecutive_rest_failures bot.rest in
+  let transport_failures =
+    Discord_rest.consecutive_transport_failures bot.rest
+  in
   let rest_fields = [
     ("rest_degraded", `Bool (Discord_rest.rest_degraded bot.rest));
     ("rest_consecutive_failures", `Int rest_failures);
-    ("rest_consecutive_transport_failures", `Int rest_failures);
+    ("rest_transport_degraded",
+     `Bool (Discord_rest.transport_degraded bot.rest));
+    ("rest_consecutive_transport_failures", `Int transport_failures);
     ("rest_retry_delay_ms",
      `Int (int_of_float (1000.0 *. Discord_rest.rest_retry_delay_s bot.rest)));
   ] in
+  let optional_error_field key err =
+    [
+      (key, `String (Resource.truncate_utf8 ~max_bytes:1000
+        (Resource.single_line err)));
+    ]
+  in
   let optional_rest_fields =
     match Discord_rest.last_rest_error bot.rest with
-    | Some err ->
-      let err =
-        `String (Resource.truncate_utf8 ~max_bytes:1000
-          (Resource.single_line err))
-      in
-      [
-        ("last_rest_error", err);
-        ("last_rest_transport_error", err);
-      ]
+    | Some err -> optional_error_field "last_rest_error" err
+    | None -> []
+  in
+  let optional_transport_fields =
+    match Discord_rest.last_transport_error bot.rest with
+    | Some err -> optional_error_field "last_rest_transport_error" err
     | None -> []
   in
   ok_response ([
@@ -68,7 +76,7 @@ let handle_health (bot : Bot.t) =
     ("sessions", `Int (Session_store.count bot.sessions));
     ("projects", `Int (List.length (Bot.projects bot)));
     ("channels", `Int (Channel_manager.count (Bot.channels bot)));
-  ] @ rest_fields @ optional_rest_fields)
+  ] @ rest_fields @ optional_rest_fields @ optional_transport_fields)
 
 let handle_list_projects (bot : Bot.t) =
   let projects = List.map (fun (p : Project.t) ->

--- a/lib/discord_rest.ml
+++ b/lib/discord_rest.ml
@@ -11,6 +11,10 @@ open Discord_types
 
 let api_base = "https://discord.com/api/v10"
 
+type backoff_source =
+  | Transport_backoff
+  | Rest_backoff
+
 type t = {
   token : string;
   call : http_call;
@@ -33,6 +37,7 @@ and health_state = {
   mutable last_transport_error : string option;
   mutable consecutive_transport_failures : int;
   mutable backoff_until : Mtime.t option;
+  mutable backoff_source : backoff_source option;
 }
 
 type retry_mode =
@@ -147,6 +152,7 @@ let create_health_state () =
     last_transport_error = None;
     consecutive_transport_failures = 0;
     backoff_until = None;
+    backoff_source = None;
   }
 
 let health_retry_delay_s ~now state =
@@ -177,7 +183,16 @@ let health_consecutive_transport_failures state =
 let effective_backoff_delay_s ~now state =
   health_retry_delay_s ~now state
 
-let note_failure_state state ~now ~summary ~delay =
+let active_rest_backoff ~now state =
+  match state.backoff_source, state.backoff_until with
+  | Some Rest_backoff, Some until when Mtime.compare now until < 0 -> true
+  | _ -> false
+
+let clear_backoff state =
+  state.backoff_until <- None;
+  state.backoff_source <- None
+
+let note_failure_state ?(source = Rest_backoff) state ~now ~summary ~delay =
   let failures =
     min max_recorded_failures (state.consecutive_failures + 1)
   in
@@ -185,6 +200,7 @@ let note_failure_state state ~now ~summary ~delay =
   state.consecutive_failures <- failures;
   state.backoff_until <-
     Some (next_backoff_until ~now ~current_until:state.backoff_until ~delay);
+  state.backoff_source <- Some source;
   effective_backoff_delay_s ~now state
 
 let note_failure_without_backoff_state state ~now ~summary =
@@ -196,7 +212,9 @@ let note_failure_without_backoff_state state ~now ~summary =
   effective_backoff_delay_s ~now state
 
 let note_transport_failure_state state ~now ~summary ~delay =
-  let delay = note_failure_state state ~now ~summary ~delay in
+  let delay =
+    note_failure_state ~source:Transport_backoff state ~now ~summary ~delay
+  in
   state.last_transport_error <- Some summary;
   state.consecutive_transport_failures <-
     min max_recorded_failures (state.consecutive_transport_failures + 1);
@@ -215,21 +233,27 @@ let note_rate_limit_state state ~now ~summary ~delay =
     min max_recorded_failures (state.consecutive_failures + 1);
   state.backoff_until <-
     Some (next_backoff_until ~now ~current_until:state.backoff_until ~delay);
+  state.backoff_source <- Some Rest_backoff;
   effective_backoff_delay_s ~now state
 
-let note_recovery_state state =
+let note_recovery_state state ~now =
   let failures = state.consecutive_failures in
-  state.last_error <- None;
-  state.consecutive_failures <- 0;
+  let active_rest_backoff = active_rest_backoff ~now state in
+  if not active_rest_backoff then begin
+    state.last_error <- None;
+    state.consecutive_failures <- 0;
+    clear_backoff state
+  end;
   state.last_transport_error <- None;
   state.consecutive_transport_failures <- 0;
-  state.backoff_until <- None;
   failures
 
 let note_transport_response_state state =
   let failures = state.consecutive_transport_failures in
   state.last_transport_error <- None;
   state.consecutive_transport_failures <- 0;
+  if state.backoff_source = Some Transport_backoff then
+    clear_backoff state;
   failures
 
 (* REST state closures must stay effect-free: no sleeps, logging, I/O, or
@@ -271,9 +295,10 @@ let consecutive_rest_failures t =
     health_consecutive_failures state)
 
 let note_rest_recovery t =
+  let now = now_s t in
   let failures =
     with_rest_state t (fun state ->
-      note_recovery_state state)
+      note_recovery_state state ~now)
   in
   if failures > 0 then
     Logs.info (fun m -> m "REST recovered after %d failure(s)"
@@ -655,6 +680,7 @@ let request ?(retry_mode = No_retry) t ~meth ~path ?body () =
         ignore (note_http_client_failure t ~host ~code ~body:body_str);
         handle_response code body_str
       end else if response_clears_rest_health code then begin
+        note_transport_response t;
         note_rest_recovery t;
         handle_response code body_str
       end else begin

--- a/lib/discord_rest.ml
+++ b/lib/discord_rest.ml
@@ -283,7 +283,14 @@ let request ?(retry_mode = No_retry) t ~meth ~path ?body () =
   let handle_response code body_str =
     if code >= 200 && code < 300 then begin
       if String.length body_str = 0 then Ok `Null
-      else Ok (Yojson.Safe.from_string body_str)
+      else
+        try Ok (Yojson.Safe.from_string body_str)
+        with exn ->
+          Logs.warn (fun m ->
+            m "REST %s %s: response parse error: %s"
+              meth_str path (Printexc.to_string exn));
+          Error (Printf.sprintf "discord REST %s %s: response parse error %s"
+            meth_str path (body_snippet (Printexc.to_string exn)))
     end else begin
       (* Log the full body (up to truncate_for_log's cap) centrally for
          operator debugging, and include a short body snippet in the
@@ -586,16 +593,13 @@ let get_channel t ~(channel_id : Discord_types.channel_id) () =
     Returns the raw bytes on success. *)
 let download_url t ~url () =
   let uri = Uri.of_string url in
-  let host = Uri.host uri |> Option.value ~default:"<unknown>" in
   let headers = Http.Header.of_list [
     ("User-Agent", "DiscordBot (discord-agents/0.1.0, OCaml)");
   ] in
   let rec loop attempt =
-    wait_for_transport_backoff t;
     try
       let (resp, body) =
         Cohttp_eio.Client.call t.client ~sw:t.sw ~headers `GET uri in
-      note_transport_recovery t;
       let status = Http.Response.status resp in
       let code = Http.Status.to_int status in
       let body_str = read_body body in
@@ -611,7 +615,13 @@ let download_url t ~url () =
         Error (Printf.sprintf "download_url %s: HTTP %d" url code)
     with exn ->
       raise_if_cancelled exn;
-      let (summary, delay) = note_transport_failure t ~host exn in
+      let summary =
+        Printf.sprintf "kind=%s error=%s"
+          (classify_transport_error_message (Printexc.to_string exn)
+           |> string_of_transport_error_kind)
+          (Printexc.to_string exn)
+      in
+      let delay = transport_backoff_seconds attempt in
       if attempt < max_transient_attempts then begin
         Logs.warn (fun m ->
           m "download_url %s: transport failure on attempt %d/%d, retrying in %.1fs (%s)"

--- a/lib/discord_rest.ml
+++ b/lib/discord_rest.ml
@@ -36,8 +36,8 @@ and health_state = {
   mutable consecutive_failures : int;
   mutable last_transport_error : string option;
   mutable consecutive_transport_failures : int;
-  mutable backoff_until : Mtime.t option;
-  mutable backoff_source : backoff_source option;
+  mutable rest_backoff_until : Mtime.t option;
+  mutable transport_backoff_until : Mtime.t option;
 }
 
 type retry_mode =
@@ -126,7 +126,7 @@ let clamp_retry_after_seconds delay =
   if finite_float delay then Some (min max_retry_after_s (max 0.0 delay))
   else None
 
-let next_backoff_until ~now ~current_until ~delay =
+let backoff_candidate_until ~now ~delay =
   let delay =
     match clamp_retry_after_seconds delay with
     | Some delay -> delay
@@ -141,6 +141,10 @@ let next_backoff_until ~now ~current_until ~delay =
     | Some ts -> ts
     | None -> Mtime.max_stamp
   in
+  candidate
+
+let next_backoff_until ~now ~current_until ~delay =
+  let candidate = backoff_candidate_until ~now ~delay in
   match current_until with
   | Some current when Mtime.is_later current ~than:candidate -> current
   | _ -> candidate
@@ -151,16 +155,20 @@ let create_health_state () =
     consecutive_failures = 0;
     last_transport_error = None;
     consecutive_transport_failures = 0;
-    backoff_until = None;
-    backoff_source = None;
+    rest_backoff_until = None;
+    transport_backoff_until = None;
   }
 
-let health_retry_delay_s ~now state =
-  match state.backoff_until with
+let retry_delay_until_s ~now = function
   | None -> 0.0
   | Some until when Mtime.compare now until >= 0 -> 0.0
   | Some until ->
     Int64.to_float (Mtime.Span.to_uint64_ns (Mtime.span now until)) /. 1e9
+
+let health_retry_delay_s ~now state =
+  max
+    (retry_delay_until_s ~now state.rest_backoff_until)
+    (retry_delay_until_s ~now state.transport_backoff_until)
 
 let health_degraded state =
   state.consecutive_failures > 0
@@ -184,13 +192,21 @@ let effective_backoff_delay_s ~now state =
   health_retry_delay_s ~now state
 
 let active_rest_backoff ~now state =
-  match state.backoff_source, state.backoff_until with
-  | Some Rest_backoff, Some until when Mtime.compare now until < 0 -> true
+  match state.rest_backoff_until with
+  | Some until when Mtime.compare now until < 0 -> true
   | _ -> false
 
-let clear_backoff state =
-  state.backoff_until <- None;
-  state.backoff_source <- None
+let set_backoff_deadline current_until ~now ~delay =
+  Some (next_backoff_until ~now ~current_until ~delay)
+
+let set_backoff state ~now ~source ~delay =
+  match source with
+  | Rest_backoff ->
+    state.rest_backoff_until <-
+      set_backoff_deadline state.rest_backoff_until ~now ~delay
+  | Transport_backoff ->
+    state.transport_backoff_until <-
+      set_backoff_deadline state.transport_backoff_until ~now ~delay
 
 let note_failure_state ?(source = Rest_backoff) state ~now ~summary ~delay =
   let failures =
@@ -198,9 +214,7 @@ let note_failure_state ?(source = Rest_backoff) state ~now ~summary ~delay =
   in
   state.last_error <- Some summary;
   state.consecutive_failures <- failures;
-  state.backoff_until <-
-    Some (next_backoff_until ~now ~current_until:state.backoff_until ~delay);
-  state.backoff_source <- Some source;
+  set_backoff state ~now ~source ~delay;
   effective_backoff_delay_s ~now state
 
 let note_failure_without_backoff_state state ~now ~summary =
@@ -212,9 +226,14 @@ let note_failure_without_backoff_state state ~now ~summary =
   effective_backoff_delay_s ~now state
 
 let note_transport_failure_state state ~now ~summary ~delay =
-  let delay =
-    note_failure_state ~source:Transport_backoff state ~now ~summary ~delay
+  let failures =
+    min max_recorded_failures (state.consecutive_failures + 1)
   in
+  if not (active_rest_backoff ~now state) then
+    state.last_error <- Some summary;
+  state.consecutive_failures <- failures;
+  set_backoff state ~now ~source:Transport_backoff ~delay;
+  let delay = effective_backoff_delay_s ~now state in
   state.last_transport_error <- Some summary;
   state.consecutive_transport_failures <-
     min max_recorded_failures (state.consecutive_transport_failures + 1);
@@ -231,9 +250,7 @@ let note_rate_limit_state state ~now ~summary ~delay =
   state.last_error <- Some summary;
   state.consecutive_failures <-
     min max_recorded_failures (state.consecutive_failures + 1);
-  state.backoff_until <-
-    Some (next_backoff_until ~now ~current_until:state.backoff_until ~delay);
-  state.backoff_source <- Some Rest_backoff;
+  set_backoff state ~now ~source:Rest_backoff ~delay;
   effective_backoff_delay_s ~now state
 
 let note_recovery_state state ~now =
@@ -242,18 +259,15 @@ let note_recovery_state state ~now =
   if not active_rest_backoff then begin
     state.last_error <- None;
     state.consecutive_failures <- 0;
-    clear_backoff state
+    state.rest_backoff_until <- None
   end;
-  state.last_transport_error <- None;
-  state.consecutive_transport_failures <- 0;
   failures
 
 let note_transport_response_state state =
   let failures = state.consecutive_transport_failures in
   state.last_transport_error <- None;
   state.consecutive_transport_failures <- 0;
-  if state.backoff_source = Some Transport_backoff then
-    clear_backoff state;
+  state.transport_backoff_until <- None;
   failures
 
 (* REST state closures must stay effect-free: no sleeps, logging, I/O, or
@@ -296,11 +310,12 @@ let consecutive_rest_failures t =
 
 let note_rest_recovery t =
   let now = now_s t in
-  let failures =
+  let (failures, recovered) =
     with_rest_state t (fun state ->
-      note_recovery_state state ~now)
+      let failures = note_recovery_state state ~now in
+      (failures, not (health_degraded state)))
   in
-  if failures > 0 then
+  if failures > 0 && recovered then
     Logs.info (fun m -> m "REST recovered after %d failure(s)"
       failures)
 

--- a/lib/discord_rest.ml
+++ b/lib/discord_rest.ml
@@ -100,6 +100,13 @@ let classify_transport_error_message msg =
           || string_contains msg "connection aborted"
           || string_contains msg "network is unreachable"
           || string_contains msg "host is unreachable"
+          || string_contains msg "epipe"
+          || string_contains msg "enetdown"
+          || string_contains msg "enetreset"
+          || string_contains msg "enetunreach"
+          || string_contains msg "ehostdown"
+          || string_contains msg "ehostunreach"
+          || string_contains msg "enotconn"
           || string_contains msg "end_of_file"
           || string_contains msg "econn"
   then Connection

--- a/lib/discord_rest.ml
+++ b/lib/discord_rest.ml
@@ -240,7 +240,14 @@ let note_transport_failure_state state ~now ~summary ~delay =
   delay
 
 let note_transport_failure_without_backoff_state state ~now ~summary =
-  let delay = note_failure_without_backoff_state state ~now ~summary in
+  let delay =
+    if active_rest_backoff ~now state then begin
+      state.consecutive_failures <-
+        min max_recorded_failures (state.consecutive_failures + 1);
+      effective_backoff_delay_s ~now state
+    end else
+      note_failure_without_backoff_state state ~now ~summary
+  in
   state.last_transport_error <- Some summary;
   state.consecutive_transport_failures <-
     min max_recorded_failures (state.consecutive_transport_failures + 1);
@@ -388,11 +395,12 @@ let note_transport_failure t ~host exn =
     (summary, None)
   end
 
+let body_for_health_summary ?(max_len = 500) body =
+  if String.length body <= max_len then body
+  else Resource.truncate_utf8 ~max_bytes:max_len body ^ "... (truncated)"
+
 let note_http_failure t ~host ~code ~body ?retry_after () =
-  let body =
-    if String.length body <= 500 then body
-    else String.sub body 0 500 ^ "... (truncated)"
-  in
+  let body = body_for_health_summary body in
   let summary =
     Printf.sprintf "host=%s kind=http_%d error=%s"
       host code body
@@ -410,10 +418,7 @@ let note_http_failure t ~host ~code ~body ?retry_after () =
   (summary, delay)
 
 let note_http_client_failure t ~host ~code ~body =
-  let body =
-    if String.length body <= 500 then body
-    else String.sub body 0 500 ^ "... (truncated)"
-  in
+  let body = body_for_health_summary body in
   let summary =
     Printf.sprintf "host=%s kind=http_%d error=%s"
       host code body
@@ -427,10 +432,7 @@ let note_http_client_failure t ~host ~code ~body =
   (summary, delay)
 
 let note_rate_limit t ~host ~retry_after ~body =
-  let body =
-    if String.length body <= 500 then body
-    else String.sub body 0 500 ^ "... (truncated)"
-  in
+  let body = body_for_health_summary body in
   let summary =
     Printf.sprintf "host=%s kind=http_429 error=%s"
       host body

--- a/lib/discord_rest.ml
+++ b/lib/discord_rest.ml
@@ -305,9 +305,12 @@ let sleep_with_jitter t delay =
     Eio.Time.Mono.sleep t.clock (delay +. jitter)
   end
 
-let wait_for_transport_backoff t =
+let rec wait_for_transport_backoff t =
   let delay = transport_retry_delay_s t in
-  sleep_with_jitter t delay
+  if delay > 0.0 then begin
+    sleep_with_jitter t delay;
+    wait_for_transport_backoff t
+  end
 
 let response_clears_rest_health code =
   code >= 200 && code < 300
@@ -349,7 +352,7 @@ let make_headers t =
     Capped at 10MB to prevent OOM from unexpected large responses. *)
 let max_body_size = 10 * 1024 * 1024
 
-let read_body (body : Cohttp_eio.Body.t) =
+let read_body_with_truncation (body : Cohttp_eio.Body.t) =
   let buf = Buffer.create 4096 in
   let chunk = Cstruct.create 4096 in
   let truncated = ref false in
@@ -363,9 +366,12 @@ let read_body (body : Cohttp_eio.Body.t) =
       end;
       (* Always drain to EOF so the connection stays clean for reuse *)
       loop ()
-    | exception End_of_file -> Buffer.contents buf
+    | exception End_of_file -> (Buffer.contents buf, !truncated)
   in
   loop ()
+
+let read_body body =
+  fst (read_body_with_truncation body)
 
 (** Truncate a byte string near [max_len] for log output. Preserves
     UTF-8 validity without verifying it: if the input is valid UTF-8,
@@ -809,8 +815,11 @@ let download_url t ~url () =
       let status = Http.Response.status resp in
       let code = Http.Status.to_int status in
       let resp_headers = Http.Response.headers resp in
-      let body_str = read_body body in
-      if code >= 200 && code < 300 then Ok body_str
+      let (body_str, truncated) = read_body_with_truncation body in
+      if truncated then
+        Error (Printf.sprintf "download_url %s: response exceeded %d bytes"
+          url max_body_size)
+      else if code >= 200 && code < 300 then Ok body_str
       else if code >= 500 && code < 600 && attempt < max_transient_attempts then begin
         let delay =
           Option.value (retry_after_seconds ~headers:resp_headers body_str)

--- a/lib/discord_rest.ml
+++ b/lib/discord_rest.ml
@@ -3,7 +3,9 @@
     Assumptions:
     - Bot token auth only
     - No file uploads yet (will add for agent output sharing)
-    - Simple rate limiting: sleep on 429 Retry-After, then retry once *)
+    - Transient transport failures are retried only for operations we can
+      safely repeat (idempotent calls, or create_message with Discord
+      nonce dedupe). *)
 
 open Discord_types
 
@@ -14,7 +16,121 @@ type t = {
   client : Cohttp_eio.Client.t;
   sw : Eio.Switch.t;
   clock : float Eio.Time.clock_ty Eio.Resource.t;
+  mutable last_transport_error : string option;
+  mutable consecutive_transport_failures : int;
+  mutable transport_backoff_until : float;
 }
+
+type retry_mode =
+  | No_retry
+  | Retry_transient
+
+type transport_error_kind =
+  | Hostname_resolution
+  | Timeout
+  | Connection
+  | Tls
+  | Other_transport
+
+let max_rate_limit_retries = 1
+let max_transient_attempts = 4
+let base_transport_backoff_s = 0.5
+let max_transport_backoff_s = 8.0
+
+let raise_if_cancelled exn =
+  match exn with
+  | Eio.Cancel.Cancelled _ -> raise exn
+  | _ -> ()
+
+let string_contains s needle =
+  let s_len = String.length s in
+  let needle_len = String.length needle in
+  let rec loop i =
+    if i + needle_len > s_len then false
+    else if String.sub s i needle_len = needle then true
+    else loop (i + 1)
+  in
+  needle_len = 0 || loop 0
+
+let classify_transport_error_message msg =
+  let msg = String.lowercase_ascii msg in
+  if string_contains msg "failed to resolve hostname"
+     || string_contains msg "name resolution"
+     || string_contains msg "getaddrinfo"
+     || string_contains msg "no address associated with hostname"
+  then Hostname_resolution
+  else if string_contains msg "timed out"
+          || string_contains msg "timeout"
+          || string_contains msg "etimedout"
+  then Timeout
+  else if string_contains msg "tls"
+          || string_contains msg "ssl"
+          || string_contains msg "certificate"
+  then Tls
+  else if string_contains msg "connection reset"
+          || string_contains msg "broken pipe"
+          || string_contains msg "connection refused"
+          || string_contains msg "connection aborted"
+          || string_contains msg "network is unreachable"
+          || string_contains msg "host is unreachable"
+          || string_contains msg "end_of_file"
+          || string_contains msg "econn"
+  then Connection
+  else Other_transport
+
+let string_of_transport_error_kind = function
+  | Hostname_resolution -> "hostname_resolution"
+  | Timeout -> "timeout"
+  | Connection -> "connection"
+  | Tls -> "tls"
+  | Other_transport -> "other_transport"
+
+let transport_backoff_seconds failure_count =
+  let exponent = max 0 (failure_count - 1) in
+  min max_transport_backoff_s
+    (base_transport_backoff_s *. (2. ** float_of_int exponent))
+
+let transport_retry_delay_s t =
+  max 0.0 (t.transport_backoff_until -. Unix.gettimeofday ())
+
+let transport_degraded t =
+  t.consecutive_transport_failures > 0
+
+let last_transport_error t =
+  t.last_transport_error
+
+let consecutive_transport_failures t =
+  t.consecutive_transport_failures
+
+let note_transport_recovery t =
+  if t.consecutive_transport_failures > 0 then
+    Logs.info (fun m -> m "REST transport recovered after %d failure(s)"
+      t.consecutive_transport_failures);
+  t.last_transport_error <- None;
+  t.consecutive_transport_failures <- 0;
+  t.transport_backoff_until <- 0.0
+
+let note_transport_failure t ~host exn =
+  let raw = Printexc.to_string exn in
+  let kind =
+    classify_transport_error_message raw
+    |> string_of_transport_error_kind
+  in
+  let failures = t.consecutive_transport_failures + 1 in
+  let delay = transport_backoff_seconds failures in
+  let summary =
+    Printf.sprintf "host=%s kind=%s error=%s" host kind raw
+  in
+  let now = Unix.gettimeofday () in
+  t.last_transport_error <- Some summary;
+  t.consecutive_transport_failures <- failures;
+  t.transport_backoff_until <- max t.transport_backoff_until (now +. delay);
+  (summary, delay)
+
+let wait_for_transport_backoff t =
+  let delay = transport_retry_delay_s t in
+  if delay > 0.0 then
+    Eio.Time.sleep t.clock delay
 
 let create ~sw ~(env : Eio_unix.Stdenv.base) ~token =
   Mirage_crypto_rng_unix.use_default ();
@@ -38,7 +154,10 @@ let create ~sw ~(env : Eio_unix.Stdenv.base) ~token =
   let net = Eio.Stdenv.net env in
   let client = Cohttp_eio.Client.make ~https:(Some https) net in
   let clock = Eio.Stdenv.clock env in
-  { token; client; sw; clock }
+  { token; client; sw; clock;
+    last_transport_error = None;
+    consecutive_transport_failures = 0;
+    transport_backoff_until = 0.0; }
 
 let make_headers t =
   Http.Header.of_list [
@@ -105,13 +224,29 @@ let body_snippet ?(max_len = 150) s =
   if String.length s <= max_len then s
   else truncate_for_log ~max_len s
 
+let message_nonce () =
+  Resource.random_hex 12
+
+let create_message_body ~content ?reply_to ~nonce () =
+  `Assoc ([
+    ("content", `String content);
+    ("nonce", `String nonce);
+    ("enforce_nonce", `Bool true);
+  ] @ match reply_to with
+    | Some msg_id ->
+      [("message_reference", `Assoc [("message_id", `String msg_id)])]
+    | None -> [])
+
 (** Low-level HTTP request. Returns parsed JSON or error string.
     On 429 (rate limited), sleeps Retry-After seconds and retries once.
-    Non-2xx responses are logged centrally so callers that [ignore] the
-    Result still surface failures. 404s log at debug level (expected for
-    typing/reactions on deleted channels); other errors log at warn. *)
-let request t ~meth ~path ?body () =
+    Retryable operations also back off and retry on transient transport
+    failures or 5xx responses. Non-2xx responses are logged centrally so
+    callers that [ignore] the Result still surface failures. 404s log at
+    debug level (expected for typing/reactions on deleted channels); other
+    errors log at warn. *)
+let request ?(retry_mode = No_retry) t ~meth ~path ?body () =
   let uri = Uri.of_string (api_base ^ path) in
+  let host = Uri.host uri |> Option.value ~default:"discord.com" in
   let headers = make_headers t in
   let body_str = Option.map (fun j -> Yojson.Safe.to_string j) body in
   let meth_str = Http.Method.to_string meth in
@@ -145,10 +280,7 @@ let request t ~meth ~path ?body () =
           meth_str path (truncate_for_log b))
       ) body_str
   in
-  let handle_response (resp, resp_body) =
-    let status = Http.Response.status resp in
-    let code = Http.Status.to_int status in
-    let body_str = read_body resp_body in
+  let handle_response code body_str =
     if code >= 200 && code < 300 then begin
       if String.length body_str = 0 then Ok `Null
       else Ok (Yojson.Safe.from_string body_str)
@@ -163,31 +295,65 @@ let request t ~meth ~path ?body () =
         meth_str path code (body_snippet body_str))
     end
   in
-  try
-    let (resp, resp_body) = do_call () in
-    let status = Http.Response.status resp in
-    let code = Http.Status.to_int status in
-    if code = 429 then begin
+  let rec loop attempt rate_limit_retries =
+    wait_for_transport_backoff t;
+    try
+      let (resp, resp_body) = do_call () in
+      note_transport_recovery t;
+      let status = Http.Response.status resp in
+      let code = Http.Status.to_int status in
       let body_str = read_body resp_body in
-      let retry_after =
-        try
-          let json = Yojson.Safe.from_string body_str in
-          Yojson.Safe.Util.(json |> member "retry_after" |> to_float)
-        with _ -> 5.0
+      if code = 429 && rate_limit_retries < max_rate_limit_retries then begin
+        let retry_after =
+          try
+            let json = Yojson.Safe.from_string body_str in
+            Yojson.Safe.Util.(json |> member "retry_after" |> to_float)
+          with _ -> 5.0
+        in
+        Logs.warn (fun m ->
+          m "REST %s %s: rate limited, retrying after %.1fs"
+            meth_str path retry_after);
+        Eio.Time.sleep t.clock retry_after;
+        loop attempt (rate_limit_retries + 1)
+      end else if code >= 500 && code < 600
+                && retry_mode = Retry_transient
+                && attempt < max_transient_attempts then begin
+        log_non_2xx code body_str;
+        let delay = transport_backoff_seconds attempt in
+        Logs.warn (fun m ->
+          m "REST %s %s: HTTP %d on attempt %d/%d, retrying in %.1fs"
+            meth_str path code attempt max_transient_attempts delay);
+        Eio.Time.sleep t.clock delay;
+        loop (attempt + 1) rate_limit_retries
+      end else
+        handle_response code body_str
+    with exn ->
+      raise_if_cancelled exn;
+      let (summary, delay) = note_transport_failure t ~host exn in
+      let can_retry =
+        retry_mode = Retry_transient && attempt < max_transient_attempts
       in
-      Logs.warn (fun m -> m "REST: rate limited on %s, retrying after %.1fs" path retry_after);
-      Eio.Time.sleep t.clock retry_after;
-      handle_response (do_call ())
-    end else
-      handle_response (resp, resp_body)
-  with exn ->
-    (* Full detail in the central log; short snippet in the Error so
-       callers that surface it to users/API retain a useful hint. *)
-    let exn_raw = Printexc.to_string exn in
-    Logs.warn (fun m -> m "REST %s %s: exception %s" meth_str path
-      (truncate_for_log exn_raw));
-    Error (Printf.sprintf "discord REST %s %s: exception %s"
-      meth_str path (body_snippet exn_raw))
+      if can_retry then begin
+        Logs.warn (fun m ->
+          m "REST %s %s: transport failure on attempt %d/%d, retrying in %.1fs (%s)"
+            meth_str path attempt max_transient_attempts delay
+            (truncate_for_log summary));
+        Eio.Time.sleep t.clock delay;
+        loop (attempt + 1) rate_limit_retries
+      end else begin
+        Logs.warn (fun m -> m "REST %s %s: exception %s"
+          meth_str path (truncate_for_log summary));
+        let suffix =
+          if attempt > 1 then
+            Printf.sprintf " after %d attempts" attempt
+          else
+            ""
+        in
+        Error (Printf.sprintf "discord REST %s %s: exception%s %s"
+          meth_str path suffix (body_snippet summary))
+      end
+  in
+  loop 1 0
 
 (** Plan the chunks for a [create_message] call. Pure function, separated
     from I/O so it can be unit-tested. Content fitting in a single Discord
@@ -226,13 +392,11 @@ let create_message t ~(channel_id : Discord_types.channel_id) ~content
      [Resource.sanitize_utf8] for the full rationale. *)
   let content = Resource.sanitize_utf8 content in
   let post_one (chunk, chunk_reply_to) =
-    let body = `Assoc ([
-      ("content", `String chunk);
-    ] @ match chunk_reply_to with
-      | Some msg_id -> [("message_reference", `Assoc [("message_id", `String msg_id)])]
-      | None -> [])
+    let body =
+      create_message_body ~content:chunk ?reply_to:chunk_reply_to
+        ~nonce:(message_nonce ()) ()
     in
-    match request t ~meth:`POST
+    match request ~retry_mode:Retry_transient t ~meth:`POST
       ~path:(Printf.sprintf "/channels/%s/messages" channel_id) ~body () with
     | Ok json ->
       (try Ok (message_of_yojson json)
@@ -265,7 +429,7 @@ let edit_message t ~(channel_id : Discord_types.channel_id)
     ~(message_id : Discord_types.message_id) ~content () =
   let content = Resource.sanitize_utf8 content in
   let body = `Assoc [("content", `String content)] in
-  match request t ~meth:`PATCH
+  match request ~retry_mode:Retry_transient t ~meth:`PATCH
     ~path:(Printf.sprintf "/channels/%s/messages/%s" channel_id message_id)
     ~body () with
   | Ok json ->
@@ -275,7 +439,7 @@ let edit_message t ~(channel_id : Discord_types.channel_id)
 
 (** Send a typing indicator. *)
 let send_typing t ~(channel_id : Discord_types.channel_id) () =
-  match request t ~meth:`POST
+  match request ~retry_mode:Retry_transient t ~meth:`POST
     ~path:(Printf.sprintf "/channels/%s/typing" channel_id) () with
   | Ok _ -> Ok ()
   | Error e -> Error e
@@ -297,7 +461,8 @@ let create_channel t ~(guild_id : Discord_types.guild_id) ~name ?(channel_type=0
 
 (** Get all channels in a guild. *)
 let get_guild_channels t ~(guild_id : Discord_types.guild_id) () =
-  match request t ~meth:`GET ~path:(Printf.sprintf "/guilds/%s/channels" guild_id) () with
+  match request ~retry_mode:Retry_transient t ~meth:`GET
+    ~path:(Printf.sprintf "/guilds/%s/channels" guild_id) () with
   | Ok json ->
     (try Ok (Yojson.Safe.Util.to_list json |> List.map channel_of_yojson)
      with exn -> Error (Printf.sprintf "get_guild_channels: parse error: %s" (Printexc.to_string exn)))
@@ -316,7 +481,8 @@ let modify_channel_position t ~(guild_id : Discord_types.guild_id)
     ("id", `String channel_id);
     ("position", `Int position);
   ]] in
-  match request t ~meth:`PATCH ~path:(Printf.sprintf "/guilds/%s/channels" guild_id) ~body () with
+  match request ~retry_mode:Retry_transient t ~meth:`PATCH
+    ~path:(Printf.sprintf "/guilds/%s/channels" guild_id) ~body () with
   | Ok _ -> Ok ()
   | Error e -> Error e
 
@@ -331,7 +497,8 @@ let batch_modify_channel_positions t ~(guild_id : Discord_types.guild_id)
       ("position", `Int position);
     ]
   ) positions) in
-  match request t ~meth:`PATCH ~path:(Printf.sprintf "/guilds/%s/channels" guild_id) ~body () with
+  match request ~retry_mode:Retry_transient t ~meth:`PATCH
+    ~path:(Printf.sprintf "/guilds/%s/channels" guild_id) ~body () with
   | Ok _ -> Ok ()
   | Error e -> Error e
 
@@ -367,7 +534,7 @@ let create_thread_no_message t ~(channel_id : Discord_types.channel_id) ~name ()
 
 (** Fetch messages from a channel. *)
 let get_messages t ~(channel_id : Discord_types.channel_id) ?(limit=20) () =
-  match request t ~meth:`GET
+  match request ~retry_mode:Retry_transient t ~meth:`GET
     ~path:(Printf.sprintf "/channels/%s/messages?limit=%d" channel_id limit) () with
   | Ok json ->
     (try
@@ -380,7 +547,7 @@ let get_messages t ~(channel_id : Discord_types.channel_id) ?(limit=20) () =
 let create_reaction t ~(channel_id : Discord_types.channel_id)
     ~(message_id : Discord_types.message_id) ~emoji () =
   let encoded_emoji = Uri.pct_encode emoji in
-  match request t ~meth:`PUT
+  match request ~retry_mode:Retry_transient t ~meth:`PUT
     ~path:(Printf.sprintf "/channels/%s/messages/%s/reactions/%s/@me"
       channel_id message_id encoded_emoji) () with
   | Ok _ -> Ok ()
@@ -399,7 +566,7 @@ let delete_own_reaction t ~(channel_id : Discord_types.channel_id)
 (** Modify a channel/thread's properties (currently: name only). *)
 let modify_channel t ~(channel_id : Discord_types.channel_id) ~name () =
   let body = `Assoc [("name", `String name)] in
-  match request t ~meth:`PATCH
+  match request ~retry_mode:Retry_transient t ~meth:`PATCH
     ~path:(Printf.sprintf "/channels/%s" channel_id) ~body () with
   | Ok json ->
     (try Ok (channel_of_yojson json)
@@ -408,7 +575,8 @@ let modify_channel t ~(channel_id : Discord_types.channel_id) ~name () =
 
 (** Get a single channel by ID (works for threads too — returns parent_id). *)
 let get_channel t ~(channel_id : Discord_types.channel_id) () =
-  match request t ~meth:`GET ~path:(Printf.sprintf "/channels/%s" channel_id) () with
+  match request ~retry_mode:Retry_transient t ~meth:`GET
+    ~path:(Printf.sprintf "/channels/%s" channel_id) () with
   | Ok json ->
     (try Ok (channel_of_yojson json)
      with exn -> Error (Printf.sprintf "get_channel: parse error: %s" (Printexc.to_string exn)))
@@ -418,23 +586,48 @@ let get_channel t ~(channel_id : Discord_types.channel_id) () =
     Returns the raw bytes on success. *)
 let download_url t ~url () =
   let uri = Uri.of_string url in
+  let host = Uri.host uri |> Option.value ~default:"<unknown>" in
   let headers = Http.Header.of_list [
     ("User-Agent", "DiscordBot (discord-agents/0.1.0, OCaml)");
   ] in
-  try
-    let (resp, body) =
-      Cohttp_eio.Client.call t.client ~sw:t.sw ~headers `GET uri in
-    let status = Http.Response.status resp in
-    let code = Http.Status.to_int status in
-    let body_str = read_body body in
-    if code >= 200 && code < 300 then Ok body_str
-    else Error (Printf.sprintf "download_url %s: HTTP %d" url code)
-  with exn ->
-    Error (Printf.sprintf "download_url %s: %s" url (Printexc.to_string exn))
+  let rec loop attempt =
+    wait_for_transport_backoff t;
+    try
+      let (resp, body) =
+        Cohttp_eio.Client.call t.client ~sw:t.sw ~headers `GET uri in
+      note_transport_recovery t;
+      let status = Http.Response.status resp in
+      let code = Http.Status.to_int status in
+      let body_str = read_body body in
+      if code >= 200 && code < 300 then Ok body_str
+      else if code >= 500 && code < 600 && attempt < max_transient_attempts then begin
+        let delay = transport_backoff_seconds attempt in
+        Logs.warn (fun m ->
+          m "download_url %s: HTTP %d on attempt %d/%d, retrying in %.1fs"
+            url code attempt max_transient_attempts delay);
+        Eio.Time.sleep t.clock delay;
+        loop (attempt + 1)
+      end else
+        Error (Printf.sprintf "download_url %s: HTTP %d" url code)
+    with exn ->
+      raise_if_cancelled exn;
+      let (summary, delay) = note_transport_failure t ~host exn in
+      if attempt < max_transient_attempts then begin
+        Logs.warn (fun m ->
+          m "download_url %s: transport failure on attempt %d/%d, retrying in %.1fs (%s)"
+            url attempt max_transient_attempts delay
+            (truncate_for_log summary));
+        Eio.Time.sleep t.clock delay;
+        loop (attempt + 1)
+      end else
+        Error (Printf.sprintf "download_url %s: %s" url summary)
+  in
+  loop 1
 
 (** Get the gateway URL for WebSocket connection. *)
 let get_gateway t =
-  match request t ~meth:`GET ~path:"/gateway/bot" () with
+  match request ~retry_mode:Retry_transient t ~meth:`GET
+    ~path:"/gateway/bot" () with
   | Ok json ->
     (try
        let url = Yojson.Safe.Util.(json |> member "url" |> to_string) in

--- a/lib/discord_rest.ml
+++ b/lib/discord_rest.ml
@@ -15,15 +15,19 @@ type t = {
   token : string;
   client : Cohttp_eio.Client.t;
   sw : Eio.Switch.t;
-  clock : float Eio.Time.clock_ty Eio.Resource.t;
-  mutable last_transport_error : string option;
-  mutable consecutive_transport_failures : int;
-  mutable transport_backoff_until : float;
+  clock : Eio.Time.Mono.ty Eio.Resource.t;
+  rest_state : health_state;
+}
+
+and health_state = {
+  mutable last_error : string option;
+  mutable consecutive_failures : int;
+  mutable backoff_until : Mtime.t option;
 }
 
 type retry_mode =
   | No_retry
-  | Retry_transient
+  | Retry_transient of int
 
 type transport_error_kind =
   | Hostname_resolution
@@ -36,10 +40,17 @@ let max_rate_limit_retries = 1
 let max_transient_attempts = 4
 let base_transport_backoff_s = 0.5
 let max_transport_backoff_s = 8.0
+let max_backoff_jitter_s = 0.25
+let max_recorded_failures = 32
+let default_retry_mode = Retry_transient max_transient_attempts
+let light_retry_mode = Retry_transient 2
 
 let raise_if_cancelled exn =
   match exn with
-  | Eio.Cancel.Cancelled _ -> raise exn
+  | Eio.Cancel.Cancelled _
+  | Out_of_memory
+  | Stack_overflow
+  | Sys.Break -> raise exn
   | _ -> ()
 
 let string_contains s needle =
@@ -90,49 +101,219 @@ let transport_backoff_seconds failure_count =
   min max_transport_backoff_s
     (base_transport_backoff_s *. (2. ** float_of_int exponent))
 
+let next_backoff_until ~now ~current_until ~delay =
+  let delay_ns =
+    Int64.of_float (max 0.0 delay *. 1e9)
+  in
+  let delay = Mtime.Span.of_uint64_ns delay_ns in
+  let candidate =
+    match Mtime.add_span now delay with
+    | Some ts -> ts
+    | None -> Mtime.max_stamp
+  in
+  match current_until with
+  | Some current when Mtime.is_later current ~than:candidate -> current
+  | _ -> candidate
+
+let create_health_state () =
+  {
+    last_error = None;
+    consecutive_failures = 0;
+    backoff_until = None;
+  }
+
+let health_retry_delay_s ~now state =
+  match state.backoff_until with
+  | None -> 0.0
+  | Some until when Mtime.compare now until >= 0 -> 0.0
+  | Some until ->
+    Int64.to_float (Mtime.Span.to_uint64_ns (Mtime.span now until)) /. 1e9
+
+let health_degraded state =
+  state.consecutive_failures > 0
+
+let health_last_error state =
+  state.last_error
+
+let health_consecutive_failures state =
+  state.consecutive_failures
+
+let effective_backoff_delay_s ~now state =
+  health_retry_delay_s ~now state
+
+let note_failure_state state ~now ~summary ~delay =
+  let failures =
+    min max_recorded_failures (state.consecutive_failures + 1)
+  in
+  state.last_error <- Some summary;
+  state.consecutive_failures <- failures;
+  state.backoff_until <-
+    Some (next_backoff_until ~now ~current_until:state.backoff_until ~delay);
+  effective_backoff_delay_s ~now state
+
+let note_rate_limit_state state ~now ~summary ~delay =
+  state.last_error <- Some summary;
+  state.consecutive_failures <-
+    min max_recorded_failures (state.consecutive_failures + 1);
+  state.backoff_until <-
+    Some (next_backoff_until ~now ~current_until:state.backoff_until ~delay);
+  effective_backoff_delay_s ~now state
+
+let note_recovery_state state =
+  let failures = state.consecutive_failures in
+  state.last_error <- None;
+  state.consecutive_failures <- 0;
+  state.backoff_until <- None;
+  failures
+
+(* REST state closures must stay effect-free: no sleeps, logging, I/O, or
+   other Eio operations inside them. In the current single-domain Eio model,
+   that keeps each update atomic with respect to fiber scheduling without
+   pulling in systhreads/Mutex. *)
+let with_rest_state t f =
+  f t.rest_state
+
+let now_s t =
+  Eio.Time.Mono.now t.clock
+
 let transport_retry_delay_s t =
-  max 0.0 (t.transport_backoff_until -. Unix.gettimeofday ())
+  let now = now_s t in
+  with_rest_state t (fun state ->
+    health_retry_delay_s ~now state)
 
 let transport_degraded t =
-  t.consecutive_transport_failures > 0
+  with_rest_state t (fun state ->
+    health_degraded state)
 
 let last_transport_error t =
-  t.last_transport_error
+  with_rest_state t (fun state ->
+    health_last_error state)
 
 let consecutive_transport_failures t =
-  t.consecutive_transport_failures
+  with_rest_state t (fun state ->
+    health_consecutive_failures state)
+
+let rest_retry_delay_s = transport_retry_delay_s
+let rest_degraded = transport_degraded
+let last_rest_error = last_transport_error
+let consecutive_rest_failures = consecutive_transport_failures
 
 let note_transport_recovery t =
-  if t.consecutive_transport_failures > 0 then
+  let failures =
+    with_rest_state t (fun state ->
+      note_recovery_state state)
+  in
+  if failures > 0 then
     Logs.info (fun m -> m "REST transport recovered after %d failure(s)"
-      t.consecutive_transport_failures);
-  t.last_transport_error <- None;
-  t.consecutive_transport_failures <- 0;
-  t.transport_backoff_until <- 0.0
+      failures)
+
+let retryable_transport_kind = function
+  | Hostname_resolution | Timeout | Connection | Tls -> true
+  | Other_transport -> false
+
+let transport_failure_summary ~host exn =
+  let raw = Printexc.to_string exn in
+  let kind = classify_transport_error_message raw in
+  let summary =
+    Printf.sprintf "host=%s kind=%s error=%s"
+      host (string_of_transport_error_kind kind) raw
+  in
+  (kind, summary)
+
+let parse_retry_after_seconds raw =
+  match float_of_string_opt (String.trim raw) with
+  | Some delay -> Some (max 0.0 delay)
+  | None -> None
+
+let retry_after_seconds_from_headers headers =
+  match Http.Header.get headers "retry-after" with
+  | Some raw -> parse_retry_after_seconds raw
+  | None -> None
+
+let retry_after_seconds_from_body body_str =
+  try
+    let json = Yojson.Safe.from_string body_str in
+    match Yojson.Safe.Util.member "retry_after" json with
+    | `Float f -> Some (max 0.0 f)
+    | `Int i -> Some (max 0.0 (float_of_int i))
+    | _ -> None
+  with _ -> None
+
+let retry_after_seconds ?headers body_str =
+  match headers with
+  | Some headers ->
+    (match retry_after_seconds_from_headers headers with
+     | Some _ as delay -> delay
+     | None -> retry_after_seconds_from_body body_str)
+  | None -> retry_after_seconds_from_body body_str
 
 let note_transport_failure t ~host exn =
-  let raw = Printexc.to_string exn in
-  let kind =
-    classify_transport_error_message raw
-    |> string_of_transport_error_kind
+  let (kind, summary) = transport_failure_summary ~host exn in
+  let now = now_s t in
+  let delay =
+    with_rest_state t (fun state ->
+      let delay =
+        transport_backoff_seconds (state.consecutive_failures + 1)
+      in
+      note_failure_state state
+        ~now ~summary ~delay)
   in
-  let failures = t.consecutive_transport_failures + 1 in
-  let delay = transport_backoff_seconds failures in
+  if retryable_transport_kind kind then (summary, Some delay)
+  else (summary, None)
+
+let note_http_failure t ~host ~code ~body ?retry_after () =
+  let body =
+    if String.length body <= 500 then body
+    else String.sub body 0 500 ^ "... (truncated)"
+  in
   let summary =
-    Printf.sprintf "host=%s kind=%s error=%s" host kind raw
+    Printf.sprintf "host=%s kind=http_%d error=%s"
+      host code body
   in
-  let now = Unix.gettimeofday () in
-  t.last_transport_error <- Some summary;
-  t.consecutive_transport_failures <- failures;
-  t.transport_backoff_until <- max t.transport_backoff_until (now +. delay);
+  let now = now_s t in
+  let delay =
+    with_rest_state t (fun state ->
+      let delay =
+        Option.value retry_after
+          ~default:(transport_backoff_seconds (state.consecutive_failures + 1))
+      in
+      note_failure_state state
+        ~now ~summary ~delay)
+  in
   (summary, delay)
+
+let note_rate_limit t ~host ~retry_after ~body =
+  let body =
+    if String.length body <= 500 then body
+    else String.sub body 0 500 ^ "... (truncated)"
+  in
+  let summary =
+    Printf.sprintf "host=%s kind=http_429 error=%s"
+      host body
+  in
+  let now = now_s t in
+  let delay =
+    with_rest_state t (fun state ->
+      note_rate_limit_state state
+        ~now ~summary ~delay:retry_after)
+  in
+  (summary, delay)
+
+let sleep_with_jitter t delay =
+  if delay > 0.0 then begin
+    let jitter = Random.float (min max_backoff_jitter_s delay) in
+    Eio.Time.Mono.sleep t.clock (delay +. jitter)
+  end
 
 let wait_for_transport_backoff t =
   let delay = transport_retry_delay_s t in
-  if delay > 0.0 then
-    Eio.Time.sleep t.clock delay
+  sleep_with_jitter t delay
+
+let response_clears_rest_health code =
+  code >= 200 && code < 300
 
 let create ~sw ~(env : Eio_unix.Stdenv.base) ~token =
+  Random.self_init ();
   Mirage_crypto_rng_unix.use_default ();
   let authenticator =
     match Ca_certs.authenticator () with
@@ -153,11 +334,9 @@ let create ~sw ~(env : Eio_unix.Stdenv.base) ~token =
   in
   let net = Eio.Stdenv.net env in
   let client = Cohttp_eio.Client.make ~https:(Some https) net in
-  let clock = Eio.Stdenv.clock env in
+  let clock = Eio.Stdenv.mono_clock env in
   { token; client; sw; clock;
-    last_transport_error = None;
-    consecutive_transport_failures = 0;
-    transport_backoff_until = 0.0; }
+    rest_state = create_health_state (); }
 
 let make_headers t =
   Http.Header.of_list [
@@ -237,8 +416,17 @@ let create_message_body ~content ?reply_to ~nonce () =
       [("message_reference", `Assoc [("message_id", `String msg_id)])]
     | None -> [])
 
+let decode_json_body body_str =
+  if String.length body_str = 0 then Ok `Null
+  else
+    try Ok (Yojson.Safe.from_string body_str)
+    with exn -> Error (Printexc.to_string exn)
+
 (** Low-level HTTP request. Returns parsed JSON or error string.
     On 429 (rate limited), sleeps Retry-After seconds and retries once.
+    This 429 retry happens even for [No_retry], because Discord explicitly
+    told us when to resume and ignoring that would convert a transient
+    throttling response into an avoidable hard failure.
     Retryable operations also back off and retry on transient transport
     failures or 5xx responses. Non-2xx responses are logged centrally so
     callers that [ignore] the Result still surface failures. 404s log at
@@ -247,6 +435,10 @@ let create_message_body ~content ?reply_to ~nonce () =
 let request ?(retry_mode = No_retry) t ~meth ~path ?body () =
   let uri = Uri.of_string (api_base ^ path) in
   let host = Uri.host uri |> Option.value ~default:"discord.com" in
+  let retry_limit = match retry_mode with
+    | No_retry -> 1
+    | Retry_transient n -> max 1 n
+  in
   let headers = make_headers t in
   let body_str = Option.map (fun j -> Yojson.Safe.to_string j) body in
   let meth_str = Http.Method.to_string meth in
@@ -282,15 +474,14 @@ let request ?(retry_mode = No_retry) t ~meth ~path ?body () =
   in
   let handle_response code body_str =
     if code >= 200 && code < 300 then begin
-      if String.length body_str = 0 then Ok `Null
-      else
-        try Ok (Yojson.Safe.from_string body_str)
-        with exn ->
-          Logs.warn (fun m ->
-            m "REST %s %s: response parse error: %s"
-              meth_str path (Printexc.to_string exn));
-          Error (Printf.sprintf "discord REST %s %s: response parse error %s"
-            meth_str path (body_snippet (Printexc.to_string exn)))
+      match decode_json_body body_str with
+      | Ok json -> Ok json
+      | Error exn_raw ->
+        Logs.warn (fun m ->
+          m "REST %s %s: response parse error: %s"
+            meth_str path (truncate_for_log exn_raw));
+        Error (Printf.sprintf "discord REST %s %s: response parse error %s"
+          meth_str path (body_snippet exn_raw))
     end else begin
       (* Log the full body (up to truncate_for_log's cap) centrally for
          operator debugging, and include a short body snippet in the
@@ -306,46 +497,59 @@ let request ?(retry_mode = No_retry) t ~meth ~path ?body () =
     wait_for_transport_backoff t;
     try
       let (resp, resp_body) = do_call () in
-      note_transport_recovery t;
       let status = Http.Response.status resp in
       let code = Http.Status.to_int status in
+      let headers = Http.Response.headers resp in
       let body_str = read_body resp_body in
       if code = 429 && rate_limit_retries < max_rate_limit_retries then begin
         let retry_after =
-          try
-            let json = Yojson.Safe.from_string body_str in
-            Yojson.Safe.Util.(json |> member "retry_after" |> to_float)
-          with _ -> 5.0
+          Option.value (retry_after_seconds ~headers body_str) ~default:5.0
+        in
+        let (_summary, delay) =
+          note_rate_limit t ~host ~retry_after ~body:body_str
         in
         Logs.warn (fun m ->
           m "REST %s %s: rate limited, retrying after %.1fs"
-            meth_str path retry_after);
-        Eio.Time.sleep t.clock retry_after;
+            meth_str path delay);
         loop attempt (rate_limit_retries + 1)
-      end else if code >= 500 && code < 600
-                && retry_mode = Retry_transient
-                && attempt < max_transient_attempts then begin
-        log_non_2xx code body_str;
-        let delay = transport_backoff_seconds attempt in
-        Logs.warn (fun m ->
-          m "REST %s %s: HTTP %d on attempt %d/%d, retrying in %.1fs"
-            meth_str path code attempt max_transient_attempts delay);
-        Eio.Time.sleep t.clock delay;
-        loop (attempt + 1) rate_limit_retries
+      end else if code = 429 then begin
+        let retry_after =
+          Option.value (retry_after_seconds ~headers body_str) ~default:5.0
+        in
+        ignore (note_rate_limit t ~host ~retry_after ~body:body_str);
+        handle_response code body_str
+      end else if code >= 500 && code < 600 then begin
+        let retry_after = retry_after_seconds ~headers body_str in
+        let (_summary, default_delay) =
+          note_http_failure t ~host ~code ~body:body_str ?retry_after ()
+        in
+        if attempt < retry_limit then begin
+          log_non_2xx code body_str;
+          Logs.warn (fun m ->
+            m "REST %s %s: HTTP %d on attempt %d/%d, retrying in %.1fs"
+              meth_str path code attempt retry_limit default_delay);
+          loop (attempt + 1) rate_limit_retries
+        end else
+          handle_response code body_str
+      end else if response_clears_rest_health code then begin
+        note_transport_recovery t;
+        handle_response code body_str
       end else
         handle_response code body_str
     with exn ->
       raise_if_cancelled exn;
-      let (summary, delay) = note_transport_failure t ~host exn in
+      let (summary, delay_opt) = note_transport_failure t ~host exn in
       let can_retry =
-        retry_mode = Retry_transient && attempt < max_transient_attempts
+        match delay_opt with
+        | Some _ -> attempt < retry_limit
+        | None -> false
       in
       if can_retry then begin
+        let delay = Option.get delay_opt in
         Logs.warn (fun m ->
           m "REST %s %s: transport failure on attempt %d/%d, retrying in %.1fs (%s)"
-            meth_str path attempt max_transient_attempts delay
+            meth_str path attempt retry_limit delay
             (truncate_for_log summary));
-        Eio.Time.sleep t.clock delay;
         loop (attempt + 1) rate_limit_retries
       end else begin
         Logs.warn (fun m -> m "REST %s %s: exception %s"
@@ -399,11 +603,12 @@ let create_message t ~(channel_id : Discord_types.channel_id) ~content
      [Resource.sanitize_utf8] for the full rationale. *)
   let content = Resource.sanitize_utf8 content in
   let post_one (chunk, chunk_reply_to) =
+    let nonce = message_nonce () in
     let body =
       create_message_body ~content:chunk ?reply_to:chunk_reply_to
-        ~nonce:(message_nonce ()) ()
+        ~nonce ()
     in
-    match request ~retry_mode:Retry_transient t ~meth:`POST
+    match request ~retry_mode:default_retry_mode t ~meth:`POST
       ~path:(Printf.sprintf "/channels/%s/messages" channel_id) ~body () with
     | Ok json ->
       (try Ok (message_of_yojson json)
@@ -436,7 +641,7 @@ let edit_message t ~(channel_id : Discord_types.channel_id)
     ~(message_id : Discord_types.message_id) ~content () =
   let content = Resource.sanitize_utf8 content in
   let body = `Assoc [("content", `String content)] in
-  match request ~retry_mode:Retry_transient t ~meth:`PATCH
+  match request ~retry_mode:default_retry_mode t ~meth:`PATCH
     ~path:(Printf.sprintf "/channels/%s/messages/%s" channel_id message_id)
     ~body () with
   | Ok json ->
@@ -446,7 +651,7 @@ let edit_message t ~(channel_id : Discord_types.channel_id)
 
 (** Send a typing indicator. *)
 let send_typing t ~(channel_id : Discord_types.channel_id) () =
-  match request ~retry_mode:Retry_transient t ~meth:`POST
+  match request ~retry_mode:light_retry_mode t ~meth:`POST
     ~path:(Printf.sprintf "/channels/%s/typing" channel_id) () with
   | Ok _ -> Ok ()
   | Error e -> Error e
@@ -468,7 +673,7 @@ let create_channel t ~(guild_id : Discord_types.guild_id) ~name ?(channel_type=0
 
 (** Get all channels in a guild. *)
 let get_guild_channels t ~(guild_id : Discord_types.guild_id) () =
-  match request ~retry_mode:Retry_transient t ~meth:`GET
+  match request ~retry_mode:default_retry_mode t ~meth:`GET
     ~path:(Printf.sprintf "/guilds/%s/channels" guild_id) () with
   | Ok json ->
     (try Ok (Yojson.Safe.Util.to_list json |> List.map channel_of_yojson)
@@ -488,7 +693,7 @@ let modify_channel_position t ~(guild_id : Discord_types.guild_id)
     ("id", `String channel_id);
     ("position", `Int position);
   ]] in
-  match request ~retry_mode:Retry_transient t ~meth:`PATCH
+  match request ~retry_mode:default_retry_mode t ~meth:`PATCH
     ~path:(Printf.sprintf "/guilds/%s/channels" guild_id) ~body () with
   | Ok _ -> Ok ()
   | Error e -> Error e
@@ -504,7 +709,7 @@ let batch_modify_channel_positions t ~(guild_id : Discord_types.guild_id)
       ("position", `Int position);
     ]
   ) positions) in
-  match request ~retry_mode:Retry_transient t ~meth:`PATCH
+  match request ~retry_mode:default_retry_mode t ~meth:`PATCH
     ~path:(Printf.sprintf "/guilds/%s/channels" guild_id) ~body () with
   | Ok _ -> Ok ()
   | Error e -> Error e
@@ -541,7 +746,7 @@ let create_thread_no_message t ~(channel_id : Discord_types.channel_id) ~name ()
 
 (** Fetch messages from a channel. *)
 let get_messages t ~(channel_id : Discord_types.channel_id) ?(limit=20) () =
-  match request ~retry_mode:Retry_transient t ~meth:`GET
+  match request ~retry_mode:default_retry_mode t ~meth:`GET
     ~path:(Printf.sprintf "/channels/%s/messages?limit=%d" channel_id limit) () with
   | Ok json ->
     (try
@@ -554,7 +759,7 @@ let get_messages t ~(channel_id : Discord_types.channel_id) ?(limit=20) () =
 let create_reaction t ~(channel_id : Discord_types.channel_id)
     ~(message_id : Discord_types.message_id) ~emoji () =
   let encoded_emoji = Uri.pct_encode emoji in
-  match request ~retry_mode:Retry_transient t ~meth:`PUT
+  match request ~retry_mode:default_retry_mode t ~meth:`PUT
     ~path:(Printf.sprintf "/channels/%s/messages/%s/reactions/%s/@me"
       channel_id message_id encoded_emoji) () with
   | Ok _ -> Ok ()
@@ -573,7 +778,7 @@ let delete_own_reaction t ~(channel_id : Discord_types.channel_id)
 (** Modify a channel/thread's properties (currently: name only). *)
 let modify_channel t ~(channel_id : Discord_types.channel_id) ~name () =
   let body = `Assoc [("name", `String name)] in
-  match request ~retry_mode:Retry_transient t ~meth:`PATCH
+  match request ~retry_mode:default_retry_mode t ~meth:`PATCH
     ~path:(Printf.sprintf "/channels/%s" channel_id) ~body () with
   | Ok json ->
     (try Ok (channel_of_yojson json)
@@ -582,7 +787,7 @@ let modify_channel t ~(channel_id : Discord_types.channel_id) ~name () =
 
 (** Get a single channel by ID (works for threads too — returns parent_id). *)
 let get_channel t ~(channel_id : Discord_types.channel_id) () =
-  match request ~retry_mode:Retry_transient t ~meth:`GET
+  match request ~retry_mode:default_retry_mode t ~meth:`GET
     ~path:(Printf.sprintf "/channels/%s" channel_id) () with
   | Ok json ->
     (try Ok (channel_of_yojson json)
@@ -593,6 +798,7 @@ let get_channel t ~(channel_id : Discord_types.channel_id) () =
     Returns the raw bytes on success. *)
 let download_url t ~url () =
   let uri = Uri.of_string url in
+  let host = Uri.host uri |> Option.value ~default:"<unknown>" in
   let headers = Http.Header.of_list [
     ("User-Agent", "DiscordBot (discord-agents/0.1.0, OCaml)");
   ] in
@@ -602,32 +808,31 @@ let download_url t ~url () =
         Cohttp_eio.Client.call t.client ~sw:t.sw ~headers `GET uri in
       let status = Http.Response.status resp in
       let code = Http.Status.to_int status in
+      let resp_headers = Http.Response.headers resp in
       let body_str = read_body body in
       if code >= 200 && code < 300 then Ok body_str
       else if code >= 500 && code < 600 && attempt < max_transient_attempts then begin
-        let delay = transport_backoff_seconds attempt in
+        let delay =
+          Option.value (retry_after_seconds ~headers:resp_headers body_str)
+            ~default:(transport_backoff_seconds attempt)
+        in
         Logs.warn (fun m ->
           m "download_url %s: HTTP %d on attempt %d/%d, retrying in %.1fs"
             url code attempt max_transient_attempts delay);
-        Eio.Time.sleep t.clock delay;
+        sleep_with_jitter t delay;
         loop (attempt + 1)
       end else
         Error (Printf.sprintf "download_url %s: HTTP %d" url code)
     with exn ->
       raise_if_cancelled exn;
-      let summary =
-        Printf.sprintf "kind=%s error=%s"
-          (classify_transport_error_message (Printexc.to_string exn)
-           |> string_of_transport_error_kind)
-          (Printexc.to_string exn)
-      in
+      let (kind, summary) = transport_failure_summary ~host exn in
       let delay = transport_backoff_seconds attempt in
-      if attempt < max_transient_attempts then begin
+      if retryable_transport_kind kind && attempt < max_transient_attempts then begin
         Logs.warn (fun m ->
           m "download_url %s: transport failure on attempt %d/%d, retrying in %.1fs (%s)"
             url attempt max_transient_attempts delay
             (truncate_for_log summary));
-        Eio.Time.sleep t.clock delay;
+        sleep_with_jitter t delay;
         loop (attempt + 1)
       end else
         Error (Printf.sprintf "download_url %s: %s" url summary)
@@ -636,7 +841,7 @@ let download_url t ~url () =
 
 (** Get the gateway URL for WebSocket connection. *)
 let get_gateway t =
-  match request ~retry_mode:Retry_transient t ~meth:`GET
+  match request ~retry_mode:default_retry_mode t ~meth:`GET
     ~path:"/gateway/bot" () with
   | Ok json ->
     (try

--- a/lib/discord_rest.ml
+++ b/lib/discord_rest.ml
@@ -13,15 +13,25 @@ let api_base = "https://discord.com/api/v10"
 
 type t = {
   token : string;
-  client : Cohttp_eio.Client.t;
+  call : http_call;
   sw : Eio.Switch.t;
   clock : Eio.Time.Mono.ty Eio.Resource.t;
   rest_state : health_state;
 }
 
+and http_call =
+  sw:Eio.Switch.t ->
+  headers:Http.Header.t ->
+  ?body:Cohttp_eio.Body.t ->
+  Http.Method.t ->
+  Uri.t ->
+  Http.Response.t * Cohttp_eio.Body.t
+
 and health_state = {
   mutable last_error : string option;
   mutable consecutive_failures : int;
+  mutable last_transport_error : string option;
+  mutable consecutive_transport_failures : int;
   mutable backoff_until : Mtime.t option;
 }
 
@@ -40,6 +50,7 @@ let max_rate_limit_retries = 1
 let max_transient_attempts = 4
 let base_transport_backoff_s = 0.5
 let max_transport_backoff_s = 8.0
+let max_retry_after_s = 300.0
 let max_backoff_jitter_s = 0.25
 let max_recorded_failures = 32
 let default_retry_mode = Retry_transient max_transient_attempts
@@ -101,7 +112,21 @@ let transport_backoff_seconds failure_count =
   min max_transport_backoff_s
     (base_transport_backoff_s *. (2. ** float_of_int exponent))
 
+let finite_float f =
+  match classify_float f with
+  | FP_nan | FP_infinite -> false
+  | FP_normal | FP_subnormal | FP_zero -> true
+
+let clamp_retry_after_seconds delay =
+  if finite_float delay then Some (min max_retry_after_s (max 0.0 delay))
+  else None
+
 let next_backoff_until ~now ~current_until ~delay =
+  let delay =
+    match clamp_retry_after_seconds delay with
+    | Some delay -> delay
+    | None -> 0.0
+  in
   let delay_ns =
     Int64.of_float (max 0.0 delay *. 1e9)
   in
@@ -119,6 +144,8 @@ let create_health_state () =
   {
     last_error = None;
     consecutive_failures = 0;
+    last_transport_error = None;
+    consecutive_transport_failures = 0;
     backoff_until = None;
   }
 
@@ -138,6 +165,15 @@ let health_last_error state =
 let health_consecutive_failures state =
   state.consecutive_failures
 
+let health_transport_degraded state =
+  state.consecutive_transport_failures > 0
+
+let health_last_transport_error state =
+  state.last_transport_error
+
+let health_consecutive_transport_failures state =
+  state.consecutive_transport_failures
+
 let effective_backoff_delay_s ~now state =
   health_retry_delay_s ~now state
 
@@ -151,6 +187,28 @@ let note_failure_state state ~now ~summary ~delay =
     Some (next_backoff_until ~now ~current_until:state.backoff_until ~delay);
   effective_backoff_delay_s ~now state
 
+let note_failure_without_backoff_state state ~now ~summary =
+  let failures =
+    min max_recorded_failures (state.consecutive_failures + 1)
+  in
+  state.last_error <- Some summary;
+  state.consecutive_failures <- failures;
+  effective_backoff_delay_s ~now state
+
+let note_transport_failure_state state ~now ~summary ~delay =
+  let delay = note_failure_state state ~now ~summary ~delay in
+  state.last_transport_error <- Some summary;
+  state.consecutive_transport_failures <-
+    min max_recorded_failures (state.consecutive_transport_failures + 1);
+  delay
+
+let note_transport_failure_without_backoff_state state ~now ~summary =
+  let delay = note_failure_without_backoff_state state ~now ~summary in
+  state.last_transport_error <- Some summary;
+  state.consecutive_transport_failures <-
+    min max_recorded_failures (state.consecutive_transport_failures + 1);
+  delay
+
 let note_rate_limit_state state ~now ~summary ~delay =
   state.last_error <- Some summary;
   state.consecutive_failures <-
@@ -163,7 +221,15 @@ let note_recovery_state state =
   let failures = state.consecutive_failures in
   state.last_error <- None;
   state.consecutive_failures <- 0;
+  state.last_transport_error <- None;
+  state.consecutive_transport_failures <- 0;
   state.backoff_until <- None;
+  failures
+
+let note_transport_response_state state =
+  let failures = state.consecutive_transport_failures in
+  state.last_transport_error <- None;
+  state.consecutive_transport_failures <- 0;
   failures
 
 (* REST state closures must stay effect-free: no sleeps, logging, I/O, or
@@ -183,25 +249,40 @@ let transport_retry_delay_s t =
 
 let transport_degraded t =
   with_rest_state t (fun state ->
-    health_degraded state)
+    health_transport_degraded state)
 
 let last_transport_error t =
   with_rest_state t (fun state ->
-    health_last_error state)
+    health_last_transport_error state)
 
 let consecutive_transport_failures t =
   with_rest_state t (fun state ->
-    health_consecutive_failures state)
+    health_consecutive_transport_failures state)
 
 let rest_retry_delay_s = transport_retry_delay_s
-let rest_degraded = transport_degraded
-let last_rest_error = last_transport_error
-let consecutive_rest_failures = consecutive_transport_failures
+let rest_degraded t =
+  with_rest_state t (fun state ->
+    health_degraded state)
+let last_rest_error t =
+  with_rest_state t (fun state ->
+    health_last_error state)
+let consecutive_rest_failures t =
+  with_rest_state t (fun state ->
+    health_consecutive_failures state)
 
-let note_transport_recovery t =
+let note_rest_recovery t =
   let failures =
     with_rest_state t (fun state ->
       note_recovery_state state)
+  in
+  if failures > 0 then
+    Logs.info (fun m -> m "REST recovered after %d failure(s)"
+      failures)
+
+let note_transport_response t =
+  let failures =
+    with_rest_state t (fun state ->
+      note_transport_response_state state)
   in
   if failures > 0 then
     Logs.info (fun m -> m "REST transport recovered after %d failure(s)"
@@ -222,7 +303,7 @@ let transport_failure_summary ~host exn =
 
 let parse_retry_after_seconds raw =
   match float_of_string_opt (String.trim raw) with
-  | Some delay -> Some (max 0.0 delay)
+  | Some delay -> clamp_retry_after_seconds delay
   | None -> None
 
 let retry_after_seconds_from_headers headers =
@@ -234,8 +315,8 @@ let retry_after_seconds_from_body body_str =
   try
     let json = Yojson.Safe.from_string body_str in
     match Yojson.Safe.Util.member "retry_after" json with
-    | `Float f -> Some (max 0.0 f)
-    | `Int i -> Some (max 0.0 (float_of_int i))
+    | `Float f -> clamp_retry_after_seconds f
+    | `Int i -> clamp_retry_after_seconds (float_of_int i)
     | _ -> None
   with _ -> None
 
@@ -250,16 +331,22 @@ let retry_after_seconds ?headers body_str =
 let note_transport_failure t ~host exn =
   let (kind, summary) = transport_failure_summary ~host exn in
   let now = now_s t in
-  let delay =
-    with_rest_state t (fun state ->
-      let delay =
-        transport_backoff_seconds (state.consecutive_failures + 1)
-      in
-      note_failure_state state
-        ~now ~summary ~delay)
-  in
-  if retryable_transport_kind kind then (summary, Some delay)
-  else (summary, None)
+  if retryable_transport_kind kind then begin
+    let delay =
+      with_rest_state t (fun state ->
+        let delay =
+          transport_backoff_seconds (state.consecutive_failures + 1)
+        in
+        note_transport_failure_state state
+          ~now ~summary ~delay)
+    in
+    (summary, Some delay)
+  end else begin
+    ignore (with_rest_state t (fun state ->
+      note_transport_failure_without_backoff_state state
+        ~now ~summary));
+    (summary, None)
+  end
 
 let note_http_failure t ~host ~code ~body ?retry_after () =
   let body =
@@ -279,6 +366,23 @@ let note_http_failure t ~host ~code ~body ?retry_after () =
       in
       note_failure_state state
         ~now ~summary ~delay)
+  in
+  (summary, delay)
+
+let note_http_client_failure t ~host ~code ~body =
+  let body =
+    if String.length body <= 500 then body
+    else String.sub body 0 500 ^ "... (truncated)"
+  in
+  let summary =
+    Printf.sprintf "host=%s kind=http_%d error=%s"
+      host code body
+  in
+  let now = now_s t in
+  let delay =
+    with_rest_state t (fun state ->
+      note_failure_without_backoff_state state
+        ~now ~summary)
   in
   (summary, delay)
 
@@ -313,7 +417,10 @@ let rec wait_for_transport_backoff t =
   end
 
 let response_clears_rest_health code =
-  code >= 200 && code < 300
+  (code >= 200 && code < 300) || code = 404
+
+let response_marks_rest_failure code =
+  code >= 400 && code < 500 && code <> 404 && code <> 429
 
 let create ~sw ~(env : Eio_unix.Stdenv.base) ~token =
   Random.self_init ();
@@ -338,7 +445,10 @@ let create ~sw ~(env : Eio_unix.Stdenv.base) ~token =
   let net = Eio.Stdenv.net env in
   let client = Cohttp_eio.Client.make ~https:(Some https) net in
   let clock = Eio.Stdenv.mono_clock env in
-  { token; client; sw; clock;
+  let call ~sw ~headers ?body meth uri =
+    Cohttp_eio.Client.call client ~sw ~headers ?body meth uri
+  in
+  { token; call; sw; clock;
     rest_state = create_health_state (); }
 
 let make_headers t =
@@ -450,7 +560,7 @@ let request ?(retry_mode = No_retry) t ~meth ~path ?body () =
   let meth_str = Http.Method.to_string meth in
   let do_call () =
     let cohttp_body = Option.map Cohttp_eio.Body.of_string body_str in
-    Cohttp_eio.Client.call t.client ~sw:t.sw ~headers ?body:cohttp_body meth uri
+    t.call ~sw:t.sw ~headers ?body:cohttp_body meth uri
   in
   let log_non_2xx code body =
     let body = truncate_for_log body in
@@ -508,6 +618,7 @@ let request ?(retry_mode = No_retry) t ~meth ~path ?body () =
       let headers = Http.Response.headers resp in
       let body_str = read_body resp_body in
       if code = 429 && rate_limit_retries < max_rate_limit_retries then begin
+        note_transport_response t;
         let retry_after =
           Option.value (retry_after_seconds ~headers body_str) ~default:5.0
         in
@@ -519,12 +630,14 @@ let request ?(retry_mode = No_retry) t ~meth ~path ?body () =
             meth_str path delay);
         loop attempt (rate_limit_retries + 1)
       end else if code = 429 then begin
+        note_transport_response t;
         let retry_after =
           Option.value (retry_after_seconds ~headers body_str) ~default:5.0
         in
         ignore (note_rate_limit t ~host ~retry_after ~body:body_str);
         handle_response code body_str
       end else if code >= 500 && code < 600 then begin
+        note_transport_response t;
         let retry_after = retry_after_seconds ~headers body_str in
         let (_summary, default_delay) =
           note_http_failure t ~host ~code ~body:body_str ?retry_after ()
@@ -537,11 +650,17 @@ let request ?(retry_mode = No_retry) t ~meth ~path ?body () =
           loop (attempt + 1) rate_limit_retries
         end else
           handle_response code body_str
+      end else if response_marks_rest_failure code then begin
+        note_transport_response t;
+        ignore (note_http_client_failure t ~host ~code ~body:body_str);
+        handle_response code body_str
       end else if response_clears_rest_health code then begin
-        note_transport_recovery t;
+        note_rest_recovery t;
         handle_response code body_str
-      end else
+      end else begin
+        note_transport_response t;
         handle_response code body_str
+      end
     with exn ->
       raise_if_cancelled exn;
       let (summary, delay_opt) = note_transport_failure t ~host exn in
@@ -811,7 +930,7 @@ let download_url t ~url () =
   let rec loop attempt =
     try
       let (resp, body) =
-        Cohttp_eio.Client.call t.client ~sw:t.sw ~headers `GET uri in
+        t.call ~sw:t.sw ~headers `GET uri in
       let status = Http.Response.status resp in
       let code = Http.Status.to_int status in
       let resp_headers = Http.Response.headers resp in

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,3 @@
 (tests
- (names test_formatting test_project test_agent_contracts)
- (libraries discord_agents alcotest str unix))
+ (names test_formatting test_project test_agent_contracts test_discord_rest)
+ (libraries discord_agents alcotest str unix yojson))

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,4 @@
 (tests
  (names test_formatting test_project test_agent_contracts test_discord_rest)
- (libraries discord_agents alcotest str unix yojson))
+ (libraries discord_agents alcotest str unix yojson eio_main cohttp-eio uri
+  mirage-crypto-rng.unix))

--- a/test/test_discord_rest.ml
+++ b/test/test_discord_rest.ml
@@ -1,0 +1,57 @@
+let test_create_message_body_enforces_nonce () =
+  let json =
+    Discord_agents.Discord_rest.create_message_body
+      ~content:"hello"
+      ~reply_to:"123"
+      ~nonce:"abcdef0123456789abcdef01"
+      ()
+  in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "content"
+    "hello" (json |> member "content" |> to_string);
+  Alcotest.(check string) "nonce"
+    "abcdef0123456789abcdef01" (json |> member "nonce" |> to_string);
+  Alcotest.(check bool) "enforce_nonce"
+    true (json |> member "enforce_nonce" |> to_bool);
+  Alcotest.(check string) "reply_to"
+    "123"
+    (json |> member "message_reference" |> member "message_id" |> to_string)
+
+let test_transport_error_classification () =
+  let classify msg =
+    Discord_agents.Discord_rest.classify_transport_error_message msg
+    |> Discord_agents.Discord_rest.string_of_transport_error_kind
+  in
+  Alcotest.(check string) "hostname resolution"
+    "hostname_resolution"
+    (classify "Failure(\"failed to resolve hostname\")");
+  Alcotest.(check string) "timeout"
+    "timeout"
+    (classify "Unix.Unix_error(ETIMEDOUT, \"connect\", \"\")");
+  Alcotest.(check string) "connection"
+    "connection"
+    (classify "Failure(\"connection reset by peer\")")
+
+let test_transport_backoff_caps () =
+  let check expected failures =
+    Alcotest.(check (float 1e-9))
+      (Printf.sprintf "failures=%d" failures)
+      expected
+      (Discord_agents.Discord_rest.transport_backoff_seconds failures)
+  in
+  check 0.5 1;
+  check 1.0 2;
+  check 2.0 3;
+  check 8.0 10
+
+let () =
+  Alcotest.run "discord_rest" [
+    ("discord_rest", [
+      Alcotest.test_case "create_message_body enforces nonce" `Quick
+        test_create_message_body_enforces_nonce;
+      Alcotest.test_case "transport error classification" `Quick
+        test_transport_error_classification;
+      Alcotest.test_case "transport backoff caps" `Quick
+        test_transport_backoff_caps;
+    ]);
+  ]

--- a/test/test_discord_rest.ml
+++ b/test/test_discord_rest.ml
@@ -63,6 +63,18 @@ let test_transport_error_classification () =
   Alcotest.(check string) "connection"
     "connection"
     (classify "Failure(\"connection reset by peer\")");
+  Alcotest.(check string) "network unreachable errno"
+    "connection"
+    (classify (Printexc.to_string
+      (Unix.Unix_error (Unix.ENETUNREACH, "connect", "discord.com"))));
+  Alcotest.(check string) "host unreachable errno"
+    "connection"
+    (classify (Printexc.to_string
+      (Unix.Unix_error (Unix.EHOSTUNREACH, "connect", "discord.com"))));
+  Alcotest.(check string) "broken pipe errno"
+    "connection"
+    (classify (Printexc.to_string
+      (Unix.Unix_error (Unix.EPIPE, "write", "discord.com"))));
   Alcotest.(check string) "other"
     "other_transport"
     (classify "Failure(\"unexpected library wording\")")

--- a/test/test_discord_rest.ml
+++ b/test/test_discord_rest.ml
@@ -251,6 +251,56 @@ let test_rest_backoff_survives_unrelated_recovery () =
   Alcotest.(check (float 1e-9)) "expired deadline cleared"
     0.0 (Rest.health_retry_delay_s ~now:(ts 16.0) state)
 
+let test_rest_backoff_survives_transport_shadowing () =
+  let ts seconds = Mtime.of_uint64_ns (Int64.of_float (seconds *. 1e9)) in
+  let state = Rest.create_health_state () in
+  let _ =
+    Rest.note_rate_limit_state state
+      ~now:(ts 10.0) ~summary:"429" ~delay:5.0
+  in
+  let delay =
+    Rest.note_transport_failure_state state
+      ~now:(ts 11.0) ~summary:"timeout" ~delay:8.0
+  in
+  Alcotest.(check (float 1e-9)) "transport extends combined deadline"
+    8.0 delay;
+  let transport_failures = Rest.note_transport_response_state state in
+  Alcotest.(check int) "transport response reports failure"
+    1 transport_failures;
+  Alcotest.(check bool) "transport cleared"
+    false (Rest.health_transport_degraded state);
+  Alcotest.(check bool) "rest backoff still degraded"
+    true (Rest.health_degraded state);
+  Alcotest.(check (option string)) "rest error preserved"
+    (Some "429") (Rest.health_last_error state);
+  Alcotest.(check (float 1e-9)) "transport clear exposes rest deadline"
+    4.0 (Rest.health_retry_delay_s ~now:(ts 11.0) state)
+
+let test_transport_backoff_survives_rest_shadowing () =
+  let ts seconds = Mtime.of_uint64_ns (Int64.of_float (seconds *. 1e9)) in
+  let state = Rest.create_health_state () in
+  let _ =
+    Rest.note_transport_failure_state state
+      ~now:(ts 10.0) ~summary:"timeout" ~delay:8.0
+  in
+  let delay =
+    Rest.note_failure_state state
+      ~now:(ts 11.0) ~summary:"500" ~delay:4.0
+  in
+  Alcotest.(check (float 1e-9)) "transport remains combined deadline"
+    7.0 delay;
+  let transport_failures = Rest.note_transport_response_state state in
+  Alcotest.(check int) "transport response reports failure"
+    1 transport_failures;
+  Alcotest.(check bool) "transport cleared"
+    false (Rest.health_transport_degraded state);
+  Alcotest.(check bool) "rest backoff remains degraded"
+    true (Rest.health_degraded state);
+  Alcotest.(check (option string)) "rest error preserved"
+    (Some "500") (Rest.health_last_error state);
+  Alcotest.(check (float 1e-9)) "rest deadline remains after transport clear"
+    4.0 (Rest.health_retry_delay_s ~now:(ts 11.0) state)
+
 let test_transport_health_clears_separately () =
   let ts seconds = Mtime.of_uint64_ns (Int64.of_float (seconds *. 1e9)) in
   let state = Rest.create_health_state () in
@@ -406,6 +456,10 @@ let () =
         test_rate_limit_state_preserves_backoff_window;
       Alcotest.test_case "rest backoff survives unrelated recovery" `Quick
         test_rest_backoff_survives_unrelated_recovery;
+      Alcotest.test_case "rest backoff survives transport shadowing" `Quick
+        test_rest_backoff_survives_transport_shadowing;
+      Alcotest.test_case "transport backoff survives rest shadowing" `Quick
+        test_transport_backoff_survives_rest_shadowing;
       Alcotest.test_case "transport health clears separately" `Quick
         test_transport_health_clears_separately;
       Alcotest.test_case "client failure records without backoff" `Quick

--- a/test/test_discord_rest.ml
+++ b/test/test_discord_rest.ml
@@ -30,7 +30,10 @@ let test_transport_error_classification () =
     (classify "Unix.Unix_error(ETIMEDOUT, \"connect\", \"\")");
   Alcotest.(check string) "connection"
     "connection"
-    (classify "Failure(\"connection reset by peer\")")
+    (classify "Failure(\"connection reset by peer\")");
+  Alcotest.(check string) "other"
+    "other_transport"
+    (classify "Failure(\"unexpected library wording\")")
 
 let test_transport_backoff_caps () =
   let check expected failures =
@@ -44,6 +47,157 @@ let test_transport_backoff_caps () =
   check 2.0 3;
   check 8.0 10
 
+let test_decode_json_body_reports_parse_error () =
+  match Discord_agents.Discord_rest.decode_json_body "{not json" with
+  | Ok _ -> Alcotest.fail "expected parse error"
+  | Error err ->
+    Alcotest.(check bool) "non-empty error"
+      true (String.length err > 0)
+
+let test_next_backoff_until_updates_deadline () =
+  let ts seconds = Mtime.of_uint64_ns (Int64.of_float (seconds *. 1e9)) in
+  let ts_s t = Int64.to_float (Mtime.to_uint64_ns t) /. 1e9 in
+  Alcotest.(check (float 1e-9)) "active window extends when needed"
+    13.0
+    (Discord_agents.Discord_rest.next_backoff_until
+      ~now:(ts 9.0) ~current_until:(Some (ts 10.0)) ~delay:4.0
+     |> ts_s);
+  Alcotest.(check (float 1e-9)) "active longer window preserved"
+    10.0
+    (Discord_agents.Discord_rest.next_backoff_until
+      ~now:(ts 9.0) ~current_until:(Some (ts 10.0)) ~delay:0.5
+     |> ts_s);
+  Alcotest.(check (float 1e-9)) "expired window advances"
+    15.0
+    (Discord_agents.Discord_rest.next_backoff_until
+      ~now:(ts 11.0) ~current_until:(Some (ts 10.0)) ~delay:4.0
+     |> ts_s);
+  Alcotest.(check (float 1e-9)) "missing window starts fresh"
+    15.0
+    (Discord_agents.Discord_rest.next_backoff_until
+      ~now:(ts 11.0) ~current_until:None ~delay:4.0
+     |> ts_s)
+
+let test_retry_after_seconds_from_body () =
+  Alcotest.(check (option (float 1e-9))) "float retry_after"
+    (Some 2.5)
+    (Discord_agents.Discord_rest.retry_after_seconds_from_body
+      {|{"retry_after":2.5}|});
+  Alcotest.(check (option (float 1e-9))) "int retry_after"
+    (Some 3.0)
+    (Discord_agents.Discord_rest.retry_after_seconds_from_body
+      {|{"retry_after":3}|});
+  Alcotest.(check (option (float 1e-9))) "missing retry_after"
+    None
+    (Discord_agents.Discord_rest.retry_after_seconds_from_body
+      {|{"message":"nope"}|});
+  Alcotest.(check (option (float 1e-9))) "retry_after preserves zero"
+    (Some 0.0)
+    (Discord_agents.Discord_rest.retry_after_seconds_from_body
+      {|{"retry_after":0}|});
+  Alcotest.(check (option (float 1e-9))) "retry_after preserves large values"
+    (Some 9999.0)
+    (Discord_agents.Discord_rest.retry_after_seconds_from_body
+      {|{"retry_after":9999}|})
+
+let test_retry_after_seconds_prefers_headers () =
+  let headers = Http.Header.of_list [("retry-after", "4.5")] in
+  Alcotest.(check (option (float 1e-9))) "header preferred"
+    (Some 4.5)
+    (Discord_agents.Discord_rest.retry_after_seconds
+      ~headers {|{"retry_after":2.5}|});
+  Alcotest.(check (option (float 1e-9))) "header fallback to body"
+    (Some 2.5)
+    (Discord_agents.Discord_rest.retry_after_seconds
+      ~headers:(Http.Header.of_list [("retry-after", "not-a-number")])
+      {|{"retry_after":2.5}|})
+
+let test_health_state_failure_and_recovery () =
+  let ts seconds = Mtime.of_uint64_ns (Int64.of_float (seconds *. 1e9)) in
+  let state = Discord_agents.Discord_rest.create_health_state () in
+  let delay1 =
+    Discord_agents.Discord_rest.note_failure_state state
+      ~now:(ts 10.0) ~summary:"first" ~delay:0.5
+  in
+  Alcotest.(check (float 1e-9)) "first delay" 0.5 delay1;
+  Alcotest.(check bool) "degraded after failure"
+    true (Discord_agents.Discord_rest.health_degraded state);
+  Alcotest.(check (option string)) "error recorded"
+    (Some "first") (Discord_agents.Discord_rest.health_last_error state);
+  Alcotest.(check int) "failures incremented"
+    1 (Discord_agents.Discord_rest.health_consecutive_failures state);
+  Alcotest.(check (float 1e-9)) "backoff set"
+    0.5
+    (Discord_agents.Discord_rest.health_retry_delay_s ~now:(ts 10.0) state);
+  let cleared =
+    Discord_agents.Discord_rest.note_recovery_state state
+  in
+  Alcotest.(check int) "recovery reports prior failures"
+    1 cleared;
+  Alcotest.(check bool) "recovery clears degraded"
+    false (Discord_agents.Discord_rest.health_degraded state);
+  Alcotest.(check (option string)) "recovery clears error"
+    None (Discord_agents.Discord_rest.health_last_error state)
+
+let test_health_state_returns_effective_shared_delay () =
+  let ts seconds = Mtime.of_uint64_ns (Int64.of_float (seconds *. 1e9)) in
+  let state = Discord_agents.Discord_rest.create_health_state () in
+  let _ =
+    Discord_agents.Discord_rest.note_failure_state state
+      ~now:(ts 10.0) ~summary:"first" ~delay:5.0
+  in
+  let delay =
+    Discord_agents.Discord_rest.note_failure_state state
+      ~now:(ts 11.0) ~summary:"second" ~delay:1.0
+  in
+  Alcotest.(check (float 1e-9)) "effective delay respects longer active window"
+    4.0 delay
+
+let test_rate_limit_state_preserves_backoff_window () =
+  let ts seconds = Mtime.of_uint64_ns (Int64.of_float (seconds *. 1e9)) in
+  let state = Discord_agents.Discord_rest.create_health_state () in
+  let _ =
+    Discord_agents.Discord_rest.note_rate_limit_state state
+      ~now:(ts 10.0) ~summary:"429" ~delay:3.0
+  in
+  Alcotest.(check int) "rate limit marks degraded"
+    1 (Discord_agents.Discord_rest.health_consecutive_failures state);
+  let _ =
+    Discord_agents.Discord_rest.note_rate_limit_state state
+      ~now:(ts 11.0) ~summary:"429-again" ~delay:1.0
+  in
+  Alcotest.(check int) "repeated rate limits increment failures"
+    2 (Discord_agents.Discord_rest.health_consecutive_failures state);
+  Alcotest.(check (float 1e-9)) "active window preserved"
+    2.0
+    (Discord_agents.Discord_rest.health_retry_delay_s ~now:(ts 11.0) state);
+  let _ =
+    Discord_agents.Discord_rest.note_rate_limit_state state
+      ~now:(ts 11.0) ~summary:"429-extend" ~delay:5.0
+  in
+  Alcotest.(check (float 1e-9)) "longer retry_after extends window"
+    5.0
+    (Discord_agents.Discord_rest.health_retry_delay_s ~now:(ts 11.0) state);
+  let _ =
+    Discord_agents.Discord_rest.note_rate_limit_state state
+      ~now:(ts 15.0) ~summary:"429-later" ~delay:2.0
+  in
+  Alcotest.(check (float 1e-9)) "later candidate extends active window"
+    2.0
+    (Discord_agents.Discord_rest.health_retry_delay_s ~now:(ts 15.0) state)
+
+let test_response_clears_rest_health () =
+  Alcotest.(check bool) "200 clears"
+    true (Discord_agents.Discord_rest.response_clears_rest_health 200);
+  Alcotest.(check bool) "204 clears"
+    true (Discord_agents.Discord_rest.response_clears_rest_health 204);
+  Alcotest.(check bool) "400 does not clear"
+    false (Discord_agents.Discord_rest.response_clears_rest_health 400);
+  Alcotest.(check bool) "404 does not clear"
+    false (Discord_agents.Discord_rest.response_clears_rest_health 404);
+  Alcotest.(check bool) "500 does not clear"
+    false (Discord_agents.Discord_rest.response_clears_rest_health 500)
+
 let () =
   Alcotest.run "discord_rest" [
     ("discord_rest", [
@@ -53,5 +207,21 @@ let () =
         test_transport_error_classification;
       Alcotest.test_case "transport backoff caps" `Quick
         test_transport_backoff_caps;
+      Alcotest.test_case "decode_json_body reports parse error" `Quick
+        test_decode_json_body_reports_parse_error;
+      Alcotest.test_case "next_backoff_until updates deadlines" `Quick
+        test_next_backoff_until_updates_deadline;
+      Alcotest.test_case "retry_after_seconds_from_body parses int/float" `Quick
+        test_retry_after_seconds_from_body;
+      Alcotest.test_case "retry_after_seconds prefers headers" `Quick
+        test_retry_after_seconds_prefers_headers;
+      Alcotest.test_case "health state failure and recovery" `Quick
+        test_health_state_failure_and_recovery;
+      Alcotest.test_case "health state returns effective shared delay" `Quick
+        test_health_state_returns_effective_shared_delay;
+      Alcotest.test_case "rate limit state preserves backoff window" `Quick
+        test_rate_limit_state_preserves_backoff_window;
+      Alcotest.test_case "response_clears_rest_health only for 2xx" `Quick
+        test_response_clears_rest_health;
     ]);
   ]

--- a/test/test_discord_rest.ml
+++ b/test/test_discord_rest.ml
@@ -154,6 +154,12 @@ let test_retry_after_rejects_non_finite_values () =
   Alcotest.(check (option (float 1e-9))) "huge exponent rejected"
     None (Rest.parse_retry_after_seconds "1e9999")
 
+let test_body_for_health_summary_preserves_utf8_boundary () =
+  let body = String.make 499 'x' ^ "\xC3\xA9tail" in
+  Alcotest.(check string) "drops incomplete final codepoint"
+    (String.make 499 'x' ^ "... (truncated)")
+    (Rest.body_for_health_summary body)
+
 let test_health_state_failure_and_recovery () =
   let ts seconds = Mtime.of_uint64_ns (Int64.of_float (seconds *. 1e9)) in
   let state = Rest.create_health_state () in
@@ -275,6 +281,24 @@ let test_rest_backoff_survives_transport_shadowing () =
     (Some "429") (Rest.health_last_error state);
   Alcotest.(check (float 1e-9)) "transport clear exposes rest deadline"
     4.0 (Rest.health_retry_delay_s ~now:(ts 11.0) state)
+
+let test_rest_backoff_preserves_error_on_nonretryable_transport () =
+  let ts seconds = Mtime.of_uint64_ns (Int64.of_float (seconds *. 1e9)) in
+  let state = Rest.create_health_state () in
+  let _ =
+    Rest.note_rate_limit_state state
+      ~now:(ts 10.0) ~summary:"429" ~delay:5.0
+  in
+  let delay =
+    Rest.note_transport_failure_without_backoff_state state
+      ~now:(ts 11.0) ~summary:"unexpected"
+  in
+  Alcotest.(check (float 1e-9)) "rest deadline remains active"
+    4.0 delay;
+  Alcotest.(check (option string)) "rest error preserved"
+    (Some "429") (Rest.health_last_error state);
+  Alcotest.(check (option string)) "transport error recorded"
+    (Some "unexpected") (Rest.health_last_transport_error state)
 
 let test_transport_backoff_survives_rest_shadowing () =
   let ts seconds = Mtime.of_uint64_ns (Int64.of_float (seconds *. 1e9)) in
@@ -448,6 +472,8 @@ let () =
         test_retry_after_seconds_prefers_headers;
       Alcotest.test_case "retry_after rejects non-finite values" `Quick
         test_retry_after_rejects_non_finite_values;
+      Alcotest.test_case "health summary truncates on UTF-8 boundary" `Quick
+        test_body_for_health_summary_preserves_utf8_boundary;
       Alcotest.test_case "health state failure and recovery" `Quick
         test_health_state_failure_and_recovery;
       Alcotest.test_case "health state returns effective shared delay" `Quick
@@ -458,6 +484,8 @@ let () =
         test_rest_backoff_survives_unrelated_recovery;
       Alcotest.test_case "rest backoff survives transport shadowing" `Quick
         test_rest_backoff_survives_transport_shadowing;
+      Alcotest.test_case "rest backoff preserves nonretryable transport error" `Quick
+        test_rest_backoff_preserves_error_on_nonretryable_transport;
       Alcotest.test_case "transport backoff survives rest shadowing" `Quick
         test_transport_backoff_survives_rest_shadowing;
       Alcotest.test_case "transport health clears separately" `Quick

--- a/test/test_discord_rest.ml
+++ b/test/test_discord_rest.ml
@@ -198,6 +198,18 @@ let test_response_clears_rest_health () =
   Alcotest.(check bool) "500 does not clear"
     false (Discord_agents.Discord_rest.response_clears_rest_health 500)
 
+let test_read_body_reports_truncation () =
+  let chunk =
+    String.make (Discord_agents.Discord_rest.max_body_size + 8192) 'x'
+  in
+  let body = Cohttp_eio.Body.of_string chunk in
+  let (body_str, truncated) =
+    Discord_agents.Discord_rest.read_body_with_truncation body
+  in
+  Alcotest.(check bool) "truncated" true truncated;
+  Alcotest.(check bool) "not full body"
+    true (String.length body_str < String.length chunk)
+
 let () =
   Alcotest.run "discord_rest" [
     ("discord_rest", [
@@ -223,5 +235,7 @@ let () =
         test_rate_limit_state_preserves_backoff_window;
       Alcotest.test_case "response_clears_rest_health only for 2xx" `Quick
         test_response_clears_rest_health;
+      Alcotest.test_case "read_body reports truncation" `Quick
+        test_read_body_reports_truncation;
     ]);
   ]

--- a/test/test_discord_rest.ml
+++ b/test/test_discord_rest.ml
@@ -1,6 +1,38 @@
+module Rest = Discord_agents.Discord_rest
+
+let rng_initialized = ref false
+
+let ensure_rng () =
+  if not !rng_initialized then begin
+    Mirage_crypto_rng_unix.use_default ();
+    rng_initialized := true
+  end
+
+let response ?(headers = Http.Header.of_list []) code body =
+  (Http.Response.make ~status:(Http.Status.of_int code) ~headers (),
+   Cohttp_eio.Body.of_string body)
+
+let with_fake_rest call f =
+  ensure_rng ();
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let t : Rest.t = {
+    token = "test-token";
+    call;
+    sw;
+    clock = Eio.Stdenv.mono_clock env;
+    rest_state = Rest.create_health_state ();
+  } in
+  f t
+
+let body_json body =
+  match body with
+  | None -> None
+  | Some body -> Some (Rest.read_body body)
+
 let test_create_message_body_enforces_nonce () =
   let json =
-    Discord_agents.Discord_rest.create_message_body
+    Rest.create_message_body
       ~content:"hello"
       ~reply_to:"123"
       ~nonce:"abcdef0123456789abcdef01"
@@ -19,8 +51,8 @@ let test_create_message_body_enforces_nonce () =
 
 let test_transport_error_classification () =
   let classify msg =
-    Discord_agents.Discord_rest.classify_transport_error_message msg
-    |> Discord_agents.Discord_rest.string_of_transport_error_kind
+    Rest.classify_transport_error_message msg
+    |> Rest.string_of_transport_error_kind
   in
   Alcotest.(check string) "hostname resolution"
     "hostname_resolution"
@@ -40,7 +72,7 @@ let test_transport_backoff_caps () =
     Alcotest.(check (float 1e-9))
       (Printf.sprintf "failures=%d" failures)
       expected
-      (Discord_agents.Discord_rest.transport_backoff_seconds failures)
+      (Rest.transport_backoff_seconds failures)
   in
   check 0.5 1;
   check 1.0 2;
@@ -48,7 +80,7 @@ let test_transport_backoff_caps () =
   check 8.0 10
 
 let test_decode_json_body_reports_parse_error () =
-  match Discord_agents.Discord_rest.decode_json_body "{not json" with
+  match Rest.decode_json_body "{not json" with
   | Ok _ -> Alcotest.fail "expected parse error"
   | Error err ->
     Alcotest.(check bool) "non-empty error"
@@ -59,95 +91,105 @@ let test_next_backoff_until_updates_deadline () =
   let ts_s t = Int64.to_float (Mtime.to_uint64_ns t) /. 1e9 in
   Alcotest.(check (float 1e-9)) "active window extends when needed"
     13.0
-    (Discord_agents.Discord_rest.next_backoff_until
+    (Rest.next_backoff_until
       ~now:(ts 9.0) ~current_until:(Some (ts 10.0)) ~delay:4.0
      |> ts_s);
   Alcotest.(check (float 1e-9)) "active longer window preserved"
     10.0
-    (Discord_agents.Discord_rest.next_backoff_until
+    (Rest.next_backoff_until
       ~now:(ts 9.0) ~current_until:(Some (ts 10.0)) ~delay:0.5
      |> ts_s);
   Alcotest.(check (float 1e-9)) "expired window advances"
     15.0
-    (Discord_agents.Discord_rest.next_backoff_until
+    (Rest.next_backoff_until
       ~now:(ts 11.0) ~current_until:(Some (ts 10.0)) ~delay:4.0
      |> ts_s);
   Alcotest.(check (float 1e-9)) "missing window starts fresh"
     15.0
-    (Discord_agents.Discord_rest.next_backoff_until
+    (Rest.next_backoff_until
       ~now:(ts 11.0) ~current_until:None ~delay:4.0
      |> ts_s)
 
 let test_retry_after_seconds_from_body () =
   Alcotest.(check (option (float 1e-9))) "float retry_after"
     (Some 2.5)
-    (Discord_agents.Discord_rest.retry_after_seconds_from_body
+    (Rest.retry_after_seconds_from_body
       {|{"retry_after":2.5}|});
   Alcotest.(check (option (float 1e-9))) "int retry_after"
     (Some 3.0)
-    (Discord_agents.Discord_rest.retry_after_seconds_from_body
+    (Rest.retry_after_seconds_from_body
       {|{"retry_after":3}|});
   Alcotest.(check (option (float 1e-9))) "missing retry_after"
     None
-    (Discord_agents.Discord_rest.retry_after_seconds_from_body
+    (Rest.retry_after_seconds_from_body
       {|{"message":"nope"}|});
   Alcotest.(check (option (float 1e-9))) "retry_after preserves zero"
     (Some 0.0)
-    (Discord_agents.Discord_rest.retry_after_seconds_from_body
+    (Rest.retry_after_seconds_from_body
       {|{"retry_after":0}|});
-  Alcotest.(check (option (float 1e-9))) "retry_after preserves large values"
-    (Some 9999.0)
-    (Discord_agents.Discord_rest.retry_after_seconds_from_body
+  Alcotest.(check (option (float 1e-9))) "retry_after caps large values"
+    (Some Rest.max_retry_after_s)
+    (Rest.retry_after_seconds_from_body
       {|{"retry_after":9999}|})
 
 let test_retry_after_seconds_prefers_headers () =
   let headers = Http.Header.of_list [("retry-after", "4.5")] in
   Alcotest.(check (option (float 1e-9))) "header preferred"
     (Some 4.5)
-    (Discord_agents.Discord_rest.retry_after_seconds
+    (Rest.retry_after_seconds
       ~headers {|{"retry_after":2.5}|});
   Alcotest.(check (option (float 1e-9))) "header fallback to body"
     (Some 2.5)
-    (Discord_agents.Discord_rest.retry_after_seconds
+    (Rest.retry_after_seconds
       ~headers:(Http.Header.of_list [("retry-after", "not-a-number")])
       {|{"retry_after":2.5}|})
 
+let test_retry_after_rejects_non_finite_values () =
+  let check_none label raw =
+    Alcotest.(check (option (float 1e-9))) label
+      None (Rest.parse_retry_after_seconds raw)
+  in
+  check_none "nan rejected" "nan";
+  check_none "infinity rejected" "inf";
+  Alcotest.(check (option (float 1e-9))) "huge exponent rejected"
+    None (Rest.parse_retry_after_seconds "1e9999")
+
 let test_health_state_failure_and_recovery () =
   let ts seconds = Mtime.of_uint64_ns (Int64.of_float (seconds *. 1e9)) in
-  let state = Discord_agents.Discord_rest.create_health_state () in
+  let state = Rest.create_health_state () in
   let delay1 =
-    Discord_agents.Discord_rest.note_failure_state state
+    Rest.note_failure_state state
       ~now:(ts 10.0) ~summary:"first" ~delay:0.5
   in
   Alcotest.(check (float 1e-9)) "first delay" 0.5 delay1;
   Alcotest.(check bool) "degraded after failure"
-    true (Discord_agents.Discord_rest.health_degraded state);
+    true (Rest.health_degraded state);
   Alcotest.(check (option string)) "error recorded"
-    (Some "first") (Discord_agents.Discord_rest.health_last_error state);
+    (Some "first") (Rest.health_last_error state);
   Alcotest.(check int) "failures incremented"
-    1 (Discord_agents.Discord_rest.health_consecutive_failures state);
+    1 (Rest.health_consecutive_failures state);
   Alcotest.(check (float 1e-9)) "backoff set"
     0.5
-    (Discord_agents.Discord_rest.health_retry_delay_s ~now:(ts 10.0) state);
+    (Rest.health_retry_delay_s ~now:(ts 10.0) state);
   let cleared =
-    Discord_agents.Discord_rest.note_recovery_state state
+    Rest.note_recovery_state state
   in
   Alcotest.(check int) "recovery reports prior failures"
     1 cleared;
   Alcotest.(check bool) "recovery clears degraded"
-    false (Discord_agents.Discord_rest.health_degraded state);
+    false (Rest.health_degraded state);
   Alcotest.(check (option string)) "recovery clears error"
-    None (Discord_agents.Discord_rest.health_last_error state)
+    None (Rest.health_last_error state)
 
 let test_health_state_returns_effective_shared_delay () =
   let ts seconds = Mtime.of_uint64_ns (Int64.of_float (seconds *. 1e9)) in
-  let state = Discord_agents.Discord_rest.create_health_state () in
+  let state = Rest.create_health_state () in
   let _ =
-    Discord_agents.Discord_rest.note_failure_state state
+    Rest.note_failure_state state
       ~now:(ts 10.0) ~summary:"first" ~delay:5.0
   in
   let delay =
-    Discord_agents.Discord_rest.note_failure_state state
+    Rest.note_failure_state state
       ~now:(ts 11.0) ~summary:"second" ~delay:1.0
   in
   Alcotest.(check (float 1e-9)) "effective delay respects longer active window"
@@ -155,60 +197,162 @@ let test_health_state_returns_effective_shared_delay () =
 
 let test_rate_limit_state_preserves_backoff_window () =
   let ts seconds = Mtime.of_uint64_ns (Int64.of_float (seconds *. 1e9)) in
-  let state = Discord_agents.Discord_rest.create_health_state () in
+  let state = Rest.create_health_state () in
   let _ =
-    Discord_agents.Discord_rest.note_rate_limit_state state
+    Rest.note_rate_limit_state state
       ~now:(ts 10.0) ~summary:"429" ~delay:3.0
   in
   Alcotest.(check int) "rate limit marks degraded"
-    1 (Discord_agents.Discord_rest.health_consecutive_failures state);
+    1 (Rest.health_consecutive_failures state);
   let _ =
-    Discord_agents.Discord_rest.note_rate_limit_state state
+    Rest.note_rate_limit_state state
       ~now:(ts 11.0) ~summary:"429-again" ~delay:1.0
   in
   Alcotest.(check int) "repeated rate limits increment failures"
-    2 (Discord_agents.Discord_rest.health_consecutive_failures state);
+    2 (Rest.health_consecutive_failures state);
   Alcotest.(check (float 1e-9)) "active window preserved"
     2.0
-    (Discord_agents.Discord_rest.health_retry_delay_s ~now:(ts 11.0) state);
+    (Rest.health_retry_delay_s ~now:(ts 11.0) state);
   let _ =
-    Discord_agents.Discord_rest.note_rate_limit_state state
+    Rest.note_rate_limit_state state
       ~now:(ts 11.0) ~summary:"429-extend" ~delay:5.0
   in
   Alcotest.(check (float 1e-9)) "longer retry_after extends window"
     5.0
-    (Discord_agents.Discord_rest.health_retry_delay_s ~now:(ts 11.0) state);
+    (Rest.health_retry_delay_s ~now:(ts 11.0) state);
   let _ =
-    Discord_agents.Discord_rest.note_rate_limit_state state
+    Rest.note_rate_limit_state state
       ~now:(ts 15.0) ~summary:"429-later" ~delay:2.0
   in
   Alcotest.(check (float 1e-9)) "later candidate extends active window"
     2.0
-    (Discord_agents.Discord_rest.health_retry_delay_s ~now:(ts 15.0) state)
+    (Rest.health_retry_delay_s ~now:(ts 15.0) state)
+
+let test_transport_health_clears_separately () =
+  let ts seconds = Mtime.of_uint64_ns (Int64.of_float (seconds *. 1e9)) in
+  let state = Rest.create_health_state () in
+  let _ =
+    Rest.note_transport_failure_state state
+      ~now:(ts 10.0) ~summary:"transport" ~delay:0.5
+  in
+  Alcotest.(check bool) "rest degraded"
+    true (Rest.health_degraded state);
+  Alcotest.(check bool) "transport degraded"
+    true (Rest.health_transport_degraded state);
+  Alcotest.(check int) "transport failures"
+    1 (Rest.health_consecutive_transport_failures state);
+  let cleared = Rest.note_transport_response_state state in
+  Alcotest.(check int) "transport response reports failures" 1 cleared;
+  Alcotest.(check bool) "rest remains degraded"
+    true (Rest.health_degraded state);
+  Alcotest.(check bool) "transport cleared"
+    false (Rest.health_transport_degraded state);
+  Alcotest.(check (option string)) "transport error cleared"
+    None (Rest.health_last_transport_error state)
+
+let test_client_failure_without_backoff_state () =
+  let ts seconds = Mtime.of_uint64_ns (Int64.of_float (seconds *. 1e9)) in
+  let state = Rest.create_health_state () in
+  let delay =
+    Rest.note_failure_without_backoff_state state
+      ~now:(ts 10.0) ~summary:"host=discord.com kind=http_401 error=bad auth"
+  in
+  Alcotest.(check (float 1e-9)) "no backoff delay" 0.0 delay;
+  Alcotest.(check int) "failure recorded"
+    1 (Rest.health_consecutive_failures state);
+  Alcotest.(check (float 1e-9)) "no retry delay"
+    0.0 (Rest.health_retry_delay_s ~now:(ts 10.0) state)
 
 let test_response_clears_rest_health () =
   Alcotest.(check bool) "200 clears"
-    true (Discord_agents.Discord_rest.response_clears_rest_health 200);
+    true (Rest.response_clears_rest_health 200);
   Alcotest.(check bool) "204 clears"
-    true (Discord_agents.Discord_rest.response_clears_rest_health 204);
+    true (Rest.response_clears_rest_health 204);
   Alcotest.(check bool) "400 does not clear"
-    false (Discord_agents.Discord_rest.response_clears_rest_health 400);
-  Alcotest.(check bool) "404 does not clear"
-    false (Discord_agents.Discord_rest.response_clears_rest_health 404);
+    false (Rest.response_clears_rest_health 400);
+  Alcotest.(check bool) "404 clears expected missing resources"
+    true (Rest.response_clears_rest_health 404);
   Alcotest.(check bool) "500 does not clear"
-    false (Discord_agents.Discord_rest.response_clears_rest_health 500)
+    false (Rest.response_clears_rest_health 500);
+  Alcotest.(check bool) "401 marks rest failure"
+    true (Rest.response_marks_rest_failure 401);
+  Alcotest.(check bool) "404 does not mark failure"
+    false (Rest.response_marks_rest_failure 404);
+  Alcotest.(check bool) "429 handled separately"
+    false (Rest.response_marks_rest_failure 429)
 
 let test_read_body_reports_truncation () =
   let chunk =
-    String.make (Discord_agents.Discord_rest.max_body_size + 8192) 'x'
+    String.make (Rest.max_body_size + 8192) 'x'
   in
   let body = Cohttp_eio.Body.of_string chunk in
   let (body_str, truncated) =
-    Discord_agents.Discord_rest.read_body_with_truncation body
+    Rest.read_body_with_truncation body
   in
   Alcotest.(check bool) "truncated" true truncated;
   Alcotest.(check bool) "not full body"
     true (String.length body_str < String.length chunk)
+
+let test_create_message_reuses_nonce_across_5xx_retry () =
+  let attempts = ref [] in
+  let call ~sw:_ ~headers:_ ?body meth uri =
+    attempts := (meth, Uri.path uri, body_json body) :: !attempts;
+    match List.length !attempts with
+    | 1 ->
+      response
+        ~headers:(Http.Header.of_list [("retry-after", "0")])
+        500 {|{"message":"server unavailable"}|}
+    | _ ->
+      response 200
+        {|{"id":"m1","channel_id":"c1","author":{"id":"u1","username":"bot"},"content":"hello","timestamp":"2026-06-05T00:00:00.000000+00:00"}|}
+  in
+  with_fake_rest call @@ fun t ->
+  match Rest.create_message t ~channel_id:"c1" ~content:"hello" () with
+  | Error err -> Alcotest.fail ("expected retry success: " ^ err)
+  | Ok _ ->
+    let attempts = List.rev !attempts in
+    Alcotest.(check int) "two attempts" 2 (List.length attempts);
+    match attempts with
+    | [(`POST, _, Some body1); (`POST, _, Some body2)] ->
+      Alcotest.(check string) "serialized body reused" body1 body2;
+      let open Yojson.Safe.Util in
+      let json = Yojson.Safe.from_string body1 in
+      Alcotest.(check string) "nonce stable"
+        (json |> member "nonce" |> to_string)
+        (Yojson.Safe.from_string body2 |> member "nonce" |> to_string);
+      Alcotest.(check bool) "enforce nonce"
+        true (json |> member "enforce_nonce" |> to_bool)
+    | _ -> Alcotest.fail "unexpected attempt shape"
+
+let test_create_channel_does_not_retry_5xx () =
+  let attempts = ref 0 in
+  let call ~sw:_ ~headers:_ ?body:_ _meth _uri =
+    incr attempts;
+    response 500 {|{"message":"server unavailable"}|}
+  in
+  with_fake_rest call @@ fun t ->
+  match Rest.create_channel t ~guild_id:"g1" ~name:"new-channel" () with
+  | Ok _ -> Alcotest.fail "expected create_channel failure"
+  | Error _ ->
+    Alcotest.(check int) "single non-idempotent attempt" 1 !attempts
+
+let test_401_marks_rest_health_without_transport_backoff () =
+  let call ~sw:_ ~headers:_ ?body:_ _meth _uri =
+    response 401 {|{"message":"bad auth"}|}
+  in
+  with_fake_rest call @@ fun t ->
+  match Rest.request t ~meth:`GET ~path:"/gateway/bot" () with
+  | Ok _ -> Alcotest.fail "expected 401 failure"
+  | Error _ ->
+    Alcotest.(check bool) "rest degraded" true (Rest.rest_degraded t);
+    Alcotest.(check bool) "transport not degraded"
+      false (Rest.transport_degraded t);
+    Alcotest.(check (float 1e-9)) "no shared backoff"
+      0.0 (Rest.rest_retry_delay_s t);
+    Alcotest.(check int) "rest failure recorded"
+      1 (Rest.consecutive_rest_failures t);
+    Alcotest.(check int) "transport failure not recorded"
+      0 (Rest.consecutive_transport_failures t)
 
 let () =
   Alcotest.run "discord_rest" [
@@ -227,15 +371,27 @@ let () =
         test_retry_after_seconds_from_body;
       Alcotest.test_case "retry_after_seconds prefers headers" `Quick
         test_retry_after_seconds_prefers_headers;
+      Alcotest.test_case "retry_after rejects non-finite values" `Quick
+        test_retry_after_rejects_non_finite_values;
       Alcotest.test_case "health state failure and recovery" `Quick
         test_health_state_failure_and_recovery;
       Alcotest.test_case "health state returns effective shared delay" `Quick
         test_health_state_returns_effective_shared_delay;
       Alcotest.test_case "rate limit state preserves backoff window" `Quick
         test_rate_limit_state_preserves_backoff_window;
-      Alcotest.test_case "response_clears_rest_health only for 2xx" `Quick
+      Alcotest.test_case "transport health clears separately" `Quick
+        test_transport_health_clears_separately;
+      Alcotest.test_case "client failure records without backoff" `Quick
+        test_client_failure_without_backoff_state;
+      Alcotest.test_case "response_clears_rest_health semantics" `Quick
         test_response_clears_rest_health;
       Alcotest.test_case "read_body reports truncation" `Quick
         test_read_body_reports_truncation;
+      Alcotest.test_case "create_message reuses nonce across 5xx retry" `Quick
+        test_create_message_reuses_nonce_across_5xx_retry;
+      Alcotest.test_case "create_channel does not retry 5xx" `Quick
+        test_create_channel_does_not_retry_5xx;
+      Alcotest.test_case "401 marks rest health without transport backoff" `Quick
+        test_401_marks_rest_health_without_transport_backoff;
     ]);
   ]

--- a/test/test_discord_rest.ml
+++ b/test/test_discord_rest.ml
@@ -172,7 +172,7 @@ let test_health_state_failure_and_recovery () =
     0.5
     (Rest.health_retry_delay_s ~now:(ts 10.0) state);
   let cleared =
-    Rest.note_recovery_state state
+    Rest.note_recovery_state state ~now:(ts 11.0)
   in
   Alcotest.(check int) "recovery reports prior failures"
     1 cleared;
@@ -228,6 +228,29 @@ let test_rate_limit_state_preserves_backoff_window () =
     2.0
     (Rest.health_retry_delay_s ~now:(ts 15.0) state)
 
+let test_rest_backoff_survives_unrelated_recovery () =
+  let ts seconds = Mtime.of_uint64_ns (Int64.of_float (seconds *. 1e9)) in
+  let state = Rest.create_health_state () in
+  let _ =
+    Rest.note_rate_limit_state state
+      ~now:(ts 10.0) ~summary:"429" ~delay:5.0
+  in
+  let failures = Rest.note_recovery_state state ~now:(ts 11.0) in
+  Alcotest.(check int) "reports active rest failures" 1 failures;
+  Alcotest.(check bool) "active rest backoff keeps degraded"
+    true (Rest.health_degraded state);
+  Alcotest.(check (option string)) "active rest error preserved"
+    (Some "429") (Rest.health_last_error state);
+  Alcotest.(check (float 1e-9)) "active deadline preserved"
+    4.0 (Rest.health_retry_delay_s ~now:(ts 11.0) state);
+  let _ = Rest.note_recovery_state state ~now:(ts 16.0) in
+  Alcotest.(check bool) "expired rest backoff can recover"
+    false (Rest.health_degraded state);
+  Alcotest.(check (option string)) "expired rest error cleared"
+    None (Rest.health_last_error state);
+  Alcotest.(check (float 1e-9)) "expired deadline cleared"
+    0.0 (Rest.health_retry_delay_s ~now:(ts 16.0) state)
+
 let test_transport_health_clears_separately () =
   let ts seconds = Mtime.of_uint64_ns (Int64.of_float (seconds *. 1e9)) in
   let state = Rest.create_health_state () in
@@ -245,6 +268,8 @@ let test_transport_health_clears_separately () =
   Alcotest.(check int) "transport response reports failures" 1 cleared;
   Alcotest.(check bool) "rest remains degraded"
     true (Rest.health_degraded state);
+  Alcotest.(check (float 1e-9)) "transport backoff cleared"
+    0.0 (Rest.health_retry_delay_s ~now:(ts 10.0) state);
   Alcotest.(check bool) "transport cleared"
     false (Rest.health_transport_degraded state);
   Alcotest.(check (option string)) "transport error cleared"
@@ -379,6 +404,8 @@ let () =
         test_health_state_returns_effective_shared_delay;
       Alcotest.test_case "rate limit state preserves backoff window" `Quick
         test_rate_limit_state_preserves_backoff_window;
+      Alcotest.test_case "rest backoff survives unrelated recovery" `Quick
+        test_rest_backoff_survives_unrelated_recovery;
       Alcotest.test_case "transport health clears separately" `Quick
         test_transport_health_clears_separately;
       Alcotest.test_case "client failure records without backoff" `Quick

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -1791,6 +1791,37 @@ let test_truncate_utf8_drops_2byte_lead_at_cut () =
   Alcotest.(check string) "incomplete 2-byte lead dropped"
     "x" out
 
+let test_context_header_truncates_utf8_boundary () =
+  let session : Discord_agents.Session_store.session = {
+    project_name = String.make 99 'p' ^ "\xC3\xA9tail";
+    working_dir = "/tmp/project";
+    agent_kind = Discord_agents.Config.Claude;
+    session_id = "sid";
+    session_id_confirmed = true;
+    thread_id = "thread";
+    system_prompt = None;
+    message_count = 0;
+    processing = false;
+    pending_queue = Queue.create ();
+    initial_prompt = None;
+  } in
+  let header =
+    Discord_agents.Agent_runner.build_context_header
+      ~session ~author_name:"author" ~channel_name:"channel"
+      ~channel_type:"thread"
+  in
+  Alcotest.(check bool) "truncated project stays valid"
+    true
+    (String.starts_with
+      ~prefix:("[Discord context: project=" ^ String.make 99 'p' ^ ",")
+      header)
+
+let test_control_thread_name_truncates_utf8_boundary () =
+  let s = String.make 79 't' ^ "\xC3\xA9tail" in
+  Alcotest.(check string) "control name boundary"
+    (String.make 79 't')
+    (Discord_agents.Resource.truncate_utf8 ~max_bytes:80 s)
+
 let truncate_utf8_tests = [
   Alcotest.test_case "preserves \\n in multi-line input" `Quick
     test_truncate_utf8_preserves_newlines;
@@ -1810,6 +1841,10 @@ let truncate_utf8_tests = [
     test_truncate_utf8_keeps_complete_codepoint_at_cut;
   Alcotest.test_case "incomplete 2-byte lead dropped at cut" `Quick
     test_truncate_utf8_drops_2byte_lead_at_cut;
+  Alcotest.test_case "context header truncates UTF-8 boundary" `Quick
+    test_context_header_truncates_utf8_boundary;
+  Alcotest.test_case "control thread name truncates UTF-8 boundary" `Quick
+    test_control_thread_name_truncates_utf8_boundary;
 ]
 
 (* ── sanitize_utf8 ─────────────────────────────────────────────────── *)

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -1816,6 +1816,12 @@ let test_context_header_truncates_utf8_boundary () =
       ~prefix:("[Discord context: project=" ^ String.make 99 'p' ^ ",")
       header)
 
+let test_prompt_preview_truncates_utf8_boundary () =
+  let prompt = String.make 79 'q' ^ "\xC3\xA9tail" in
+  Alcotest.(check string) "prompt preview boundary"
+    (String.make 79 'q' ^ "...")
+    (Discord_agents.Agent_runner.prompt_preview prompt)
+
 let test_control_thread_name_truncates_utf8_boundary () =
   let s = String.make 79 't' ^ "\xC3\xA9tail" in
   Alcotest.(check string) "control name boundary"
@@ -1843,6 +1849,8 @@ let truncate_utf8_tests = [
     test_truncate_utf8_drops_2byte_lead_at_cut;
   Alcotest.test_case "context header truncates UTF-8 boundary" `Quick
     test_context_header_truncates_utf8_boundary;
+  Alcotest.test_case "prompt preview truncates UTF-8 boundary" `Quick
+    test_prompt_preview_truncates_utf8_boundary;
   Alcotest.test_case "control thread name truncates UTF-8 boundary" `Quick
     test_control_thread_name_truncates_utf8_boundary;
 ]


### PR DESCRIPTION
## Summary
- retry transient REST transport and 5xx failures for safe operations
- add Discord nonce dedupe to message creation so send retries do not duplicate messages
- expose REST transport degradation details in the control health response
- cover the retry classification and nonce body shape with unit tests

## Validation
- nix develop --command dune build --build-dir _build_reststack
- nix develop --command dune runtest --build-dir _build_reststack

## Follow-up
- #39 Make bot restart crash-only and replayable
- #40 Harden disk-pressure handling and fault-injection coverage
- #45 Make state-file writes crash-durable with fsync and backup parity