### PR TITLE
fix: make state writes crash-durable

### DIFF
--- a/lib/resource.ml
+++ b/lib/resource.ml
@@ -79,15 +79,38 @@ let read_file path =
     really_input ic s 0 n;
     Bytes.to_string s)
 
-(** Write string to file atomically (temp + rename). *)
+(** Best-effort fsync of a parent directory after a rename. *)
+let fsync_dir path =
+  let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
+  Fun.protect ~finally:(fun () -> Unix.close fd) (fun () ->
+    Unix.fsync fd)
+
+let rec write_all fd content offset length =
+  if length > 0 then
+    let wrote = Unix.single_write_substring fd content offset length in
+    if wrote <= 0 then
+      failwith "resource: short write"
+    else
+      write_all fd content (offset + wrote) (length - wrote)
+
+(** Write string to file atomically and durably:
+    - write to a temp file in the same directory
+    - fsync the temp file
+    - rename into place
+    - fsync the parent directory so the rename is durable *)
 let write_file_atomic path content =
   let tmp = path ^ ".tmp" in
   (try
     ensure_parent_dir path;
-    with_file_out tmp (fun oc ->
-      output_string oc content;
-      output_char oc '\n');
+    let fd = Unix.openfile tmp
+      [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o600 in
+    Fun.protect ~finally:(fun () -> Unix.close fd) (fun () ->
+      write_all fd content 0 (String.length content);
+      write_all fd "\n" 0 1;
+      Unix.fsync fd);
     Unix.rename tmp path
+    ;
+    fsync_dir (Filename.dirname path)
   with exn ->
     (try Sys.remove tmp with _ -> ());
     raise exn)

--- a/lib/resource.ml
+++ b/lib/resource.ml
@@ -79,15 +79,52 @@ let read_file path =
     really_input ic s 0 n;
     Bytes.to_string s)
 
+exception Durable_write_visible_but_unconfirmed of string * exn
+
+(** Retry fsync across EINTR so signals do not turn a completed write
+    into a spurious failure. *)
+let rec fsync fd =
+  try Unix.fsync fd with
+  | Unix.Unix_error (Unix.EINTR, _, _) ->
+    fsync fd
+
 (** Best-effort fsync of a parent directory after a rename. *)
 let fsync_dir path =
   let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
   Fun.protect ~finally:(fun () -> Unix.close fd) (fun () ->
-    Unix.fsync fd)
+    fsync fd)
+
+(** Reap stale temp files from prior crashed writers.
+    Callers must already hold the per-file flock before using this. *)
+let cleanup_atomic_write_temps path =
+  let dir = Filename.dirname path in
+  let prefix = Filename.basename path ^ ".tmp." in
+  match Sys.readdir dir with
+  | exception Sys_error _ -> ()
+  | entries ->
+    Array.iter (fun name ->
+      if String.starts_with ~prefix name then
+        let temp_path = Filename.concat dir name in
+        match Unix.lstat temp_path with
+        | { Unix.st_kind = S_REG; _ } ->
+          (try Unix.unlink temp_path with
+           | Unix.Unix_error (Unix.ENOENT, _, _) -> ()
+           | exn ->
+             Logs.warn (fun m ->
+               m "resource: failed to remove stale temp file %s: %s"
+                 temp_path (Printexc.to_string exn)))
+        | _ -> ()
+        | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ())
+      entries
+
+let rec write_once fd content offset length =
+  try Unix.single_write_substring fd content offset length with
+  | Unix.Unix_error (Unix.EINTR, _, _) ->
+    write_once fd content offset length
 
 let rec write_all fd content offset length =
   if length > 0 then
-    let wrote = Unix.single_write_substring fd content offset length in
+    let wrote = write_once fd content offset length in
     if wrote <= 0 then
       failwith "resource: short write"
     else
@@ -98,22 +135,34 @@ let rec write_all fd content offset length =
     - fsync the temp file
     - rename into place
     - fsync the parent directory so the rename is durable *)
-let write_file_atomic path content =
-  let tmp = path ^ ".tmp" in
-  (try
-    ensure_parent_dir path;
+let write_file_atomic ?(fsync_parent=fsync_dir) path content =
+  ensure_parent_dir path;
+  let dir = Filename.dirname path in
+  let tmp =
+    Filename.temp_file
+      ~temp_dir:dir
+      (Filename.basename path ^ ".tmp.")
+      ""
+  in
+  let renamed = ref false in
+  try
     let fd = Unix.openfile tmp
       [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o600 in
     Fun.protect ~finally:(fun () -> Unix.close fd) (fun () ->
       write_all fd content 0 (String.length content);
       write_all fd "\n" 0 1;
-      Unix.fsync fd);
-    Unix.rename tmp path
-    ;
-    fsync_dir (Filename.dirname path)
+      fsync fd);
+    Unix.rename tmp path;
+    renamed := true;
+    (try
+       fsync_parent dir
+     with exn ->
+       raise (Durable_write_visible_but_unconfirmed
+         (path, exn)))
   with exn ->
-    (try Sys.remove tmp with _ -> ());
-    raise exn)
+    if not !renamed then
+      (try Sys.remove tmp with _ -> ());
+    raise exn
 
 (** Execute f while holding an exclusive flock on lock_path.
     Used for cross-process synchronization (bot + MCP server). *)

--- a/lib/runtime_settings.ml
+++ b/lib/runtime_settings.ml
@@ -65,22 +65,41 @@ let load () =
          Logs.warn (fun m ->
            m "runtime_settings: backup load error from %s: %s"
              backup (Printexc.to_string backup_exn));
-         default ())
+        default ())
 
-let save t =
+let log_visible_but_unconfirmed path exn =
+  Logs.warn (fun m ->
+    m "runtime_settings: write to %s is visible but durability could not be confirmed: %s"
+      path (Printexc.to_string exn))
+
+let save_with ~write_file t =
   let path = settings_path () in
   let backup = backup_path () in
   let rendered = Yojson.Safe.pretty_to_string (to_yojson t) in
+  let primary_warning = ref None in
   try
     Resource.with_flock (lock_path ()) (fun () ->
-      Resource.write_file_atomic path rendered;
-      (try Resource.write_file_atomic backup rendered with exn ->
+      Resource.cleanup_atomic_write_temps path;
+      Resource.cleanup_atomic_write_temps backup;
+      (try write_file path rendered with
+       | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
+         primary_warning := Some (path, exn));
+      (try write_file backup rendered with
+       | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
+         log_visible_but_unconfirmed path exn
+       | exn ->
          Logs.warn (fun m ->
            m "runtime_settings: failed to update backup %s: %s"
              backup (Printexc.to_string exn))));
+    Option.iter (fun (path, exn) ->
+      log_visible_but_unconfirmed path exn) !primary_warning;
     Ok ()
   with exn ->
     Error (Printexc.to_string exn)
+
+let save t =
+  save_with ~write_file:(fun path rendered ->
+    Resource.write_file_atomic path rendered) t
 
 let set_default_agent t agent =
   if Config.equal_agent_kind t.default_agent agent then

--- a/lib/session_store.ml
+++ b/lib/session_store.ml
@@ -80,6 +80,7 @@ type t = {
 let sessions_file () =
   Filename.concat (Resource.app_config_dir ()) "sessions.json"
 
+let backup_file () = sessions_file () ^ ".bak"
 let lock_file () = sessions_file () ^ ".lock"
 
 (** Serialize sessions to JSON. *)
@@ -184,20 +185,53 @@ let sessions_of_json json =
 let save (t : t) =
   let json = sessions_to_json t.sessions in
   let path = sessions_file () in
+  let backup = backup_file () in
+  let rendered = Yojson.Safe.pretty_to_string json in
   Resource.with_flock (lock_file ()) (fun () ->
-    Resource.write_file_atomic path (Yojson.Safe.pretty_to_string json))
+    Resource.write_file_atomic path rendered;
+    (try Resource.write_file_atomic backup rendered with exn ->
+       Logs.warn (fun m ->
+         m "session_store: failed to update backup %s: %s"
+           backup (Printexc.to_string exn))))
+
+let load_file path =
+  let contents = Resource.read_file path in
+  sessions_of_json (Yojson.Safe.from_string contents)
 
 (** Load sessions from disk. *)
 let load_from_disk () =
   let path = sessions_file () in
-  if not (Sys.file_exists path) then SessionMap.empty
-  else
-    try
-      let contents = Resource.read_file path in
-      sessions_of_json (Yojson.Safe.from_string contents)
-    with exn ->
-      Logs.warn (fun m -> m "session_store: load error: %s" (Printexc.to_string exn));
-      SessionMap.empty
+  let backup = backup_file () in
+  match Sys.file_exists path, Sys.file_exists backup with
+  | false, false -> SessionMap.empty
+  | false, true ->
+    (match load_file backup with
+     | sessions ->
+       Logs.warn (fun m ->
+         m "session_store: primary missing; recovered from backup %s" backup);
+       sessions
+     | exception backup_exn ->
+       Logs.warn (fun m ->
+         m "session_store: backup load error from %s: %s"
+           backup (Printexc.to_string backup_exn));
+       SessionMap.empty)
+  | true, _ ->
+    match load_file path with
+    | sessions -> sessions
+    | exception exn ->
+      Logs.warn (fun m ->
+        m "session_store: load error from %s: %s"
+          path (Printexc.to_string exn));
+      (match load_file backup with
+       | sessions ->
+         Logs.warn (fun m ->
+           m "session_store: recovered from backup %s" backup);
+         sessions
+       | exception backup_exn ->
+         Logs.warn (fun m ->
+           m "session_store: backup load error from %s: %s"
+             backup (Printexc.to_string backup_exn));
+         SessionMap.empty)
 
 (** Create a session store, loading persisted sessions from disk. *)
 let create () =

--- a/lib/session_store.ml
+++ b/lib/session_store.ml
@@ -182,17 +182,36 @@ let sessions_of_json json =
     SessionMap.empty
 
 (** Save sessions to disk with file locking. *)
-let save (t : t) =
+let log_visible_but_unconfirmed path exn =
+  Logs.warn (fun m ->
+    m "session_store: write to %s is visible but durability could not be confirmed: %s"
+      path (Printexc.to_string exn))
+
+let save_with ~write_file (t : t) =
   let json = sessions_to_json t.sessions in
   let path = sessions_file () in
   let backup = backup_file () in
   let rendered = Yojson.Safe.pretty_to_string json in
+  let primary_warning = ref None in
   Resource.with_flock (lock_file ()) (fun () ->
-    Resource.write_file_atomic path rendered;
-    (try Resource.write_file_atomic backup rendered with exn ->
+    Resource.cleanup_atomic_write_temps path;
+    Resource.cleanup_atomic_write_temps backup;
+    (try write_file path rendered with
+     | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
+       primary_warning := Some (path, exn));
+    (try write_file backup rendered with
+     | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
+       log_visible_but_unconfirmed path exn
+     | exn ->
        Logs.warn (fun m ->
          m "session_store: failed to update backup %s: %s"
-           backup (Printexc.to_string exn))))
+           backup (Printexc.to_string exn))));
+  Option.iter (fun (path, exn) ->
+    log_visible_but_unconfirmed path exn) !primary_warning
+
+let save t =
+  save_with ~write_file:(fun path rendered ->
+    Resource.write_file_atomic path rendered) t
 
 let load_file path =
   let contents = Resource.read_file path in

--- a/lib/session_store.ml
+++ b/lib/session_store.ml
@@ -120,66 +120,62 @@ let sessions_to_json sessions =
 
 (** Deserialize sessions from JSON. *)
 let sessions_of_json json =
-  try
-    let open Yojson.Safe.Util in
-    let entries = to_list json |> List.map (fun j ->
-      let thread_id = j |> member "thread_id" |> to_string in
-      let agent_kind = (match Config.agent_kind_of_string
-        (j |> member "agent_kind" |> to_string) with
-        | Ok k -> k | Error _ -> Config.Claude) in
-      (* For sessions written before session_id_confirmed existed,
-         derive the default from the agent's id origin: caller-pinned
-         agents (Claude) are always confirmed; server-allocated ones
-         (Codex, Gemini) default to false so the next run starts
-         fresh rather than resuming a placeholder. *)
-      let session_id_confirmed = match j |> member "session_id_confirmed" with
-        | `Bool b -> b
-        | _ -> Config.caller_pinned_session_id agent_kind in
-      let pending_agent_change =
-        match j |> member "pending_agent_kind" with
-        | `String s ->
-          (match Config.agent_kind_of_string s with
-           | Ok kind ->
-             let origin =
-               pending_agent_origin_of_json (j |> member "pending_agent_origin")
-             in
-             Some { kind; origin }
-           | Error _ -> None)
-        | _ -> None
-      in
-      let session = {
-        project_name = j |> member "project_name" |> to_string;
-        working_dir = j |> member "working_dir" |> to_string;
-        agent_kind;
-        session_override_kind =
-          (match j |> member "session_override_kind" with
-           | `String s ->
-             (match Config.agent_kind_of_string s with
-              | Ok kind -> Some kind
-              | Error _ -> None)
-           | _ -> None);
-        session_id = j |> member "session_id" |> to_string;
-        session_id_confirmed;
-        thread_id;
-        system_prompt = j |> member "system_prompt" |> to_string_option;
-        message_count = j |> member "message_count" |> to_int;
-        processing = false;
-        pending_queue = Queue.create ();
-        pending_agent_change;
-        initial_prompt = j |> member "initial_prompt" |> to_string_option;
-        child_pid = None;
-        stop_requested =
-          (match j |> member "stop_requested" with
-           | `Bool b -> b
-           | _ -> false);
-      } in
-      (thread_id, session)
-    ) in
-    List.fold_left (fun acc (tid, s) -> SessionMap.add tid s acc)
-      SessionMap.empty entries
-  with exn ->
-    Logs.warn (fun m -> m "session_store: parse error: %s" (Printexc.to_string exn));
-    SessionMap.empty
+  let open Yojson.Safe.Util in
+  let entries = to_list json |> List.map (fun j ->
+    let thread_id = j |> member "thread_id" |> to_string in
+    let agent_kind = (match Config.agent_kind_of_string
+      (j |> member "agent_kind" |> to_string) with
+      | Ok k -> k | Error _ -> Config.Claude) in
+    (* For sessions written before session_id_confirmed existed,
+       derive the default from the agent's id origin: caller-pinned
+       agents (Claude) are always confirmed; server-allocated ones
+       (Codex, Gemini) default to false so the next run starts
+       fresh rather than resuming a placeholder. *)
+    let session_id_confirmed = match j |> member "session_id_confirmed" with
+      | `Bool b -> b
+      | _ -> Config.caller_pinned_session_id agent_kind in
+    let pending_agent_change =
+      match j |> member "pending_agent_kind" with
+      | `String s ->
+        (match Config.agent_kind_of_string s with
+         | Ok kind ->
+           let origin =
+             pending_agent_origin_of_json (j |> member "pending_agent_origin")
+           in
+           Some { kind; origin }
+         | Error _ -> None)
+      | _ -> None
+    in
+    let session = {
+      project_name = j |> member "project_name" |> to_string;
+      working_dir = j |> member "working_dir" |> to_string;
+      agent_kind;
+      session_override_kind =
+        (match j |> member "session_override_kind" with
+         | `String s ->
+           (match Config.agent_kind_of_string s with
+            | Ok kind -> Some kind
+            | Error _ -> None)
+         | _ -> None);
+      session_id = j |> member "session_id" |> to_string;
+      session_id_confirmed;
+      thread_id;
+      system_prompt = j |> member "system_prompt" |> to_string_option;
+      message_count = j |> member "message_count" |> to_int;
+      processing = false;
+      pending_queue = Queue.create ();
+      pending_agent_change;
+      initial_prompt = j |> member "initial_prompt" |> to_string_option;
+      child_pid = None;
+      stop_requested =
+        (match j |> member "stop_requested" with
+         | `Bool b -> b
+         | _ -> false);
+    } in
+    (thread_id, session)
+  ) in
+  List.fold_left (fun acc (tid, s) -> SessionMap.add tid s acc)
+    SessionMap.empty entries
 
 (** Save sessions to disk with file locking. *)
 let log_visible_but_unconfirmed path exn =
@@ -235,22 +231,22 @@ let load_from_disk () =
            backup (Printexc.to_string backup_exn));
        SessionMap.empty)
   | true, _ ->
-    match load_file path with
-    | sessions -> sessions
-    | exception exn ->
-      Logs.warn (fun m ->
-        m "session_store: load error from %s: %s"
-          path (Printexc.to_string exn));
-      (match load_file backup with
-       | sessions ->
-         Logs.warn (fun m ->
-           m "session_store: recovered from backup %s" backup);
-         sessions
-       | exception backup_exn ->
-         Logs.warn (fun m ->
-           m "session_store: backup load error from %s: %s"
-             backup (Printexc.to_string backup_exn));
-         SessionMap.empty)
+    (match load_file path with
+     | sessions -> sessions
+     | exception exn ->
+       Logs.warn (fun m ->
+         m "session_store: load error from %s: %s"
+           path (Printexc.to_string exn));
+       (match load_file backup with
+        | sessions ->
+          Logs.warn (fun m ->
+            m "session_store: recovered from backup %s" backup);
+          sessions
+        | exception backup_exn ->
+          Logs.warn (fun m ->
+            m "session_store: backup load error from %s: %s"
+              backup (Printexc.to_string backup_exn));
+          SessionMap.empty))
 
 (** Create a session store, loading persisted sessions from disk. *)
 let create () =

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,5 @@
 (tests
  (names test_formatting test_project test_agent_contracts test_discord_rest test_gateway
-  test_runtime_settings test_bot_defaults)
+  test_runtime_settings test_bot_defaults test_session_store)
  (libraries discord_agents alcotest str unix yojson eio.mock eio_main cohttp-eio
   uri mirage-crypto-rng.unix))

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -11,10 +11,7 @@ let rec rm_rf path =
     Unix.unlink path
 
 let make_tmp_dir prefix =
-  let base = Filename.temp_file prefix "" in
-  Sys.remove base;
-  Unix.mkdir base 0o755;
-  base
+  Filename.temp_dir prefix ""
 
 let restore_env name = function
   | Some value -> Unix.putenv name value

--- a/test/test_runtime_settings.ml
+++ b/test/test_runtime_settings.ml
@@ -11,10 +11,7 @@ let rec rm_rf path =
     Unix.unlink path
 
 let make_tmp_dir prefix =
-  let base = Filename.temp_file prefix "" in
-  Sys.remove base;
-  Unix.mkdir base 0o755;
-  base
+  Filename.temp_dir prefix ""
 
 let restore_env name = function
   | Some value -> Unix.putenv name value
@@ -46,6 +43,7 @@ let settings_path home =
   Filename.concat home ".config/discord-agents/settings.json"
 
 let backup_path home = settings_path home ^ ".bak"
+let stale_temp_path home = settings_path home ^ ".tmp.stale"
 
 let test_load_defaults_to_claude () =
   with_tmp_home (fun _home ->
@@ -85,6 +83,44 @@ let test_load_uses_backup_when_primary_corrupt () =
       Alcotest.(check string) "recovered default agent"
         "codex"
         (Discord_agents.Config.string_of_agent_kind recovered.default_agent))
+
+let test_save_with_visible_but_unconfirmed_primary_updates_backup () =
+  with_tmp_home (fun home ->
+    let settings = Discord_agents.Runtime_settings.load () in
+    settings.default_agent <- Discord_agents.Config.Codex;
+    let write_file path content =
+      if String.equal path (settings_path home) then
+        Discord_agents.Resource.write_file_atomic
+          ~fsync_parent:(fun dir ->
+            raise (Unix.Unix_error (Unix.EINVAL, "fsync", dir)))
+          path content
+      else
+        Discord_agents.Resource.write_file_atomic path content
+    in
+    match Discord_agents.Runtime_settings.save_with ~write_file settings with
+    | Error err -> Alcotest.failf "save_with failed: %s" err
+    | Ok () ->
+      Alcotest.(check string) "backup mirrors primary after warning"
+        (Discord_agents.Resource.read_file (settings_path home))
+        (Discord_agents.Resource.read_file (backup_path home));
+      let recovered = Discord_agents.Runtime_settings.load () in
+      Alcotest.(check string) "reloaded default agent"
+        "codex"
+        (Discord_agents.Config.string_of_agent_kind recovered.default_agent))
+
+let test_save_reaps_stale_atomic_write_temps () =
+  with_tmp_home (fun home ->
+    let settings = Discord_agents.Runtime_settings.load () in
+    Discord_agents.Resource.ensure_parent_dir (stale_temp_path home);
+    let oc = open_out (stale_temp_path home) in
+    output_string oc "stale";
+    close_out oc;
+    match Discord_agents.Runtime_settings.set_default_agent
+            settings Discord_agents.Config.Gemini with
+    | Error err -> Alcotest.failf "save failed: %s" err
+    | Ok () ->
+      Alcotest.(check bool) "stale temp removed"
+        false (Sys.file_exists (stale_temp_path home)))
 
 let test_xdg_config_home_without_home () =
   let xdg_root = make_tmp_dir "discord_agents_xdg_" in
@@ -139,6 +175,10 @@ let () =
         test_save_and_reload_roundtrip;
       Alcotest.test_case "load uses backup when primary corrupt" `Quick
         test_load_uses_backup_when_primary_corrupt;
+      Alcotest.test_case "visible but unconfirmed primary still updates backup" `Quick
+        test_save_with_visible_but_unconfirmed_primary_updates_backup;
+      Alcotest.test_case "save reaps stale atomic write temps" `Quick
+        test_save_reaps_stale_atomic_write_temps;
       Alcotest.test_case "xdg config home without home" `Quick
         test_xdg_config_home_without_home;
       Alcotest.test_case "xdg falls back to existing legacy home" `Quick

--- a/test/test_runtime_settings.ml
+++ b/test/test_runtime_settings.ml
@@ -42,6 +42,11 @@ let with_tmp_home f =
     (fun () ->
       with_tmp_env ~home:base ~xdg_config_home:"" (fun () -> f base))
 
+let settings_path home =
+  Filename.concat home ".config/discord-agents/settings.json"
+
+let backup_path home = settings_path home ^ ".bak"
+
 let test_load_defaults_to_claude () =
   with_tmp_home (fun _home ->
     let settings = Discord_agents.Runtime_settings.load () in
@@ -50,12 +55,17 @@ let test_load_defaults_to_claude () =
       (Discord_agents.Config.string_of_agent_kind settings.default_agent))
 
 let test_save_and_reload_roundtrip () =
-  with_tmp_home (fun _home ->
+  with_tmp_home (fun home ->
     let settings = Discord_agents.Runtime_settings.load () in
     match Discord_agents.Runtime_settings.set_default_agent
             settings Discord_agents.Config.Codex with
     | Error err -> Alcotest.failf "save failed: %s" err
     | Ok () ->
+      Alcotest.(check bool) "backup exists"
+        true (Sys.file_exists (backup_path home));
+      Alcotest.(check string) "backup mirrors primary"
+        (Discord_agents.Resource.read_file (settings_path home))
+        (Discord_agents.Resource.read_file (backup_path home));
       let reloaded = Discord_agents.Runtime_settings.load () in
       Alcotest.(check string) "saved default agent"
         "codex"
@@ -68,10 +78,7 @@ let test_load_uses_backup_when_primary_corrupt () =
             settings Discord_agents.Config.Codex with
     | Error err -> Alcotest.failf "save failed: %s" err
     | Ok () ->
-      let settings_path =
-        Filename.concat home ".config/discord-agents/settings.json"
-      in
-      let oc = open_out settings_path in
+      let oc = open_out (settings_path home) in
       output_string oc "{ definitely not json";
       close_out oc;
       let recovered = Discord_agents.Runtime_settings.load () in

--- a/test/test_session_store.ml
+++ b/test/test_session_store.ml
@@ -9,10 +9,7 @@ let rec rm_rf path =
     Unix.unlink path
 
 let make_tmp_dir prefix =
-  let base = Filename.temp_file prefix "" in
-  Sys.remove base;
-  Unix.mkdir base 0o755;
-  base
+  Filename.temp_dir prefix ""
 
 let restore_env name = function
   | Some value -> Unix.putenv name value
@@ -94,6 +91,31 @@ let test_load_uses_backup_when_primary_missing () =
     Alcotest.(check string) "project recovered from backup"
       "control" recovered.Discord_agents.Session_store.project_name)
 
+let test_save_with_visible_but_unconfirmed_primary_updates_backup () =
+  with_tmp_home (fun home ->
+    let store = Discord_agents.Session_store.create () in
+    let session = make_session () in
+    Discord_agents.Session_store.add store ~thread_id:"control" session;
+    session.stop_requested <- true;
+    let write_file path content =
+      if String.equal path (sessions_path home) then
+        Discord_agents.Resource.write_file_atomic
+          ~fsync_parent:(fun dir ->
+            raise (Unix.Unix_error (Unix.EINVAL, "fsync", dir)))
+          path content
+      else
+        Discord_agents.Resource.write_file_atomic path content
+    in
+    Discord_agents.Session_store.save_with ~write_file store;
+    Alcotest.(check string) "backup mirrors primary after warning"
+      (Discord_agents.Resource.read_file (sessions_path home))
+      (Discord_agents.Resource.read_file (backup_path home));
+    Sys.remove (sessions_path home);
+    let reloaded = Discord_agents.Session_store.create () in
+    let recovered = find_control_session reloaded in
+    Alcotest.(check bool) "backup captured updated stop_requested"
+      true recovered.Discord_agents.Session_store.stop_requested)
+
 let () =
   Alcotest.run "session_store" [
     ("persistence", [
@@ -103,5 +125,7 @@ let () =
         test_load_uses_backup_when_primary_corrupt;
       Alcotest.test_case "load uses backup when primary missing" `Quick
         test_load_uses_backup_when_primary_missing;
+      Alcotest.test_case "visible but unconfirmed primary still updates backup" `Quick
+        test_save_with_visible_but_unconfirmed_primary_updates_backup;
     ]);
   ]

--- a/test/test_session_store.ml
+++ b/test/test_session_store.ml
@@ -80,6 +80,23 @@ let test_load_uses_backup_when_primary_corrupt () =
     Alcotest.(check bool) "stop_requested recovered from backup"
       true recovered.Discord_agents.Session_store.stop_requested)
 
+let test_load_uses_backup_when_primary_has_wrong_shape () =
+  with_tmp_home (fun home ->
+    let store = Discord_agents.Session_store.create () in
+    let session = make_session () in
+    Discord_agents.Session_store.add store ~thread_id:"control" session;
+    (match Discord_agents.Session_store.set_stop_requested store session true with
+     | Ok () -> ()
+     | Error err -> Alcotest.failf "set_stop_requested failed: %s" err);
+    let primary = sessions_path home in
+    let oc = open_out primary in
+    output_string oc "{}";
+    close_out oc;
+    let reloaded = Discord_agents.Session_store.create () in
+    let recovered = find_control_session reloaded in
+    Alcotest.(check bool) "structural error recovered from backup"
+      true recovered.Discord_agents.Session_store.stop_requested)
+
 let test_load_uses_backup_when_primary_missing () =
   with_tmp_home (fun home ->
     let store = Discord_agents.Session_store.create () in
@@ -123,6 +140,8 @@ let () =
         test_save_updates_backup;
       Alcotest.test_case "load uses backup when primary corrupt" `Quick
         test_load_uses_backup_when_primary_corrupt;
+      Alcotest.test_case "load uses backup when primary has wrong shape" `Quick
+        test_load_uses_backup_when_primary_has_wrong_shape;
       Alcotest.test_case "load uses backup when primary missing" `Quick
         test_load_uses_backup_when_primary_missing;
       Alcotest.test_case "visible but unconfirmed primary still updates backup" `Quick

--- a/test/test_session_store.ml
+++ b/test/test_session_store.ml
@@ -1,0 +1,107 @@
+let rec rm_rf path =
+  match Unix.lstat path with
+  | exception Unix.Unix_error (ENOENT, _, _) -> ()
+  | { Unix.st_kind = S_DIR; _ } ->
+    Sys.readdir path
+    |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+    Unix.rmdir path
+  | _ ->
+    Unix.unlink path
+
+let make_tmp_dir prefix =
+  let base = Filename.temp_file prefix "" in
+  Sys.remove base;
+  Unix.mkdir base 0o755;
+  base
+
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> Unix.putenv name ""
+
+let with_tmp_home f =
+  let base = make_tmp_dir "discord_agents_sessions_" in
+  let old_home = Sys.getenv_opt "HOME" in
+  let old_xdg_config_home = Sys.getenv_opt "XDG_CONFIG_HOME" in
+  Fun.protect
+    ~finally:(fun () ->
+      restore_env "HOME" old_home;
+      restore_env "XDG_CONFIG_HOME" old_xdg_config_home;
+      rm_rf base)
+    (fun () ->
+      Unix.putenv "HOME" base;
+      Unix.putenv "XDG_CONFIG_HOME" "";
+      f base)
+
+let sessions_path home =
+  Filename.concat home ".config/discord-agents/sessions.json"
+
+let backup_path home = sessions_path home ^ ".bak"
+
+let make_session () =
+  Discord_agents.Session_store.make_session
+    ~project_name:"control"
+    ~working_dir:"/tmp/project"
+    ~agent_kind:Discord_agents.Config.Claude
+    ~session_id:"session-1"
+    ~thread_id:"control"
+    ~system_prompt:(Some "prompt")
+    ~initial_prompt:None
+    ()
+
+let find_control_session store =
+  match Discord_agents.Session_store.find_opt store ~thread_id:"control" with
+  | Some session -> session
+  | None -> Alcotest.fail "expected persisted control session"
+
+let test_save_updates_backup () =
+  with_tmp_home (fun home ->
+    let store = Discord_agents.Session_store.create () in
+    let session = make_session () in
+    Discord_agents.Session_store.add store ~thread_id:"control" session;
+    let primary = sessions_path home in
+    let backup = backup_path home in
+    Alcotest.(check bool) "primary exists" true (Sys.file_exists primary);
+    Alcotest.(check bool) "backup exists" true (Sys.file_exists backup);
+    Alcotest.(check string) "backup mirrors primary"
+      (Discord_agents.Resource.read_file primary)
+      (Discord_agents.Resource.read_file backup))
+
+let test_load_uses_backup_when_primary_corrupt () =
+  with_tmp_home (fun home ->
+    let store = Discord_agents.Session_store.create () in
+    let session = make_session () in
+    Discord_agents.Session_store.add store ~thread_id:"control" session;
+    (match Discord_agents.Session_store.set_stop_requested store session true with
+     | Ok () -> ()
+     | Error err -> Alcotest.failf "set_stop_requested failed: %s" err);
+    let primary = sessions_path home in
+    let oc = open_out primary in
+    output_string oc "{ definitely not json";
+    close_out oc;
+    let reloaded = Discord_agents.Session_store.create () in
+    let recovered = find_control_session reloaded in
+    Alcotest.(check bool) "stop_requested recovered from backup"
+      true recovered.Discord_agents.Session_store.stop_requested)
+
+let test_load_uses_backup_when_primary_missing () =
+  with_tmp_home (fun home ->
+    let store = Discord_agents.Session_store.create () in
+    let session = make_session () in
+    Discord_agents.Session_store.add store ~thread_id:"control" session;
+    Sys.remove (sessions_path home);
+    let reloaded = Discord_agents.Session_store.create () in
+    let recovered = find_control_session reloaded in
+    Alcotest.(check string) "project recovered from backup"
+      "control" recovered.Discord_agents.Session_store.project_name)
+
+let () =
+  Alcotest.run "session_store" [
+    ("persistence", [
+      Alcotest.test_case "save updates backup" `Quick
+        test_save_updates_backup;
+      Alcotest.test_case "load uses backup when primary corrupt" `Quick
+        test_load_uses_backup_when_primary_corrupt;
+      Alcotest.test_case "load uses backup when primary missing" `Quick
+        test_load_uses_backup_when_primary_missing;
+    ]);
+  ]


### PR DESCRIPTION
## Summary
- make `Resource.write_file_atomic` durable by fsyncing temp files and parent directories around rename
- add `sessions.json.bak` backup/recovery parity with `settings.json`
- add direct persistence tests for session-store backup recovery and settings backup mirroring

## Testing
- `nix develop --command dune build --build-dir _build_durable1`
- `nix develop --command dune runtest --build-dir _build_durable1`
- `nix develop --command dune exec ./test/test_agent_contracts.exe --build-dir _build_durable2` (Claude contract probe failed twice with an external non-zero exit after init; other suites and new persistence tests passed)

## Issues
- Implements #45
- Follow-up policy/ENOSPC work remains in #40
