### PR TITLE
fix: harden disk-pressure degraded mode

### DIFF
--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1185,11 +1185,19 @@ let mcp_json = lazy (
 )
 
 let write_file_safely ~path contents =
-  try
-    let oc = open_out path in
-    output_string oc contents;
-    close_out oc
-  with _ -> ()
+  match Disk_health.preflight_write path with
+  | Error err ->
+    Logs.warn (fun m ->
+      m "agent_process: refused write to %s: %s" path err)
+  | Ok () ->
+    (try
+       Resource.write_file_atomic path contents;
+       Disk_health.note_write_success path
+     with exn ->
+       Disk_health.note_write_failure path exn;
+       Logs.warn (fun m ->
+         m "agent_process: failed to write %s: %s"
+           path (Printexc.to_string exn)))
 
 let read_file_opt path =
   try

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1191,7 +1191,9 @@ let write_file_safely ~path contents =
       m "agent_process: refused write to %s: %s" path err)
   | Ok () ->
     (try
-       Resource.write_file_atomic path contents;
+       Resource.with_flock (path ^ ".lock") (fun () ->
+         Resource.cleanup_atomic_write_temps path;
+         Resource.write_file_atomic path contents);
        Disk_health.note_write_success path
      with exn ->
        Disk_health.note_write_failure path exn;

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -74,6 +74,7 @@ type t = {
 let projects t = t.project_state.projects
 let channels t = t.project_state.channels
 let default_agent t = t.settings.default_agent
+let new_session_block_message () = Disk_health.new_session_block_message ()
 let pending_default_rotation kind =
   Session_store.{ kind; origin = Default_rotation }
 let pending_session_override kind =
@@ -948,6 +949,14 @@ let create_explicit_channel_session t ~channel_id ~agent_kind =
           ~agent_kind ~session_override_kind:(Some agent_kind);
         true
 
+let cleanup_orphan_thread t ~thread_id ~context =
+  match Discord_rest.delete_channel t.rest ~channel_id:thread_id () with
+  | Ok _ -> ()
+  | Error err ->
+    Logs.warn (fun m ->
+      m "bot: failed to clean up orphan thread %s after %s: %s"
+        thread_id context err)
+
 (** Handle a parsed command. *)
 let handle_command t msg cmd =
   let channel_id = msg.Discord_types.channel_id in
@@ -984,9 +993,13 @@ let handle_command t msg cmd =
         ~resume_hint:"!resume <session_id_prefix>" entries))
   | Command.Start_agent { project; kind } ->
     let kind = Option.value kind ~default:(default_agent t) in
-    let proj = Command.find_project_fuzzy (projects t) project in
-    (match proj with
+    (match new_session_block_message () with
+     | Some msg ->
+       reply msg
      | None ->
+       let proj = Command.find_project_fuzzy (projects t) project in
+       match proj with
+       | None ->
        let q = String.lowercase_ascii project in
        let suggestions = List.filter (fun (p : Project.t) ->
          let name = String.lowercase_ascii p.name in
@@ -1005,7 +1018,7 @@ let handle_command t msg cmd =
         | _ -> reply (Printf.sprintf "No unique match for `%s`. Did you mean:\n%s" project_safe
             (String.concat "\n" (List.map (fun (p : Project.t) ->
               Printf.sprintf "- `!start %s`" p.name) suggestions))))
-     | Some p ->
+       | Some p ->
        let kind_str = Config.string_of_agent_kind kind in
        let branch_name = Printf.sprintf "agent/%s-%s"
          kind_str (String.sub (Resource.generate_uuid ()) 0 8) in
@@ -1035,13 +1048,19 @@ let handle_command t msg cmd =
              ~session_id:(Resource.generate_uuid ())
              ~thread_id:thread_ch.Discord_types.id
              ~system_prompt:None ~initial_prompt:None () in
-           Session_store.add t.sessions ~thread_id:thread_ch.id session;
-           let branch_str = match branch_info with
-             | Some b -> Printf.sprintf "\nBranch: `%s`" b | None -> "" in
-           ignore (Discord_rest.create_message t.rest ~channel_id:thread_ch.id
-             ~content:(Printf.sprintf
-               "**%s** session started for **%s**%s\nWorking in: `%s`\nSend a message to interact."
-               kind_str p.name branch_str working_dir) ())
+           (try
+              Session_store.add t.sessions ~thread_id:thread_ch.id session;
+              let branch_str = match branch_info with
+                | Some b -> Printf.sprintf "\nBranch: `%s`" b | None -> "" in
+              ignore (Discord_rest.create_message t.rest ~channel_id:thread_ch.id
+                ~content:(Printf.sprintf
+                  "**%s** session started for **%s**%s\nWorking in: `%s`\nSend a message to interact."
+                  kind_str p.name branch_str working_dir) ())
+            with exn ->
+              cleanup_orphan_thread t ~thread_id:thread_ch.id
+                ~context:"session persistence failure";
+              reply (Printf.sprintf "Failed to persist session: %s"
+                (Printexc.to_string exn)))
        end)
   | Command.List_codex_sessions ->
     Eio.Fiber.fork ~sw:t.sw (fun () ->
@@ -1065,6 +1084,10 @@ let handle_command t msg cmd =
         ~resume_hint:"!resume gemini <session_id_prefix>" entries))
   | Command.Resume_session { session_id; kind } ->
     Eio.Fiber.fork ~sw:t.sw (fun () ->
+      match new_session_block_message () with
+      | Some msg ->
+        reply msg
+      | None ->
       (* Locate the session in the requested store, or try the
          current default first if [kind] is unspecified. *)
       let try_claude () =
@@ -1134,11 +1157,17 @@ let handle_command t msg cmd =
             ~message_count:1
             ~thread_id:thread_ch.Discord_types.id
             ~system_prompt:None ~initial_prompt:None () in
-          Session_store.add t.sessions ~thread_id:thread_ch.id session;
-          ignore (Discord_rest.create_message t.rest ~channel_id:thread_ch.id
-            ~content:(Printf.sprintf
-              "**Resumed** %s session `%s`\nWorking in: `%s`\nSend a message to continue."
-              kind_title sid_short working_dir) ())))
+          (try
+             Session_store.add t.sessions ~thread_id:thread_ch.id session;
+             ignore (Discord_rest.create_message t.rest ~channel_id:thread_ch.id
+               ~content:(Printf.sprintf
+                 "**Resumed** %s session `%s`\nWorking in: `%s`\nSend a message to continue."
+                 kind_title sid_short working_dir) ())
+           with exn ->
+             cleanup_orphan_thread t ~thread_id:thread_ch.id
+               ~context:"resume persistence failure";
+             reply (Printf.sprintf "Failed to persist resumed session: %s"
+               (Printexc.to_string exn)))))
   | Command.Stop_session { thread_id } ->
     (match stop_session t ~thread_id with
      | Session_not_found ->
@@ -1276,11 +1305,16 @@ let handle_command t msg cmd =
           reply (Printf.sprintf
             "Failed to start a fresh `%s` session for this channel: %s"
             kind_str err))
-     | None when create_explicit_channel_session t ~channel_id ~agent_kind:kind ->
-       reply (Printf.sprintf "Started a fresh `%s` session for this channel."
-         kind_str)
      | None ->
-       reply "No session exists in this channel. Use `!start` or `!resume`.")
+       (match new_session_block_message () with
+        | Some msg ->
+          reply msg
+        | None when create_explicit_channel_session t ~channel_id ~agent_kind:kind ->
+          reply (Printf.sprintf "Started a fresh `%s` session for this channel."
+            kind_str)
+        | None ->
+          reply "No session exists in this channel. Use `!start` or `!resume`."
+       ))
   | Command.Cleanup_channels ->
     Eio.Fiber.fork ~sw:t.sw (fun () ->
       match Channel_manager.cleanup ~rest:t.rest
@@ -1329,6 +1363,7 @@ let handle_command t msg cmd =
   | Command.Status ->
     Eio.Fiber.fork ~sw:t.sw (fun () ->
       let status_lines = Eio_unix.run_in_systhread (fun () ->
+        ignore (Disk_health.preflight_state_mutation ());
         let pid = Unix.getpid () in
         let uptime_sec = int_of_float (Unix.gettimeofday () -. t.started_at) in
         let hours = uptime_sec / 3600 in
@@ -1407,6 +1442,7 @@ let handle_command t msg cmd =
           Printf.sprintf "**%s** (pid %d, up %s)" (Build_info.version_string ()) pid uptime_str;
           Printf.sprintf "Default agent: %s"
             (Config.string_of_agent_kind (default_agent t));
+          Disk_health.status_summary ();
           Printf.sprintf "Sessions: %d (%d processing)"
             (Session_store.count t.sessions)
             (List.length (List.filter (fun (_, (s : Session_store.session)) ->
@@ -1738,12 +1774,20 @@ let fork_initial_prompt_run t ~session ~msg =
     Creates a persistent session using the current default agent. *)
 let ensure_channel_session t ~channel_id ~project_name ~working_dir ~system_prompt =
   match Session_store.find_opt t.sessions ~thread_id:channel_id with
-  | Some _ -> ()
+  | Some _ -> Ok ()
   | None ->
-    create_persistent_channel_session t ~channel_id ~project_name
-      ~working_dir ~system_prompt ~agent_kind:(default_agent t)
-      ~session_override_kind:None;
-    Logs.info (fun m -> m "bot: auto-created session for %s" project_name)
+    match new_session_block_message () with
+    | Some msg -> Error msg
+    | None ->
+      (try
+         create_persistent_channel_session t ~channel_id ~project_name
+           ~working_dir ~system_prompt ~agent_kind:(default_agent t)
+           ~session_override_kind:None;
+         Logs.info (fun m -> m "bot: auto-created session for %s" project_name);
+         Ok ()
+       with exn ->
+         Error (Printf.sprintf "Failed to persist session: %s"
+           (Printexc.to_string exn)))
 
 let handle_command_safely t msg cmd =
   try
@@ -1787,10 +1831,13 @@ let handle_message t (msg : Discord_types.message) =
     let project_for_channel =
       Channel_manager.project_for_channel (channels t) ~channel_id:msg.channel_id in
     if is_control then begin
-      ensure_channel_session t ~channel_id:msg.channel_id
-        ~project_name:"control" ~working_dir:(Sys.getcwd ())
-        ~system_prompt:(Some (control_system_prompt (projects t)));
-      handle_thread_message t msg ()
+      match ensure_channel_session t ~channel_id:msg.channel_id
+              ~project_name:"control" ~working_dir:(Sys.getcwd ())
+              ~system_prompt:(Some (control_system_prompt (projects t))) with
+      | Ok () -> handle_thread_message t msg ()
+      | Error err ->
+        ignore (Discord_rest.create_message t.rest
+          ~channel_id:msg.channel_id ~content:err ())
     end else match project_for_channel with
     | Some proj_name ->
       (* Message in a project channel — persistent session (like control channel).
@@ -1799,81 +1846,97 @@ let handle_message t (msg : Discord_types.message) =
       (match proj with
        | Some p ->
          let wd = match working_dir_of_project p with Ok d -> d | Error _ -> p.path in
-         ensure_channel_session t ~channel_id:msg.channel_id
-           ~project_name:p.name ~working_dir:wd
-           ~system_prompt:(Some (project_system_prompt p));
-         Channel_manager.bump ~rest:t.rest ~guild_id:t.config.guild_id
-           ~project_name:p.name (channels t);
-         handle_thread_message t msg ()
+         (match ensure_channel_session t ~channel_id:msg.channel_id
+                  ~project_name:p.name ~working_dir:wd
+                  ~system_prompt:(Some (project_system_prompt p)) with
+          | Ok () ->
+            Channel_manager.bump ~rest:t.rest ~guild_id:t.config.guild_id
+              ~project_name:p.name (channels t);
+            handle_thread_message t msg ()
+          | Error err ->
+            ignore (Discord_rest.create_message t.rest
+              ~channel_id:msg.channel_id ~content:err ()))
        | None -> ())
     | None ->
       (* Check if this is a thread under a project channel.
          Since the control API creates sessions directly in bot memory,
          no disk reload is needed — sessions are always authoritative. *)
-      (match Session_store.find_opt t.sessions ~thread_id:msg.channel_id with
-       | Some _ -> handle_thread_message t msg ()
-       | None ->
-         (* Look up the channel to find its parent *)
-         (match Discord_rest.get_channel t.rest ~channel_id:msg.channel_id () with
-          | Ok ch ->
-            let parent_project = match ch.Discord_types.parent_id with
-              | Some pid -> Channel_manager.project_for_channel (channels t) ~channel_id:pid
-              | None -> None
-            in
-            (match parent_project with
-             | Some proj_name ->
-               (* Thread under a project channel with no session —
-                  auto-create one (e.g. manually created in Discord).
+      match Session_store.find_opt t.sessions ~thread_id:msg.channel_id with
+      | Some _ -> handle_thread_message t msg ()
+      | None ->
+        (* Look up the channel to find its parent *)
+        (match Discord_rest.get_channel t.rest ~channel_id:msg.channel_id () with
+         | Ok ch ->
+           let parent_project =
+             match ch.Discord_types.parent_id with
+             | Some pid ->
+               Channel_manager.project_for_channel (channels t) ~channel_id:pid
+             | None -> None
+           in
+           (match parent_project with
+            | Some proj_name ->
+              (* Thread under a project channel with no session —
+                 auto-create one (e.g. manually created in Discord).
 
-                  Race-safety: defer the auto-create by 2s and re-
-                  check the session store, in case
-                  [control_api.handle_start_session] is in the middle
-                  of an HTTP roundtrip to create a session for this
-                  thread. Without the wait, a user typing into a
-                  freshly-bot-created thread would race the
-                  start_session HTTP and get a default-worktree
-                  session here instead of the agent-specific
-                  worktree the MCP caller asked for. The cost is a
-                  one-time 2s delay for messages in manually-
-                  created threads (rare in this bot's usage). *)
-               let proj = List.find_opt (fun (p : Project.t) ->
-                 p.name = proj_name) (projects t) in
-               (match proj with
-                | Some p ->
-                  let wd = match working_dir_of_project p with
-                    | Ok d -> d | Error _ -> p.path in
-                  Eio.Fiber.fork ~sw:t.sw (fun () ->
-                    Eio.Time.sleep (Eio.Stdenv.clock t.env) 2.0;
-                    (* If the bot started draining during the wait,
-                       don't start fresh work — the restart's drain
-                       phase may have already moved on past its
-                       processing-flag wait, and a session born now
-                       could orphan its child at handoff timeout. *)
-                    if t.draining then
-                      ignore (Discord_rest.create_message t.rest
-                        ~channel_id:msg.channel_id
-                        ~content:"Bot is restarting. Try again \
-                                  shortly." ())
-                    else
-                      match Session_store.find_opt t.sessions
-                              ~thread_id:msg.channel_id with
-                      | Some _ ->
-                        (* start_session won the race; route normally
-                           (handle_thread_message queues if processing). *)
-                        handle_thread_message t msg ~channel_info:ch ()
-                      | None ->
-                        ensure_channel_session t ~channel_id:msg.channel_id
-                          ~project_name:p.name ~working_dir:wd
-                          ~system_prompt:None;
-                        handle_thread_message t msg ~channel_info:ch ())
-                | None -> handle_thread_message t msg ())
-             | None -> handle_thread_message t msg ())
-          | Error e ->
-            Logs.warn (fun m -> m "bot: channel lookup failed for %s: %s"
-              msg.channel_id e);
-            ignore (Discord_rest.create_message t.rest
-              ~channel_id:msg.channel_id
-              ~content:"Could not set up a session for this thread (channel lookup failed). Try again or use `!start`." ())))
+                 Race-safety: defer the auto-create by 2s and re-
+                 check the session store, in case
+                 [control_api.handle_start_session] is in the middle
+                 of an HTTP roundtrip to create a session for this
+                 thread. Without the wait, a user typing into a
+                 freshly-bot-created thread would race the
+                 start_session HTTP and get a default-worktree
+                 session here instead of the agent-specific
+                 worktree the MCP caller asked for. The cost is a
+                 one-time 2s delay for messages in manually-
+                 created threads (rare in this bot's usage). *)
+              let proj =
+                List.find_opt (fun (p : Project.t) -> p.name = proj_name)
+                  (projects t)
+              in
+              (match proj with
+               | Some p ->
+                 let wd =
+                   match working_dir_of_project p with
+                   | Ok d -> d
+                   | Error _ -> p.path
+                 in
+                 Eio.Fiber.fork ~sw:t.sw (fun () ->
+                   Eio.Time.sleep (Eio.Stdenv.clock t.env) 2.0;
+                   (* If the bot started draining during the wait,
+                      don't start fresh work — the restart's drain
+                      phase may have already moved on past its
+                      processing-flag wait, and a session born now
+                      could orphan its child at handoff timeout. *)
+                   if t.draining then
+                     ignore (Discord_rest.create_message t.rest
+                       ~channel_id:msg.channel_id
+                       ~content:"Bot is restarting. Try again \
+                                 shortly." ())
+                   else
+                     match Session_store.find_opt t.sessions
+                             ~thread_id:msg.channel_id with
+                     | Some _ ->
+                       (* start_session won the race; route normally
+                          (handle_thread_message queues if processing). *)
+                       handle_thread_message t msg ~channel_info:ch ()
+                     | None ->
+                       (match ensure_channel_session t
+                                ~channel_id:msg.channel_id
+                                ~project_name:p.name ~working_dir:wd
+                                ~system_prompt:None with
+                        | Ok () ->
+                          handle_thread_message t msg ~channel_info:ch ()
+                        | Error err ->
+                          ignore (Discord_rest.create_message t.rest
+                            ~channel_id:msg.channel_id ~content:err ())))
+               | None -> handle_thread_message t msg ())
+            | None -> handle_thread_message t msg ())
+         | Error e ->
+           Logs.warn (fun m -> m "bot: channel lookup failed for %s: %s"
+             msg.channel_id e);
+           ignore (Discord_rest.create_message t.rest
+             ~channel_id:msg.channel_id
+             ~content:"Could not set up a session for this thread (channel lookup failed). Try again or use `!start`." ()))
   end
 
 let create ~sw ~(env : Eio_unix.Stdenv.base) config =

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -957,6 +957,50 @@ let cleanup_orphan_thread t ~thread_id ~context =
       m "bot: failed to clean up orphan thread %s after %s: %s"
         thread_id context err)
 
+let cleanup_orphan_worktree ~project ~branch_info ~working_dir ~context =
+  match branch_info with
+  | None -> ()
+  | Some branch_name ->
+    (match Project.remove_worktree project ~branch_name
+             ~worktree_path:working_dir with
+     | Ok () -> ()
+     | Error err ->
+       Logs.warn (fun m ->
+         m "bot: failed to clean up orphan worktree %s after %s: %s"
+           working_dir context err))
+
+let remove_persisted_session_for_cleanup t ~thread_id ~context =
+  match Session_store.find_opt t.sessions ~thread_id with
+  | None -> true
+  | Some _ ->
+    try
+      Session_store.remove t.sessions ~thread_id;
+      true
+    with exn ->
+      Logs.warn (fun m ->
+        m "bot: failed to remove persisted session %s during %s cleanup: %s"
+          thread_id context (Printexc.to_string exn));
+      false
+
+let cleanup_start_artifacts t ~project ~branch_info ~working_dir
+    ~thread_id ~session_persisted ~context =
+  let session_removed =
+    (not session_persisted)
+    || remove_persisted_session_for_cleanup t ~thread_id ~context
+  in
+  if session_removed then begin
+    cleanup_orphan_thread t ~thread_id ~context;
+    cleanup_orphan_worktree ~project ~branch_info ~working_dir ~context
+  end
+
+let cleanup_thread_session_artifacts t ~thread_id ~session_persisted ~context =
+  let session_removed =
+    (not session_persisted)
+    || remove_persisted_session_for_cleanup t ~thread_id ~context
+  in
+  if session_removed then
+    cleanup_orphan_thread t ~thread_id ~context
+
 (** Handle a parsed command. *)
 let handle_command t msg cmd =
   let channel_id = msg.Discord_types.channel_id in
@@ -1041,15 +1085,20 @@ let handle_command t msg cmd =
          match Discord_rest.create_thread_no_message t.rest
                  ~channel_id:thread_parent
                  ~name:(Printf.sprintf "%s / %s" kind_str p.name) () with
-         | Error e -> reply (Printf.sprintf "Failed to create thread: %s" e)
+         | Error e ->
+           cleanup_orphan_worktree ~project:p ~branch_info ~working_dir
+             ~context:"thread creation failure";
+           reply (Printf.sprintf "Failed to create thread: %s" e)
          | Ok thread_ch ->
            let session = Session_store.make_session
              ~project_name:p.name ~working_dir ~agent_kind:kind
              ~session_id:(Resource.generate_uuid ())
              ~thread_id:thread_ch.Discord_types.id
              ~system_prompt:None ~initial_prompt:None () in
+           let session_persisted = ref false in
            (try
               Session_store.add t.sessions ~thread_id:thread_ch.id session;
+              session_persisted := true;
               let branch_str = match branch_info with
                 | Some b -> Printf.sprintf "\nBranch: `%s`" b | None -> "" in
               ignore (Discord_rest.create_message t.rest ~channel_id:thread_ch.id
@@ -1057,8 +1106,10 @@ let handle_command t msg cmd =
                   "**%s** session started for **%s**%s\nWorking in: `%s`\nSend a message to interact."
                   kind_str p.name branch_str working_dir) ())
             with exn ->
-              cleanup_orphan_thread t ~thread_id:thread_ch.id
-                ~context:"session persistence failure";
+              cleanup_start_artifacts t ~project:p ~branch_info ~working_dir
+                ~thread_id:thread_ch.id
+                ~session_persisted:!session_persisted
+                ~context:"session startup failure";
               reply (Printf.sprintf "Failed to persist session: %s"
                 (Printexc.to_string exn)))
        end)
@@ -1157,15 +1208,18 @@ let handle_command t msg cmd =
             ~message_count:1
             ~thread_id:thread_ch.Discord_types.id
             ~system_prompt:None ~initial_prompt:None () in
+          let session_persisted = ref false in
           (try
              Session_store.add t.sessions ~thread_id:thread_ch.id session;
+             session_persisted := true;
              ignore (Discord_rest.create_message t.rest ~channel_id:thread_ch.id
                ~content:(Printf.sprintf
                  "**Resumed** %s session `%s`\nWorking in: `%s`\nSend a message to continue."
                  kind_title sid_short working_dir) ())
            with exn ->
-             cleanup_orphan_thread t ~thread_id:thread_ch.id
-               ~context:"resume persistence failure";
+             cleanup_thread_session_artifacts t ~thread_id:thread_ch.id
+               ~session_persisted:!session_persisted
+               ~context:"resume startup failure";
              reply (Printf.sprintf "Failed to persist resumed session: %s"
                (Printexc.to_string exn)))))
   | Command.Stop_session { thread_id } ->

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -105,11 +105,13 @@ let load () =
 
 let save config =
   let path = config_path () in
-  Resource.ensure_parent_dir path;
-  let json = yojson_of_t config in
-  (* Write with restricted permissions — file contains discord token *)
-  let fd = Unix.openfile path [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o600 in
-  let oc = Unix.out_channel_of_descr fd in
-  output_string oc (Yojson.Safe.pretty_to_string json);
-  output_char oc '\n';
-  close_out oc
+  match Disk_health.preflight_write path with
+  | Error err -> failwith err
+  | Ok () ->
+    let json = yojson_of_t config in
+    try
+      Resource.write_file_atomic path (Yojson.Safe.pretty_to_string json);
+      Disk_health.note_write_success path
+    with exn ->
+      Disk_health.note_write_failure path exn;
+      raise exn

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -110,7 +110,9 @@ let save config =
   | Ok () ->
     let json = yojson_of_t config in
     try
-      Resource.write_file_atomic path (Yojson.Safe.pretty_to_string json);
+      Resource.with_flock (path ^ ".lock") (fun () ->
+        Resource.cleanup_atomic_write_temps path;
+        Resource.write_file_atomic path (Yojson.Safe.pretty_to_string json));
       Disk_health.note_write_success path
     with exn ->
       Disk_health.note_write_failure path exn;

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -52,10 +52,24 @@ let ok_response body =
 let error_response msg =
   `Assoc [("error", `String msg)]
 
+let json_of_int64 n =
+  `Intlit (Int64.to_string n)
+
+let cleanup_orphan_thread rest ~thread_id ~context =
+  match Discord_rest.delete_channel rest ~channel_id:thread_id () with
+  | Ok _ -> ()
+  | Error err ->
+    Logs.warn (fun m ->
+      m "control_api: failed to clean up orphan thread %s after %s: %s"
+        thread_id context err)
+
 (* ── Handlers ──────────────────────────────────────────────────── *)
 
 let handle_health (bot : Bot.t) =
+  ignore (Eio_unix.run_in_systhread (fun () ->
+    Disk_health.preflight_state_mutation ()));
   let uptime = int_of_float (Unix.gettimeofday () -. bot.started_at) in
+  let disk = Disk_health.snapshot () in
   let rest_failures = Discord_rest.consecutive_rest_failures bot.rest in
   let transport_failures =
     Discord_rest.consecutive_transport_failures bot.rest
@@ -103,6 +117,32 @@ let handle_health (bot : Bot.t) =
      | Some summary -> [("last_gateway_payload", `String summary)]
      | None -> [])
   in
+  let disk_fields = [
+    ("disk_mode", `String (Disk_health.string_of_mode disk.mode));
+    ("disk_pressure", `Bool (Disk_health.pressure disk));
+    ("disk_degraded", `Bool (disk.mode = Disk_health.Read_only));
+    ("disk_warning_threshold_bytes",
+     json_of_int64 disk.warning_threshold_bytes);
+    ("disk_read_only_threshold_bytes",
+     json_of_int64 disk.read_only_threshold_bytes);
+  ] in
+  let optional_disk_fields =
+    (match disk.available_bytes with
+     | Some available ->
+       [("disk_free_bytes", json_of_int64 available)]
+     | None -> [])
+    @
+    (match disk.checked_path with
+     | Some path -> [("disk_path", `String path)]
+     | None -> [])
+    @
+    (match disk.last_error with
+     | Some err ->
+       [("last_disk_error",
+         `String (Resource.truncate_utf8 ~max_bytes:1000
+           (Resource.single_line err)))]
+     | None -> [])
+  in
   ok_response ([
     ("uptime_seconds", `Int uptime);
     ("default_agent",
@@ -111,7 +151,9 @@ let handle_health (bot : Bot.t) =
     ("projects", `Int (List.length (Bot.projects bot)));
     ("channels", `Int (Channel_manager.count (Bot.channels bot)));
   ] @ rest_fields @ optional_rest_fields
-    @ optional_transport_fields @ gateway_fields @ optional_gateway_fields)
+    @ optional_transport_fields
+    @ gateway_fields @ optional_gateway_fields
+    @ disk_fields @ optional_disk_fields)
 
 let handle_list_projects (bot : Bot.t) =
   let projects = List.map (fun (p : Project.t) ->
@@ -208,85 +250,88 @@ let handle_start_session (bot : Bot.t) params =
   if bot.draining then
     error_response "Bot is restarting; try again shortly."
   else
-  let project_str = params |> member "project" |> to_string in
-  let kind_str = match params |> member "agent" |> to_string_option with
-    | Some s -> s
-    | None ->
-      Config.string_of_agent_kind bot.settings.default_agent
-  in
-  let kind = match Config.agent_kind_of_string kind_str with
-    | Ok k -> k | Error _ -> failwith ("unknown agent: " ^ kind_str) in
-  let thread_name = params |> member "thread_name" |> to_string_option in
-  let initial_prompt = params |> member "initial_prompt" |> to_string_option in
-  let initial_prompt = match initial_prompt with
-    | Some s ->
-      let s = String.trim s in
-      (* Cap below Discord's 2000-byte message limit so the prompt
-         posts as a single message; we use that message as the
-         reaction anchor for the auto-triggered agent run.
-         [Resource.truncate_utf8] is codepoint-aware (a raw
-         [String.sub] would split a multi-byte character, and the
-         send-path sanitization in PR #33 would then "repair" the
-         cut byte to U+FFFD, silently corrupting the last character).
-         We DON'T use [normalize_summary] here because its
-         [single_line] pass collapses \\n / \\r / \\t and would
-         flatten a structured prompt (code blocks, bullets,
-         paragraph breaks) into one line — and the prompt is posted
-         as a standalone Discord message, not embedded in a markdown
-         list, so there are no sibling bullets to defend against.
-         Cap is 1900 *bytes*; the MCP schema description matches. *)
-      let s = Resource.truncate_utf8 ~max_bytes:1900 s in
-      if s = "" then None else Some s
-    | None -> None in
-  match Command.find_project_fuzzy (Bot.projects bot) project_str with
-  | None ->
-    (* Sanitize the MCP-supplied project string before echoing it
-       back: the MCP client renders the error into Discord, where a
-       literal newline in the input would let the rest of the error
-       land at column 0 and parse as a sibling bullet. Same defense
-       Bot.handle_command applies for the Discord !start path. *)
-    error_response (Printf.sprintf "No project matching '%s'."
-      (Resource.single_line project_str))
-  | Some p ->
-    let kind_str = Config.string_of_agent_kind kind in
-    let branch_name = Printf.sprintf "agent/%s-%s"
-      kind_str (String.sub (Resource.generate_uuid ()) 0 8) in
-    let working_dir, branch_info =
-      match Project.create_worktree p ~branch_name with
-      | Ok wt -> wt, Some branch_name
-      | Error e ->
-        Logs.warn (fun m -> m "control_api: worktree failed: %s" e);
-        (match Bot.working_dir_of_project p with
-         | Ok wd -> wd, None
-         | Error _ -> "", None)
-    in
-    if working_dir = "" then
-      error_response "No working directory available."
-    else
-      let thread_display_name = match thread_name with
-        | Some n when String.length (String.trim n) > 0 ->
-          let n = String.trim n in
-          if String.length n > 80 then
-            Resource.truncate_utf8 ~max_bytes:80 n
-          else
-            n
-        | _ -> Printf.sprintf "%s / %s" kind_str p.name
-      in
-      let thread_parent =
-        match Channel_manager.find_or_create ~rest:bot.rest
-                ~guild_id:bot.config.guild_id ~project:p (Bot.channels bot) with
-        | Some ch_id -> ch_id
+    match Disk_health.preflight_state_mutation () with
+    | Error err -> error_response err
+    | Ok () ->
+      let project_str = params |> member "project" |> to_string in
+      let kind_str = match params |> member "agent" |> to_string_option with
+        | Some s -> s
         | None ->
-          (match bot.config.control_channel_id with
-           | Some ctl -> ctl | None -> "")
+          Config.string_of_agent_kind bot.settings.default_agent
       in
-      if thread_parent = "" then
-        error_response "No channel found for thread creation."
-      else
-        match Discord_rest.create_thread_no_message bot.rest
-                ~channel_id:thread_parent ~name:thread_display_name () with
-        | Error e -> error_response (Printf.sprintf "Failed to create thread: %s" e)
-        | Ok thread_ch ->
+      let kind = match Config.agent_kind_of_string kind_str with
+        | Ok k -> k | Error _ -> failwith ("unknown agent: " ^ kind_str) in
+      let thread_name = params |> member "thread_name" |> to_string_option in
+      let initial_prompt = params |> member "initial_prompt" |> to_string_option in
+      let initial_prompt = match initial_prompt with
+        | Some s ->
+          let s = String.trim s in
+          (* Cap below Discord's 2000-byte message limit so the prompt
+             posts as a single message; we use that message as the
+             reaction anchor for the auto-triggered agent run.
+             [Resource.truncate_utf8] is codepoint-aware (a raw
+             [String.sub] would split a multi-byte character, and the
+             send-path sanitization in PR #33 would then "repair" the
+             cut byte to U+FFFD, silently corrupting the last character).
+             We DON'T use [normalize_summary] here because its
+             [single_line] pass collapses \\n / \\r / \\t and would
+             flatten a structured prompt (code blocks, bullets,
+             paragraph breaks) into one line — and the prompt is posted
+             as a standalone Discord message, not embedded in a markdown
+             list, so there are no sibling bullets to defend against.
+             Cap is 1900 *bytes*; the MCP schema description matches. *)
+          let s = Resource.truncate_utf8 ~max_bytes:1900 s in
+          if s = "" then None else Some s
+        | None -> None in
+      match Command.find_project_fuzzy (Bot.projects bot) project_str with
+      | None ->
+        (* Sanitize the MCP-supplied project string before echoing it
+           back: the MCP client renders the error into Discord, where a
+           literal newline in the input would let the rest of the error
+           land at column 0 and parse as a sibling bullet. Same defense
+           Bot.handle_command applies for the Discord !start path. *)
+        error_response (Printf.sprintf "No project matching '%s'."
+          (Resource.single_line project_str))
+      | Some p ->
+        let kind_str = Config.string_of_agent_kind kind in
+        let branch_name = Printf.sprintf "agent/%s-%s"
+          kind_str (String.sub (Resource.generate_uuid ()) 0 8) in
+        let working_dir, branch_info =
+          match Project.create_worktree p ~branch_name with
+          | Ok wt -> wt, Some branch_name
+          | Error e ->
+            Logs.warn (fun m -> m "control_api: worktree failed: %s" e);
+            (match Bot.working_dir_of_project p with
+             | Ok wd -> wd, None
+             | Error _ -> "", None)
+        in
+        if working_dir = "" then
+          error_response "No working directory available."
+        else
+          let thread_display_name = match thread_name with
+            | Some n when String.length (String.trim n) > 0 ->
+              let n = String.trim n in
+              if String.length n > 80 then
+                Resource.truncate_utf8 ~max_bytes:80 n
+              else
+                n
+            | _ -> Printf.sprintf "%s / %s" kind_str p.name
+          in
+          let thread_parent =
+            match Channel_manager.find_or_create ~rest:bot.rest
+                    ~guild_id:bot.config.guild_id ~project:p (Bot.channels bot) with
+            | Some ch_id -> ch_id
+            | None ->
+              (match bot.config.control_channel_id with
+               | Some ctl -> ctl | None -> "")
+          in
+          if thread_parent = "" then
+            error_response "No channel found for thread creation."
+          else
+            match Discord_rest.create_thread_no_message bot.rest
+                    ~channel_id:thread_parent ~name:thread_display_name () with
+            | Error e -> error_response (Printf.sprintf "Failed to create thread: %s" e)
+            | Ok thread_ch ->
           let session_id = Resource.generate_uuid () in
           let branch_str = match branch_info with
             | Some b -> Printf.sprintf "\nBranch: `%s`" b | None -> "" in
@@ -327,56 +372,15 @@ let handle_start_session (bot : Bot.t) params =
              For the no-prompt path we add normally (no
              [processing] lock); the user's first message goes
              through the standard [handle_thread_message] flow. *)
-          (match initial_prompt with
-           | None ->
-             Session_store.add bot.sessions ~thread_id:thread_ch.id session;
-             ignore (Discord_rest.create_message bot.rest
-               ~channel_id:thread_ch.id
-               ~content:(Printf.sprintf
-                 "**%s** session started for **%s**%s\nWorking in: `%s`\n%s"
-                 kind_str p.name branch_str working_dir starter_text) ());
-             ok_response [
-               ("thread_id", `String thread_ch.id);
-               ("working_dir", `String working_dir);
-               ("branch", match branch_info with
-                 | Some b -> `String b | None -> `Null);
-               ("project_name", `String p.name);
-               ("session_id", `String session_id);
-             ]
-           | Some prompt ->
-             session.processing <- true;
-             Session_store.add bot.sessions ~thread_id:thread_ch.id session;
-             ignore (Discord_rest.create_message bot.rest
-               ~channel_id:thread_ch.id
-               ~content:(Printf.sprintf
-                 "**%s** session started for **%s**%s\nWorking in: `%s`\n%s"
-                 kind_str p.name branch_str working_dir starter_text) ());
-             match Discord_rest.create_message bot.rest
-                     ~channel_id:thread_ch.id ~content:prompt () with
-             | Error e ->
-               (* Roll back: the session is half-published (in store
-                  but [processing] locked, no agent fiber will fire),
-                  and the thread holds an orphan announcement. Remove
-                  the session, delete the thread, and surface the
-                  error to the MCP caller. *)
-               Logs.warn (fun m -> m
-                 "control_api: failed to post initial_prompt: %s" e);
-               session.processing <- false;
-               Session_store.remove bot.sessions
-                 ~thread_id:thread_ch.id;
-               (match Discord_rest.delete_channel bot.rest
-                       ~channel_id:thread_ch.id () with
-                | Ok _ -> ()
-                | Error de ->
-                  Logs.warn (fun m -> m
-                    "control_api: failed to clean up orphan thread \
-                     %s after prompt-post failure: %s"
-                    thread_ch.id de));
-               error_response (Printf.sprintf
-                 "Failed to post initial_prompt: %s" e)
-             | Ok prompt_msg ->
-               Bot.fork_initial_prompt_run bot
-                 ~session ~msg:prompt_msg;
+          match initial_prompt with
+          | None ->
+            (try
+               Session_store.add bot.sessions ~thread_id:thread_ch.id session;
+               ignore (Discord_rest.create_message bot.rest
+                 ~channel_id:thread_ch.id
+                 ~content:(Printf.sprintf
+                   "**%s** session started for **%s**%s\nWorking in: `%s`\n%s"
+                   kind_str p.name branch_str working_dir starter_text) ());
                ok_response [
                  ("thread_id", `String thread_ch.id);
                  ("working_dir", `String working_dir);
@@ -384,7 +388,55 @@ let handle_start_session (bot : Bot.t) params =
                    | Some b -> `String b | None -> `Null);
                  ("project_name", `String p.name);
                  ("session_id", `String session_id);
-               ])
+               ]
+             with exn ->
+               cleanup_orphan_thread bot.rest ~thread_id:thread_ch.id
+                 ~context:"session persistence failure";
+               error_response (Printf.sprintf "Failed to persist session: %s"
+                 (Printexc.to_string exn)))
+          | Some prompt ->
+            session.processing <- true;
+            (try
+               Session_store.add bot.sessions ~thread_id:thread_ch.id session;
+               ignore (Discord_rest.create_message bot.rest
+                 ~channel_id:thread_ch.id
+                 ~content:(Printf.sprintf
+                   "**%s** session started for **%s**%s\nWorking in: `%s`\n%s"
+                   kind_str p.name branch_str working_dir starter_text) ());
+               match Discord_rest.create_message bot.rest
+                       ~channel_id:thread_ch.id ~content:prompt () with
+               | Error e ->
+                 (* Roll back: the session is half-published (in store
+                    but [processing] locked, no agent fiber will fire),
+                    and the thread holds an orphan announcement. Remove
+                    the session, delete the thread, and surface the
+                    error to the MCP caller. *)
+                 Logs.warn (fun m -> m
+                   "control_api: failed to post initial_prompt: %s" e);
+                 session.processing <- false;
+                 Session_store.remove bot.sessions
+                   ~thread_id:thread_ch.id;
+                 cleanup_orphan_thread bot.rest ~thread_id:thread_ch.id
+                   ~context:"prompt-post failure";
+                 error_response (Printf.sprintf
+                   "Failed to post initial_prompt: %s" e)
+               | Ok prompt_msg ->
+                 Bot.fork_initial_prompt_run bot
+                   ~session ~msg:prompt_msg;
+                 ok_response [
+                   ("thread_id", `String thread_ch.id);
+                   ("working_dir", `String working_dir);
+                   ("branch", match branch_info with
+                     | Some b -> `String b | None -> `Null);
+                   ("project_name", `String p.name);
+                   ("session_id", `String session_id);
+                 ]
+             with exn ->
+               session.processing <- false;
+               cleanup_orphan_thread bot.rest ~thread_id:thread_ch.id
+                 ~context:"session persistence failure";
+               error_response (Printf.sprintf "Failed to persist session: %s"
+                 (Printexc.to_string exn)))
 
 let handle_resume_session (bot : Bot.t) params =
   let open Yojson.Safe.Util in
@@ -397,69 +449,72 @@ let handle_resume_session (bot : Bot.t) params =
   if bot.draining then
     error_response "Bot is restarting; try again shortly."
   else
-  let sid_prefix = params |> member "session_id" |> to_string in
-  let kind = match params |> member "kind" |> to_string_option with
-    | None -> None
-    | Some s ->
-      (match Config.agent_kind_of_string (String.lowercase_ascii s) with
-       | Ok k -> Some k | Error _ -> None)
-  in
-  (* Mirror Bot.handle_command's Resume_session dispatch: explicit
-     kind looks up its own store; None tries the current default
-     first, then the remaining stores. *)
-  let try_claude () =
-    match Claude_sessions.find_by_prefix sid_prefix with
-    | Some (sid, wd) -> Some (Config.Claude, sid, wd) | None -> None
-  in
-  let try_codex () =
-    match Codex_sessions.find_by_prefix sid_prefix with
-    | Some (sid, wd) -> Some (Config.Codex, sid, wd) | None -> None
-  in
-  let try_gemini () =
-    match Gemini_sessions.find_by_prefix sid_prefix with
-    | Some (sid, wd) -> Some (Config.Gemini, sid, wd) | None -> None
-  in
-  let try_kind = function
-    | Config.Claude -> try_claude ()
-    | Config.Codex -> try_codex ()
-    | Config.Gemini -> try_gemini ()
-  in
-  let found = match kind with
-    | Some k -> try_kind k
-    | None ->
-      Config.find_with_preferred_agent bot.settings.default_agent try_kind
-  in
-  match found with
-  | None ->
-    error_response (Bot.resume_not_found_message ~kind ~sid_prefix)
-  | Some (_, full_sid, "") ->
+    match Disk_health.preflight_state_mutation () with
+    | Error err -> error_response err
+    | Ok () ->
+      let sid_prefix = params |> member "session_id" |> to_string in
+      let kind = match params |> member "kind" |> to_string_option with
+        | None -> None
+        | Some s ->
+          (match Config.agent_kind_of_string (String.lowercase_ascii s) with
+           | Ok k -> Some k | Error _ -> None)
+      in
+      (* Mirror Bot.handle_command's Resume_session dispatch: explicit
+         kind looks up its own store; None tries the current default
+         first, then the remaining stores. *)
+      let try_claude () =
+        match Claude_sessions.find_by_prefix sid_prefix with
+        | Some (sid, wd) -> Some (Config.Claude, sid, wd) | None -> None
+      in
+      let try_codex () =
+        match Codex_sessions.find_by_prefix sid_prefix with
+        | Some (sid, wd) -> Some (Config.Codex, sid, wd) | None -> None
+      in
+      let try_gemini () =
+        match Gemini_sessions.find_by_prefix sid_prefix with
+        | Some (sid, wd) -> Some (Config.Gemini, sid, wd) | None -> None
+      in
+      let try_kind = function
+        | Config.Claude -> try_claude ()
+        | Config.Codex -> try_codex ()
+        | Config.Gemini -> try_gemini ()
+      in
+      let found = match kind with
+        | Some k -> try_kind k
+        | None ->
+          Config.find_with_preferred_agent bot.settings.default_agent try_kind
+      in
+      match found with
+      | None ->
+        error_response (Bot.resume_not_found_message ~kind ~sid_prefix)
+      | Some (_, full_sid, "") ->
     (* See Bot.handle_command Resume_session for the rationale —
        Gemini sessions with unresolvable projectHash arrive here
        with an empty working_dir; running gemini with an empty cwd
        writes settings.json into the bot's directory. *)
-    error_response (Printf.sprintf
-      "Cannot resume session '%s': its working directory could not \
-       be resolved." (Resource.short_id full_sid))
-  | Some (resolved_kind, full_sid, raw_working_dir) ->
-    let kind_label = Config.string_of_agent_kind resolved_kind in
-    let kind_title = String.capitalize_ascii kind_label in
-    let sid_short = Resource.short_id full_sid in
-    let fallback_channel = match bot.config.control_channel_id with
-      | Some ctl -> ctl | None -> ""
-    in
-    let { Bot.thread_parent; working_dir; project_name } =
-      Bot.resolve_resume_target bot
-        ~raw_working_dir ~kind_label ~fallback_channel
-    in
-    if thread_parent = "" then
-      error_response "No channel found for thread creation."
-    else
-      let thread_name =
-        Printf.sprintf "resume %s / %s" kind_label sid_short in
-      (match Discord_rest.create_thread_no_message bot.rest
-              ~channel_id:thread_parent ~name:thread_name () with
-      | Error e -> error_response (Printf.sprintf "Failed to create thread: %s" e)
-      | Ok thread_ch ->
+        error_response (Printf.sprintf
+          "Cannot resume session '%s': its working directory could not \
+           be resolved." (Resource.short_id full_sid))
+      | Some (resolved_kind, full_sid, raw_working_dir) ->
+        let kind_label = Config.string_of_agent_kind resolved_kind in
+        let kind_title = String.capitalize_ascii kind_label in
+        let sid_short = Resource.short_id full_sid in
+        let fallback_channel = match bot.config.control_channel_id with
+          | Some ctl -> ctl | None -> ""
+        in
+        let { Bot.thread_parent; working_dir; project_name } =
+          Bot.resolve_resume_target bot
+            ~raw_working_dir ~kind_label ~fallback_channel
+        in
+        if thread_parent = "" then
+          error_response "No channel found for thread creation."
+        else
+          let thread_name =
+            Printf.sprintf "resume %s / %s" kind_label sid_short in
+          (match Discord_rest.create_thread_no_message bot.rest
+                  ~channel_id:thread_parent ~name:thread_name () with
+          | Error e -> error_response (Printf.sprintf "Failed to create thread: %s" e)
+          | Ok thread_ch ->
         (* session_id_confirmed:true is critical: see Bot.handle_command
            Resume_session for the rationale — without it, Gemini resumes
            start fresh chats instead of resuming. *)
@@ -469,18 +524,25 @@ let handle_resume_session (bot : Bot.t) params =
           ~message_count:1
           ~thread_id:thread_ch.Discord_types.id
           ~system_prompt:None ~initial_prompt:None () in
-        Session_store.add bot.sessions ~thread_id:thread_ch.id session;
-        ignore (Discord_rest.create_message bot.rest ~channel_id:thread_ch.id
-          ~content:(Printf.sprintf
-            "**Resumed** %s session `%s`\nWorking in: `%s`\nSend a message to continue."
-            kind_title sid_short working_dir) ());
-        ok_response [
-          ("thread_id", `String thread_ch.id);
-          ("working_dir", `String working_dir);
-          ("session_id", `String full_sid);
-          ("project_name", `String project_name);
-          ("agent_kind", `String kind_label);
-        ])
+        (try
+           Session_store.add bot.sessions ~thread_id:thread_ch.id session;
+           ignore (Discord_rest.create_message bot.rest ~channel_id:thread_ch.id
+             ~content:(Printf.sprintf
+               "**Resumed** %s session `%s`\nWorking in: `%s`\nSend a message to continue."
+               kind_title sid_short working_dir) ());
+           ok_response [
+             ("thread_id", `String thread_ch.id);
+             ("working_dir", `String working_dir);
+             ("session_id", `String full_sid);
+             ("project_name", `String project_name);
+             ("agent_kind", `String kind_label);
+           ]
+         with exn ->
+           cleanup_orphan_thread bot.rest ~thread_id:thread_ch.id
+             ~context:"resume persistence failure";
+           error_response (Printf.sprintf
+             "Failed to persist resumed session: %s"
+             (Printexc.to_string exn))))
 
 let handle_default_agent (bot : Bot.t) params =
   let open Yojson.Safe.Util in

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -63,6 +63,53 @@ let cleanup_orphan_thread rest ~thread_id ~context =
       m "control_api: failed to clean up orphan thread %s after %s: %s"
         thread_id context err)
 
+let cleanup_orphan_worktree ~project ~branch_info ~working_dir ~context =
+  match branch_info with
+  | None -> ()
+  | Some branch_name ->
+    (match Project.remove_worktree project ~branch_name
+             ~worktree_path:working_dir with
+     | Ok () -> ()
+     | Error err ->
+       Logs.warn (fun m ->
+         m "control_api: failed to clean up orphan worktree %s after %s: %s"
+           working_dir context err))
+
+let remove_persisted_session_for_cleanup (bot : Bot.t) ~thread_id ~context =
+  match Session_store.find_opt bot.sessions ~thread_id with
+  | None -> true
+  | Some _ ->
+    try
+      Session_store.remove bot.sessions ~thread_id;
+      true
+    with exn ->
+      Logs.warn (fun m ->
+        m "control_api: failed to remove persisted session %s during %s cleanup: %s"
+          thread_id context (Printexc.to_string exn));
+      false
+
+let cleanup_start_artifacts (bot : Bot.t) ~project ~branch_info ~working_dir
+    ~thread_id ~session_persisted ~context =
+  let session_removed =
+    (not session_persisted)
+    || remove_persisted_session_for_cleanup bot ~thread_id ~context
+  in
+  if session_removed then begin
+    cleanup_orphan_thread bot.rest ~thread_id ~context;
+    cleanup_orphan_worktree ~project ~branch_info ~working_dir ~context
+  end;
+  session_removed
+
+let cleanup_thread_session_artifacts (bot : Bot.t)
+    ~thread_id ~session_persisted ~context =
+  let session_removed =
+    (not session_persisted)
+    || remove_persisted_session_for_cleanup bot ~thread_id ~context
+  in
+  if session_removed then
+    cleanup_orphan_thread bot.rest ~thread_id ~context;
+  session_removed
+
 (* ── Handlers ──────────────────────────────────────────────────── *)
 
 let handle_health (bot : Bot.t) =
@@ -305,9 +352,11 @@ let handle_start_session (bot : Bot.t) params =
              | Ok wd -> wd, None
              | Error _ -> "", None)
         in
-        if working_dir = "" then
+        if working_dir = "" then begin
+          cleanup_orphan_worktree ~project:p ~branch_info ~working_dir
+            ~context:"working directory resolution failure";
           error_response "No working directory available."
-        else
+        end else
           let thread_display_name = match thread_name with
             | Some n when String.length (String.trim n) > 0 ->
               let n = String.trim n in
@@ -325,12 +374,18 @@ let handle_start_session (bot : Bot.t) params =
               (match bot.config.control_channel_id with
                | Some ctl -> ctl | None -> "")
           in
-          if thread_parent = "" then
+          if thread_parent = "" then begin
+            cleanup_orphan_worktree ~project:p ~branch_info ~working_dir
+              ~context:"thread parent resolution failure";
             error_response "No channel found for thread creation."
+          end
           else
             match Discord_rest.create_thread_no_message bot.rest
                     ~channel_id:thread_parent ~name:thread_display_name () with
-            | Error e -> error_response (Printf.sprintf "Failed to create thread: %s" e)
+            | Error e ->
+              cleanup_orphan_worktree ~project:p ~branch_info ~working_dir
+                ~context:"thread creation failure";
+              error_response (Printf.sprintf "Failed to create thread: %s" e)
             | Ok thread_ch ->
           let session_id = Resource.generate_uuid () in
           let branch_str = match branch_info with
@@ -374,8 +429,10 @@ let handle_start_session (bot : Bot.t) params =
              through the standard [handle_thread_message] flow. *)
           match initial_prompt with
           | None ->
+            let session_persisted = ref false in
             (try
                Session_store.add bot.sessions ~thread_id:thread_ch.id session;
+               session_persisted := true;
                ignore (Discord_rest.create_message bot.rest
                  ~channel_id:thread_ch.id
                  ~content:(Printf.sprintf
@@ -390,14 +447,18 @@ let handle_start_session (bot : Bot.t) params =
                  ("session_id", `String session_id);
                ]
              with exn ->
-               cleanup_orphan_thread bot.rest ~thread_id:thread_ch.id
-                 ~context:"session persistence failure";
+               ignore (cleanup_start_artifacts bot ~project:p ~branch_info ~working_dir
+                 ~thread_id:thread_ch.id
+                 ~session_persisted:!session_persisted
+                 ~context:"session startup failure");
                error_response (Printf.sprintf "Failed to persist session: %s"
                  (Printexc.to_string exn)))
           | Some prompt ->
             session.processing <- true;
+            let session_persisted = ref false in
             (try
                Session_store.add bot.sessions ~thread_id:thread_ch.id session;
+               session_persisted := true;
                ignore (Discord_rest.create_message bot.rest
                  ~channel_id:thread_ch.id
                  ~content:(Printf.sprintf
@@ -414,12 +475,18 @@ let handle_start_session (bot : Bot.t) params =
                  Logs.warn (fun m -> m
                    "control_api: failed to post initial_prompt: %s" e);
                  session.processing <- false;
-                 Session_store.remove bot.sessions
-                   ~thread_id:thread_ch.id;
-                 cleanup_orphan_thread bot.rest ~thread_id:thread_ch.id
-                   ~context:"prompt-post failure";
+                 let cleaned =
+                   cleanup_start_artifacts bot ~project:p ~branch_info
+                     ~working_dir ~thread_id:thread_ch.id
+                     ~session_persisted:true
+                     ~context:"prompt-post failure"
+                 in
+                 let suffix =
+                   if cleaned then ""
+                   else " The session was persisted and could not be rolled back; send a message in the new thread or stop it manually."
+                 in
                  error_response (Printf.sprintf
-                   "Failed to post initial_prompt: %s" e)
+                   "Failed to post initial_prompt: %s%s" e suffix)
                | Ok prompt_msg ->
                  Bot.fork_initial_prompt_run bot
                    ~session ~msg:prompt_msg;
@@ -433,8 +500,10 @@ let handle_start_session (bot : Bot.t) params =
                  ]
              with exn ->
                session.processing <- false;
-               cleanup_orphan_thread bot.rest ~thread_id:thread_ch.id
-                 ~context:"session persistence failure";
+               ignore (cleanup_start_artifacts bot ~project:p ~branch_info ~working_dir
+                 ~thread_id:thread_ch.id
+                 ~session_persisted:!session_persisted
+                 ~context:"session startup failure");
                error_response (Printf.sprintf "Failed to persist session: %s"
                  (Printexc.to_string exn)))
 
@@ -524,8 +593,10 @@ let handle_resume_session (bot : Bot.t) params =
           ~message_count:1
           ~thread_id:thread_ch.Discord_types.id
           ~system_prompt:None ~initial_prompt:None () in
+        let session_persisted = ref false in
         (try
            Session_store.add bot.sessions ~thread_id:thread_ch.id session;
+           session_persisted := true;
            ignore (Discord_rest.create_message bot.rest ~channel_id:thread_ch.id
              ~content:(Printf.sprintf
                "**Resumed** %s session `%s`\nWorking in: `%s`\nSend a message to continue."
@@ -538,8 +609,9 @@ let handle_resume_session (bot : Bot.t) params =
              ("agent_kind", `String kind_label);
            ]
          with exn ->
-           cleanup_orphan_thread bot.rest ~thread_id:thread_ch.id
-             ~context:"resume persistence failure";
+           ignore (cleanup_thread_session_artifacts bot ~thread_id:thread_ch.id
+             ~session_persisted:!session_persisted
+             ~context:"resume startup failure");
            error_response (Printf.sprintf
              "Failed to persist resumed session: %s"
              (Printexc.to_string exn))))

--- a/lib/discord_agents.ml
+++ b/lib/discord_agents.ml
@@ -1,6 +1,7 @@
 (** Discord Agents — top-level library module. *)
 
 module Resource = Resource
+module Disk_health = Disk_health
 module Config = Config
 module Runtime_settings = Runtime_settings
 module Project = Project

--- a/lib/disk_health.ml
+++ b/lib/disk_health.ml
@@ -1,12 +1,9 @@
 (** Shared disk-pressure state for durable bot metadata writes.
 
-    The bot only has a few write-critical paths (sessions, runtime
-    settings, config, generated MCP config), but they sit under several
-    different modules. This module centralizes:
-    - proactive free-space checks before writes
-    - classification of disk-related write failures
-    - a process-wide degraded/read-only state surfaced through health
-    - user-facing summaries for commands/control API *)
+    The bot writes critical state under the app config directory, but
+    generated agent config can land inside project worktrees. Disk
+    pressure therefore has to be tracked per filesystem path: a healthy
+    app-config probe must not erase a read-only project-worktree failure. *)
 
 type mode =
   | Healthy
@@ -28,6 +25,29 @@ type write_failure = {
   summary : string;
 }
 
+type observation = {
+  path : string;
+  mode : mode;
+  available_bytes : int64 option;
+  last_error : string option;
+  checked_at : float;
+  sticky_until_write_success : bool;
+}
+
+type probe_error = {
+  probe_path : string;
+  probe_error : string;
+  probe_checked_at : float;
+}
+
+type state = {
+  observations : observation list;
+  last_probe_error : probe_error option;
+}
+
+external statvfs_available_bytes : string -> int64 =
+  "discord_agents_available_bytes"
+
 let mib n =
   Int64.mul (Int64.of_int n) (Int64.mul 1024L 1024L)
 
@@ -37,13 +57,8 @@ let read_only_threshold_bytes = mib 64
 let state_mu = Mutex.create ()
 
 let state = ref {
-  mode = Healthy;
-  available_bytes = None;
-  warning_threshold_bytes;
-  read_only_threshold_bytes;
-  last_error = None;
-  checked_path = None;
-  checked_at = None;
+  observations = [];
+  last_probe_error = None;
 }
 
 let with_state f =
@@ -52,35 +67,20 @@ let with_state f =
     ~finally:(fun () -> Mutex.unlock state_mu)
     (fun () -> f state)
 
-let reset_for_tests () =
-  with_state (fun state ->
-    state := {
-      mode = Healthy;
-      available_bytes = None;
-      warning_threshold_bytes;
-      read_only_threshold_bytes;
-      last_error = None;
-      checked_path = None;
-      checked_at = None;
-    })
-
-let snapshot () =
-  with_state (fun state -> !state)
-
 let string_of_mode = function
   | Healthy -> "healthy"
   | Warning -> "warning"
   | Read_only -> "read_only"
 
-let pressure snapshot =
+let severity = function
+  | Healthy -> 0
+  | Warning -> 1
+  | Read_only -> 2
+
+let pressure (snapshot : snapshot) =
   match snapshot.mode with
   | Healthy -> false
   | Warning | Read_only -> true
-
-let is_read_only () =
-  match (snapshot ()).mode with
-  | Read_only -> true
-  | Healthy | Warning -> false
 
 let human_bytes bytes =
   let f = Int64.to_float bytes in
@@ -114,6 +114,11 @@ let low_space_summary ~path ~available_bytes ~mode =
       "disk pressure near %s: %s free (read-only threshold %s)"
       path available (human_bytes read_only_threshold_bytes)
 
+let read_only_message ~path ~available_bytes =
+  Printf.sprintf
+    "Bot is in read-only mode due to disk pressure near `%s`: only %s free. Free space and retry."
+    path (human_bytes available_bytes)
+
 let rec existing_ancestor path =
   if Sys.file_exists path then
     path
@@ -132,43 +137,97 @@ let probe_target path =
   in
   existing_ancestor candidate
 
-let split_fields line =
-  String.split_on_char ' ' line
-  |> List.filter (fun field -> field <> "")
+let replace_observation observations observation =
+  observation
+  :: List.filter (fun prior -> prior.path <> observation.path) observations
 
-let available_bytes_of_df_line line =
-  match split_fields line with
-  | _filesystem :: _blocks :: _used :: available_kib :: _capacity :: _mount ->
-    Int64.mul 1024L (Int64.of_string available_kib)
-  | _ ->
-    failwith (Printf.sprintf "unexpected df output: %s" line)
+let drop_observation observations path =
+  List.filter (fun prior -> prior.path <> path) observations
 
-let probe_available_bytes_with_df path =
-  let argv = [| "df"; "-Pk"; path |] in
-  let ic = Unix.open_process_args_in "df" argv in
-  let read_result =
-    try
-      ignore (input_line ic);
-      Ok (available_bytes_of_df_line (input_line ic))
-    with exn ->
-      Error exn
+let rec path_is_ancestor ~ancestor path =
+  ancestor = path
+  || (let parent = Filename.dirname path in
+      parent <> path && path_is_ancestor ~ancestor parent)
+
+let clear_sticky_observations_for_success path =
+  with_state (fun state ->
+    state := {
+      !state with
+      observations =
+        List.filter (fun obs ->
+          not (obs.sticky_until_write_success
+               && path_is_ancestor ~ancestor:obs.path path))
+          !state.observations;
+    })
+
+let representative observations =
+  let better a b =
+    let severity_cmp = compare (severity a.mode) (severity b.mode) in
+    if severity_cmp <> 0 then severity_cmp > 0
+    else a.checked_at >= b.checked_at
   in
-  match read_result, Unix.close_process_in ic with
-  | Ok available_bytes, Unix.WEXITED 0 ->
-    available_bytes
-  | Ok _, Unix.WEXITED code ->
-    failwith (Printf.sprintf "df exited with status %d for %s" code path)
-  | Ok _, status ->
-    failwith (Printf.sprintf "df failed for %s: %s"
-      path
-      (match status with
-       | Unix.WSIGNALED signal -> Printf.sprintf "signaled %d" signal
-       | Unix.WSTOPPED signal -> Printf.sprintf "stopped %d" signal
-       | Unix.WEXITED _ -> "unexpected exit"))
-  | Error exn, _ ->
-    raise exn
+  List.fold_left
+    (fun acc obs ->
+       match acc with
+       | None -> Some obs
+       | Some current when better obs current -> Some obs
+       | Some _ -> acc)
+    None observations
 
-let update_from_available_bytes ~path available_bytes =
+let snapshot_of_state state =
+  match representative state.observations with
+  | Some obs ->
+    let last_error =
+      match obs.mode, obs.last_error, state.last_probe_error with
+      | Healthy, None, Some err -> Some err.probe_error
+      | _ -> obs.last_error
+    in
+    let checked_path, checked_at =
+      match obs.mode, state.last_probe_error with
+      | Healthy, Some err
+        when err.probe_checked_at > obs.checked_at ->
+        Some err.probe_path, Some err.probe_checked_at
+      | _ -> Some obs.path, Some obs.checked_at
+    in
+    {
+      mode = obs.mode;
+      available_bytes = obs.available_bytes;
+      warning_threshold_bytes;
+      read_only_threshold_bytes;
+      last_error;
+      checked_path;
+      checked_at;
+    }
+  | None ->
+    {
+      mode = Healthy;
+      available_bytes = None;
+      warning_threshold_bytes;
+      read_only_threshold_bytes;
+      last_error =
+        Option.map (fun err -> err.probe_error) state.last_probe_error;
+      checked_path =
+        Option.map (fun err -> err.probe_path) state.last_probe_error;
+      checked_at =
+        Option.map (fun err -> err.probe_checked_at) state.last_probe_error;
+    }
+
+let snapshot () =
+  with_state (fun state -> snapshot_of_state !state)
+
+let is_read_only () =
+  match (snapshot ()).mode with
+  | Read_only -> true
+  | Healthy | Warning -> false
+
+let reset_for_tests () =
+  with_state (fun state ->
+    state := {
+      observations = [];
+      last_probe_error = None;
+    })
+
+let update_from_available_bytes ?(force = false) ~path available_bytes =
   let mode = mode_of_available_bytes available_bytes in
   let last_error =
     match mode with
@@ -176,22 +235,30 @@ let update_from_available_bytes ~path available_bytes =
     | Warning | Read_only ->
       Some (low_space_summary ~path ~available_bytes ~mode)
   in
+  let checked_at = Unix.gettimeofday () in
   with_state (fun state ->
+    let next =
+      { path; mode; available_bytes = Some available_bytes;
+        last_error; checked_at; sticky_until_write_success = false }
+    in
+    let keep_sticky =
+      (not force)
+      && mode <> Read_only
+      && List.exists (fun prior ->
+        prior.path = path && prior.sticky_until_write_success)
+        !state.observations
+    in
     state := {
-      mode;
-      available_bytes = Some available_bytes;
-      warning_threshold_bytes;
-      read_only_threshold_bytes;
-      last_error;
-      checked_path = Some path;
-      checked_at = Some (Unix.gettimeofday ());
+      observations =
+        if keep_sticky then
+          !state.observations
+        else
+          replace_observation !state.observations next;
+      last_probe_error = None;
     });
   match mode with
   | Healthy | Warning -> Ok ()
-  | Read_only ->
-    Error (Printf.sprintf
-      "Bot is in read-only mode due to disk pressure near `%s`: only %s free. Free space and retry."
-      path (human_bytes available_bytes))
+  | Read_only -> Error (read_only_message ~path ~available_bytes)
 
 let note_probe_failure ~path exn =
   let err =
@@ -201,14 +268,26 @@ let note_probe_failure ~path exn =
   with_state (fun state ->
     state := {
       !state with
-      available_bytes = None;
-      last_error = Some err;
-      checked_path = Some path;
-      checked_at = Some (Unix.gettimeofday ());
+      last_probe_error =
+        Some {
+          probe_path = path;
+          probe_error = err;
+          probe_checked_at = Unix.gettimeofday ();
+        };
     })
 
+let probe_available_bytes path =
+  statvfs_available_bytes path
+
 let preflight_path_with ~available_bytes_of_path path =
+  let requested_path = path in
   let path = probe_target path in
+  if path <> requested_path then
+    with_state (fun state ->
+      state := {
+        !state with
+        observations = drop_observation !state.observations requested_path;
+      });
   try
     let available_bytes = available_bytes_of_path path in
     update_from_available_bytes ~path available_bytes
@@ -220,91 +299,22 @@ let preflight_path_with ~available_bytes_of_path path =
     Ok ()
 
 let preflight_path path =
-  preflight_path_with ~available_bytes_of_path:probe_available_bytes_with_df path
+  preflight_path_with ~available_bytes_of_path:probe_available_bytes path
 
 let preflight_write path =
   preflight_path path
 
-let preflight_state_mutation () =
-  preflight_path (Resource.app_config_dir ())
+let tracked_pressure_paths () =
+  with_state (fun state ->
+    !state.observations
+    |> List.filter_map (fun obs ->
+      match obs.mode with
+      | Healthy -> None
+      | Warning | Read_only -> Some obs.path))
 
-let string_contains s needle =
-  let s_len = String.length s in
-  let needle_len = String.length needle in
-  let rec loop i =
-    if i + needle_len > s_len then false
-    else if String.sub s i needle_len = needle then true
-    else loop (i + 1)
-  in
-  needle_len = 0 || loop 0
-
-let classify_sys_error msg =
-  let lower = String.lowercase_ascii msg in
-  if string_contains lower "no space left on device" then
-    Some { code = "ENOSPC"; summary = msg }
-  else if string_contains lower "disk quota exceeded" then
-    Some { code = "EDQUOT"; summary = msg }
-  else if string_contains lower "read-only file system" then
-    Some { code = "EROFS"; summary = msg }
-  else
-    None
-
-let rec classify_write_failure exn =
-  match exn with
-  | Resource.Durable_write_visible_but_unconfirmed (_, inner) ->
-    classify_write_failure inner
-  | Unix.Unix_error (code, _fn, path) ->
-    let code_message = Unix.error_message code in
-    let tracked =
-      if code = Unix.ENOSPC then Some ("ENOSPC", code_message)
-      else if code = Unix.EROFS then Some ("EROFS", code_message)
-      else if code = Unix.EIO then Some ("EIO", code_message)
-      else if string_contains (String.lowercase_ascii code_message) "quota" then
-        Some ("EDQUOT", code_message)
-      else
-        None
-    in
-    Option.map (fun (label, unix_code) ->
-      let target = if path = "" then "<unknown>" else path in
-      {
-        code = label;
-        summary =
-          Printf.sprintf "%s while writing %s: %s"
-            label target unix_code;
-      }) tracked
-  | Failure msg when String.equal msg "resource: short write" ->
-    Some {
-      code = "PARTIAL_WRITE";
-      summary = "partial write while updating durable state";
-    }
-  | Sys_error msg ->
-    classify_sys_error msg
-  | _ ->
-    None
-
-let note_write_failure path exn =
-  match classify_write_failure exn with
-  | None -> ()
-  | Some failure ->
-    let available_bytes =
-      try
-        let target = probe_target path in
-        Some (probe_available_bytes_with_df target)
-      with _ -> None
-    in
-    with_state (fun state ->
-      state := {
-        mode = Read_only;
-        available_bytes;
-        warning_threshold_bytes;
-        read_only_threshold_bytes;
-        last_error = Some failure.summary;
-        checked_path = Some path;
-        checked_at = Some (Unix.gettimeofday ());
-      })
-
-let note_write_success path =
-  ignore (preflight_path path)
+let refresh_tracked_pressure_paths () =
+  tracked_pressure_paths ()
+  |> List.iter (fun path -> ignore (preflight_path path))
 
 let status_summary () =
   let state = snapshot () in
@@ -333,6 +343,109 @@ let status_summary () =
   | Read_only, None, None ->
     "Disk: read-only."
 
+let preflight_state_mutation () =
+  match preflight_path (Resource.app_config_dir ()) with
+  | Error _ as err -> err
+  | Ok () ->
+    refresh_tracked_pressure_paths ();
+    if is_read_only () then
+      Error (status_summary () ^ " Free space and retry.")
+    else
+      Ok ()
+
+let string_contains s needle =
+  let s_len = String.length s in
+  let needle_len = String.length needle in
+  let rec loop i =
+    if i + needle_len > s_len then false
+    else if String.sub s i needle_len = needle then true
+    else loop (i + 1)
+  in
+  needle_len = 0 || loop 0
+
+let classify_sys_error msg =
+  let lower = String.lowercase_ascii msg in
+  if string_contains lower "no space left on device" then
+    Some { code = "ENOSPC"; summary = msg }
+  else if string_contains lower "disk quota exceeded"
+          || string_contains lower "quota exceeded" then
+    Some { code = "EDQUOT"; summary = msg }
+  else if string_contains lower "read-only file system" then
+    Some { code = "EROFS"; summary = msg }
+  else
+    None
+
+let unix_error_is_quota = function
+  | Unix.EUNKNOWNERR 122 -> true
+  | _ -> false
+
+let rec classify_write_failure exn =
+  match exn with
+  | Resource.Durable_write_visible_but_unconfirmed (_, inner) ->
+    classify_write_failure inner
+  | Unix.Unix_error (code, _fn, path) ->
+    let code_message = Unix.error_message code in
+    let lower_message = String.lowercase_ascii code_message in
+    let tracked =
+      if code = Unix.ENOSPC then Some ("ENOSPC", code_message)
+      else if code = Unix.EROFS then Some ("EROFS", code_message)
+      else if code = Unix.EIO then Some ("EIO", code_message)
+      else if unix_error_is_quota code
+              || string_contains lower_message "quota" then
+        Some ("EDQUOT", code_message)
+      else
+        None
+    in
+    Option.map (fun (label, unix_code) ->
+      let target = if path = "" then "<unknown>" else path in
+      {
+        code = label;
+        summary =
+          Printf.sprintf "%s while writing %s: %s"
+            label target unix_code;
+      }) tracked
+  | Failure msg when String.equal msg "resource: short write" ->
+    Some {
+      code = "PARTIAL_WRITE";
+      summary = "partial write while updating durable state";
+    }
+  | Sys_error msg ->
+    classify_sys_error msg
+  | _ ->
+    None
+
+let note_write_failure path exn =
+  match classify_write_failure exn with
+  | None -> ()
+  | Some failure ->
+    let target = probe_target path in
+    let available_bytes =
+      try Some (probe_available_bytes target)
+      with _ -> None
+    in
+    let checked_at = Unix.gettimeofday () in
+    with_state (fun state ->
+      state := {
+        observations =
+          replace_observation !state.observations
+            { path = target; mode = Read_only; available_bytes;
+              last_error = Some failure.summary; checked_at;
+              sticky_until_write_success = true };
+        last_probe_error = !state.last_probe_error;
+      })
+
+let note_write_success path =
+  let path = probe_target path in
+  clear_sticky_observations_for_success path;
+  try
+    let available_bytes = probe_available_bytes path in
+    ignore (update_from_available_bytes ~force:true ~path available_bytes)
+  with exn ->
+    note_probe_failure ~path exn;
+    Logs.warn (fun m ->
+      m "disk_health: free-space probe failed for %s after write success: %s"
+        path (Printexc.to_string exn))
+
 let new_session_block_message ?(preflight=preflight_state_mutation) () =
   match preflight () with
   | Error err -> Some err
@@ -340,3 +453,15 @@ let new_session_block_message ?(preflight=preflight_state_mutation) () =
     Some (status_summary () ^ " Free space and retry.")
   | Ok () ->
     None
+
+module For_testing = struct
+  let reset = reset_for_tests
+  let mib = mib
+  let mode_of_available_bytes = mode_of_available_bytes
+  let update_from_available_bytes = update_from_available_bytes
+  let classify_write_failure = classify_write_failure
+  let note_write_failure = note_write_failure
+  let new_session_block_message = new_session_block_message
+  let preflight_path_with = preflight_path_with
+  let note_write_success = note_write_success
+end

--- a/lib/disk_health.ml
+++ b/lib/disk_health.ml
@@ -1,0 +1,342 @@
+(** Shared disk-pressure state for durable bot metadata writes.
+
+    The bot only has a few write-critical paths (sessions, runtime
+    settings, config, generated MCP config), but they sit under several
+    different modules. This module centralizes:
+    - proactive free-space checks before writes
+    - classification of disk-related write failures
+    - a process-wide degraded/read-only state surfaced through health
+    - user-facing summaries for commands/control API *)
+
+type mode =
+  | Healthy
+  | Warning
+  | Read_only
+
+type snapshot = {
+  mode : mode;
+  available_bytes : int64 option;
+  warning_threshold_bytes : int64;
+  read_only_threshold_bytes : int64;
+  last_error : string option;
+  checked_path : string option;
+  checked_at : float option;
+}
+
+type write_failure = {
+  code : string;
+  summary : string;
+}
+
+let mib n =
+  Int64.mul (Int64.of_int n) (Int64.mul 1024L 1024L)
+
+let warning_threshold_bytes = mib 128
+let read_only_threshold_bytes = mib 64
+
+let state_mu = Mutex.create ()
+
+let state = ref {
+  mode = Healthy;
+  available_bytes = None;
+  warning_threshold_bytes;
+  read_only_threshold_bytes;
+  last_error = None;
+  checked_path = None;
+  checked_at = None;
+}
+
+let with_state f =
+  Mutex.lock state_mu;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock state_mu)
+    (fun () -> f state)
+
+let reset_for_tests () =
+  with_state (fun state ->
+    state := {
+      mode = Healthy;
+      available_bytes = None;
+      warning_threshold_bytes;
+      read_only_threshold_bytes;
+      last_error = None;
+      checked_path = None;
+      checked_at = None;
+    })
+
+let snapshot () =
+  with_state (fun state -> !state)
+
+let string_of_mode = function
+  | Healthy -> "healthy"
+  | Warning -> "warning"
+  | Read_only -> "read_only"
+
+let pressure snapshot =
+  match snapshot.mode with
+  | Healthy -> false
+  | Warning | Read_only -> true
+
+let is_read_only () =
+  match (snapshot ()).mode with
+  | Read_only -> true
+  | Healthy | Warning -> false
+
+let human_bytes bytes =
+  let f = Int64.to_float bytes in
+  let kib = 1024.0 in
+  let mib = kib *. 1024.0 in
+  let gib = mib *. 1024.0 in
+  if f >= gib then Printf.sprintf "%.1f GiB" (f /. gib)
+  else if f >= mib then Printf.sprintf "%.1f MiB" (f /. mib)
+  else if f >= kib then Printf.sprintf "%.1f KiB" (f /. kib)
+  else Printf.sprintf "%Ld B" bytes
+
+let mode_of_available_bytes available_bytes =
+  if Int64.compare available_bytes read_only_threshold_bytes <= 0 then
+    Read_only
+  else if Int64.compare available_bytes warning_threshold_bytes <= 0 then
+    Warning
+  else
+    Healthy
+
+let low_space_summary ~path ~available_bytes ~mode =
+  let available = human_bytes available_bytes in
+  match mode with
+  | Healthy ->
+    Printf.sprintf "disk healthy near %s: %s free" path available
+  | Warning ->
+    Printf.sprintf
+      "disk pressure near %s: %s free (warning threshold %s)"
+      path available (human_bytes warning_threshold_bytes)
+  | Read_only ->
+    Printf.sprintf
+      "disk pressure near %s: %s free (read-only threshold %s)"
+      path available (human_bytes read_only_threshold_bytes)
+
+let rec existing_ancestor path =
+  if Sys.file_exists path then
+    path
+  else
+    let parent = Filename.dirname path in
+    if parent = path then
+      path
+    else
+      existing_ancestor parent
+
+let probe_target path =
+  let candidate =
+    match Sys.file_exists path with
+    | true when Sys.is_directory path -> path
+    | _ -> Filename.dirname path
+  in
+  existing_ancestor candidate
+
+let split_fields line =
+  String.split_on_char ' ' line
+  |> List.filter (fun field -> field <> "")
+
+let available_bytes_of_df_line line =
+  match split_fields line with
+  | _filesystem :: _blocks :: _used :: available_kib :: _capacity :: _mount ->
+    Int64.mul 1024L (Int64.of_string available_kib)
+  | _ ->
+    failwith (Printf.sprintf "unexpected df output: %s" line)
+
+let probe_available_bytes_with_df path =
+  let argv = [| "df"; "-Pk"; path |] in
+  let ic = Unix.open_process_args_in "df" argv in
+  let read_result =
+    try
+      ignore (input_line ic);
+      Ok (available_bytes_of_df_line (input_line ic))
+    with exn ->
+      Error exn
+  in
+  match read_result, Unix.close_process_in ic with
+  | Ok available_bytes, Unix.WEXITED 0 ->
+    available_bytes
+  | Ok _, Unix.WEXITED code ->
+    failwith (Printf.sprintf "df exited with status %d for %s" code path)
+  | Ok _, status ->
+    failwith (Printf.sprintf "df failed for %s: %s"
+      path
+      (match status with
+       | Unix.WSIGNALED signal -> Printf.sprintf "signaled %d" signal
+       | Unix.WSTOPPED signal -> Printf.sprintf "stopped %d" signal
+       | Unix.WEXITED _ -> "unexpected exit"))
+  | Error exn, _ ->
+    raise exn
+
+let update_from_available_bytes ~path available_bytes =
+  let mode = mode_of_available_bytes available_bytes in
+  let last_error =
+    match mode with
+    | Healthy -> None
+    | Warning | Read_only ->
+      Some (low_space_summary ~path ~available_bytes ~mode)
+  in
+  with_state (fun state ->
+    state := {
+      mode;
+      available_bytes = Some available_bytes;
+      warning_threshold_bytes;
+      read_only_threshold_bytes;
+      last_error;
+      checked_path = Some path;
+      checked_at = Some (Unix.gettimeofday ());
+    });
+  match mode with
+  | Healthy | Warning -> Ok ()
+  | Read_only ->
+    Error (Printf.sprintf
+      "Bot is in read-only mode due to disk pressure near `%s`: only %s free. Free space and retry."
+      path (human_bytes available_bytes))
+
+let note_probe_failure ~path exn =
+  let err =
+    Printf.sprintf "disk probe failed near %s: %s"
+      path (Printexc.to_string exn)
+  in
+  with_state (fun state ->
+    state := {
+      !state with
+      available_bytes = None;
+      last_error = Some err;
+      checked_path = Some path;
+      checked_at = Some (Unix.gettimeofday ());
+    })
+
+let preflight_path_with ~available_bytes_of_path path =
+  let path = probe_target path in
+  try
+    let available_bytes = available_bytes_of_path path in
+    update_from_available_bytes ~path available_bytes
+  with exn ->
+    note_probe_failure ~path exn;
+    Logs.warn (fun m ->
+      m "disk_health: free-space probe failed for %s: %s"
+        path (Printexc.to_string exn));
+    Ok ()
+
+let preflight_path path =
+  preflight_path_with ~available_bytes_of_path:probe_available_bytes_with_df path
+
+let preflight_write path =
+  preflight_path path
+
+let preflight_state_mutation () =
+  preflight_path (Resource.app_config_dir ())
+
+let string_contains s needle =
+  let s_len = String.length s in
+  let needle_len = String.length needle in
+  let rec loop i =
+    if i + needle_len > s_len then false
+    else if String.sub s i needle_len = needle then true
+    else loop (i + 1)
+  in
+  needle_len = 0 || loop 0
+
+let classify_sys_error msg =
+  let lower = String.lowercase_ascii msg in
+  if string_contains lower "no space left on device" then
+    Some { code = "ENOSPC"; summary = msg }
+  else if string_contains lower "disk quota exceeded" then
+    Some { code = "EDQUOT"; summary = msg }
+  else if string_contains lower "read-only file system" then
+    Some { code = "EROFS"; summary = msg }
+  else
+    None
+
+let rec classify_write_failure exn =
+  match exn with
+  | Resource.Durable_write_visible_but_unconfirmed (_, inner) ->
+    classify_write_failure inner
+  | Unix.Unix_error (code, _fn, path) ->
+    let code_message = Unix.error_message code in
+    let tracked =
+      if code = Unix.ENOSPC then Some ("ENOSPC", code_message)
+      else if code = Unix.EROFS then Some ("EROFS", code_message)
+      else if code = Unix.EIO then Some ("EIO", code_message)
+      else if string_contains (String.lowercase_ascii code_message) "quota" then
+        Some ("EDQUOT", code_message)
+      else
+        None
+    in
+    Option.map (fun (label, unix_code) ->
+      let target = if path = "" then "<unknown>" else path in
+      {
+        code = label;
+        summary =
+          Printf.sprintf "%s while writing %s: %s"
+            label target unix_code;
+      }) tracked
+  | Failure msg when String.equal msg "resource: short write" ->
+    Some {
+      code = "PARTIAL_WRITE";
+      summary = "partial write while updating durable state";
+    }
+  | Sys_error msg ->
+    classify_sys_error msg
+  | _ ->
+    None
+
+let note_write_failure path exn =
+  match classify_write_failure exn with
+  | None -> ()
+  | Some failure ->
+    let available_bytes =
+      try
+        let target = probe_target path in
+        Some (probe_available_bytes_with_df target)
+      with _ -> None
+    in
+    with_state (fun state ->
+      state := {
+        mode = Read_only;
+        available_bytes;
+        warning_threshold_bytes;
+        read_only_threshold_bytes;
+        last_error = Some failure.summary;
+        checked_path = Some path;
+        checked_at = Some (Unix.gettimeofday ());
+      })
+
+let note_write_success path =
+  ignore (preflight_path path)
+
+let status_summary () =
+  let state = snapshot () in
+  match state.mode, state.available_bytes, state.last_error with
+  | Healthy, Some available, _ ->
+    Printf.sprintf "Disk: healthy (%s free)." (human_bytes available)
+  | Healthy, None, Some err ->
+    Printf.sprintf "Disk: probe unavailable (%s)." err
+  | Healthy, None, _ ->
+    "Disk: healthy."
+  | Warning, Some available, _ ->
+    Printf.sprintf
+      "Disk: pressure warning (%s free; warning threshold %s)."
+      (human_bytes available) (human_bytes state.warning_threshold_bytes)
+  | Warning, None, Some err ->
+    Printf.sprintf "Disk: pressure warning (%s)." err
+  | Warning, None, None ->
+    "Disk: pressure warning."
+  | Read_only, Some available, Some err ->
+    Printf.sprintf "Disk: read-only (%s free). %s"
+      (human_bytes available) err
+  | Read_only, _, Some err ->
+    Printf.sprintf "Disk: read-only. %s" err
+  | Read_only, Some available, None ->
+    Printf.sprintf "Disk: read-only (%s free)." (human_bytes available)
+  | Read_only, None, None ->
+    "Disk: read-only."
+
+let new_session_block_message ?(preflight=preflight_state_mutation) () =
+  match preflight () with
+  | Error err -> Some err
+  | Ok () when is_read_only () ->
+    Some (status_summary () ^ " Free space and retry.")
+  | Ok () ->
+    None

--- a/lib/disk_health.mli
+++ b/lib/disk_health.mli
@@ -1,0 +1,51 @@
+type mode =
+  | Healthy
+  | Warning
+  | Read_only
+
+type snapshot = {
+  mode : mode;
+  available_bytes : int64 option;
+  warning_threshold_bytes : int64;
+  read_only_threshold_bytes : int64;
+  last_error : string option;
+  checked_path : string option;
+  checked_at : float option;
+}
+
+type write_failure = {
+  code : string;
+  summary : string;
+}
+
+val warning_threshold_bytes : int64
+val read_only_threshold_bytes : int64
+val snapshot : unit -> snapshot
+val string_of_mode : mode -> string
+val pressure : snapshot -> bool
+val is_read_only : unit -> bool
+val human_bytes : int64 -> string
+val preflight_write : string -> (unit, string) result
+val preflight_state_mutation : unit -> (unit, string) result
+val note_write_failure : string -> exn -> unit
+val note_write_success : string -> unit
+val status_summary : unit -> string
+val new_session_block_message :
+  ?preflight:(unit -> (unit, string) result) -> unit -> string option
+
+module For_testing : sig
+  val reset : unit -> unit
+  val mib : int -> int64
+  val mode_of_available_bytes : int64 -> mode
+  val update_from_available_bytes :
+    ?force:bool -> path:string -> int64 -> (unit, string) result
+  val classify_write_failure : exn -> write_failure option
+  val note_write_failure : string -> exn -> unit
+  val note_write_success : string -> unit
+  val new_session_block_message :
+    ?preflight:(unit -> (unit, string) result) -> unit -> string option
+  val preflight_path_with :
+    available_bytes_of_path:(string -> int64) ->
+    string ->
+    (unit, string) result
+end

--- a/lib/disk_space_stubs.c
+++ b/lib/disk_space_stubs.c
@@ -1,0 +1,28 @@
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/statvfs.h>
+
+CAMLprim value discord_agents_available_bytes(value path_v)
+{
+  CAMLparam1(path_v);
+  struct statvfs st;
+  const char *path = String_val(path_v);
+
+  if (statvfs(path, &st) != 0) {
+    caml_failwith(strerror(errno));
+  }
+
+  unsigned __int128 bytes =
+    ((unsigned __int128) st.f_bavail) * ((unsigned __int128) st.f_frsize);
+  if (bytes > (unsigned __int128) INT64_MAX) {
+    bytes = (unsigned __int128) INT64_MAX;
+  }
+
+  CAMLreturn(caml_copy_int64((int64_t) bytes));
+}

--- a/lib/dune
+++ b/lib/dune
@@ -2,6 +2,9 @@
  (name discord_agents)
  (public_name discord_agents)
  (libraries eio_main cohttp-eio tls-eio ca-certs mirage-crypto-rng.unix base64 yojson logs fmt uri)
+ (foreign_stubs
+  (language c)
+  (names disk_space_stubs))
  (preprocess
   (pps ppx_yojson_conv ppx_deriving.show ppx_deriving.eq)))
 

--- a/lib/project.ml
+++ b/lib/project.ml
@@ -265,3 +265,52 @@ let create_worktree project ~branch_name =
   | Unix.WEXITED 0 -> Ok worktree_path
   | _ -> Error (Printf.sprintf "failed to create worktree %s: %s"
     branch_name (Buffer.contents output))
+
+let run_git_capture project args =
+  let cmd =
+    "git -C "
+    ^ Filename.quote project.path
+    ^ " "
+    ^ String.concat " " (List.map Filename.quote args)
+    ^ " 2>&1"
+  in
+  let ic = Unix.open_process_in cmd in
+  let output = Buffer.create 256 in
+  (try
+     while true do
+       Buffer.add_string output (input_line ic);
+       Buffer.add_char output '\n'
+     done
+   with End_of_file -> ());
+  match Unix.close_process_in ic with
+  | Unix.WEXITED 0 -> Ok ()
+  | _ -> Error (Buffer.contents output)
+
+let remove_worktree project ~branch_name ~worktree_path =
+  let path_existed = Sys.file_exists worktree_path in
+  let worktree_result =
+    match run_git_capture project ["worktree"; "remove"; "--force"; worktree_path] with
+    | Ok () -> Ok ()
+    | Error err ->
+      (match run_git_capture project ["worktree"; "prune"] with
+       | Ok () when not path_existed -> Ok ()
+       | Ok () -> Error err
+       | Error prune_err ->
+         Error (Printf.sprintf "%s; git worktree prune failed: %s"
+           err prune_err))
+  in
+  let branch_result =
+    run_git_capture project ["branch"; "-D"; branch_name]
+  in
+  match worktree_result, branch_result with
+  | Ok (), Ok () -> Ok ()
+  | Error worktree_err, Ok () ->
+    Error (Printf.sprintf "failed to remove worktree %s: %s"
+      worktree_path worktree_err)
+  | Ok (), Error branch_err ->
+    Error (Printf.sprintf "failed to delete branch %s: %s"
+      branch_name branch_err)
+  | Error worktree_err, Error branch_err ->
+    Error (Printf.sprintf
+      "failed to remove worktree %s: %s; failed to delete branch %s: %s"
+      worktree_path worktree_err branch_name branch_err)

--- a/lib/runtime_settings.ml
+++ b/lib/runtime_settings.ml
@@ -72,30 +72,46 @@ let log_visible_but_unconfirmed path exn =
     m "runtime_settings: write to %s is visible but durability could not be confirmed: %s"
       path (Printexc.to_string exn))
 
-let save_with ~write_file t =
+let save_with
+    ?(preflight_write=Disk_health.preflight_write)
+    ?(note_write_success=Disk_health.note_write_success)
+    ?(note_write_failure=Disk_health.note_write_failure)
+    ~write_file t =
   let path = settings_path () in
   let backup = backup_path () in
   let rendered = Yojson.Safe.pretty_to_string (to_yojson t) in
   let primary_warning = ref None in
-  try
-    Resource.with_flock (lock_path ()) (fun () ->
-      Resource.cleanup_atomic_write_temps path;
-      Resource.cleanup_atomic_write_temps backup;
-      (try write_file path rendered with
-       | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
-         primary_warning := Some (path, exn));
-      (try write_file backup rendered with
-       | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
-         log_visible_but_unconfirmed path exn
-       | exn ->
-         Logs.warn (fun m ->
-           m "runtime_settings: failed to update backup %s: %s"
-             backup (Printexc.to_string exn))));
-    Option.iter (fun (path, exn) ->
-      log_visible_but_unconfirmed path exn) !primary_warning;
-    Ok ()
-  with exn ->
-    Error (Printexc.to_string exn)
+  match preflight_write path with
+  | Error err -> Error err
+  | Ok () ->
+    let saw_disk_issue = ref false in
+    (try
+       Resource.with_flock (lock_path ()) (fun () ->
+         Resource.cleanup_atomic_write_temps path;
+         Resource.cleanup_atomic_write_temps backup;
+         (try write_file path rendered with
+          | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
+            saw_disk_issue := true;
+            note_write_failure path exn;
+            primary_warning := Some (path, exn));
+         (try write_file backup rendered with
+          | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
+            saw_disk_issue := true;
+            note_write_failure path exn;
+            log_visible_but_unconfirmed path exn
+          | exn ->
+            note_write_failure backup exn;
+            Logs.warn (fun m ->
+              m "runtime_settings: failed to update backup %s: %s"
+                backup (Printexc.to_string exn))));
+       Option.iter (fun (path, exn) ->
+         log_visible_but_unconfirmed path exn) !primary_warning;
+       if not !saw_disk_issue then
+         note_write_success path;
+       Ok ()
+     with exn ->
+       note_write_failure path exn;
+       Error (Printexc.to_string exn))
 
 let save t =
   save_with ~write_file:(fun path rendered ->

--- a/lib/session_store.ml
+++ b/lib/session_store.ml
@@ -183,27 +183,47 @@ let log_visible_but_unconfirmed path exn =
     m "session_store: write to %s is visible but durability could not be confirmed: %s"
       path (Printexc.to_string exn))
 
-let save_with ~write_file (t : t) =
+let save_with
+    ?(preflight_write=Disk_health.preflight_write)
+    ?(note_write_success=Disk_health.note_write_success)
+    ?(note_write_failure=Disk_health.note_write_failure)
+    ~write_file (t : t) =
   let json = sessions_to_json t.sessions in
   let path = sessions_file () in
   let backup = backup_file () in
   let rendered = Yojson.Safe.pretty_to_string json in
   let primary_warning = ref None in
-  Resource.with_flock (lock_file ()) (fun () ->
-    Resource.cleanup_atomic_write_temps path;
-    Resource.cleanup_atomic_write_temps backup;
-    (try write_file path rendered with
-     | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
-       primary_warning := Some (path, exn));
-    (try write_file backup rendered with
-     | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
-       log_visible_but_unconfirmed path exn
-     | exn ->
-       Logs.warn (fun m ->
-         m "session_store: failed to update backup %s: %s"
-           backup (Printexc.to_string exn))));
-  Option.iter (fun (path, exn) ->
-    log_visible_but_unconfirmed path exn) !primary_warning
+  match preflight_write path with
+  | Error err ->
+    failwith err
+  | Ok () ->
+    let saw_disk_issue = ref false in
+    (try
+       Resource.with_flock (lock_file ()) (fun () ->
+         Resource.cleanup_atomic_write_temps path;
+         Resource.cleanup_atomic_write_temps backup;
+         (try write_file path rendered with
+          | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
+            saw_disk_issue := true;
+            note_write_failure path exn;
+            primary_warning := Some (path, exn));
+         (try write_file backup rendered with
+          | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
+            saw_disk_issue := true;
+            note_write_failure path exn;
+            log_visible_but_unconfirmed path exn
+          | exn ->
+            note_write_failure backup exn;
+            Logs.warn (fun m ->
+              m "session_store: failed to update backup %s: %s"
+                backup (Printexc.to_string exn))));
+       Option.iter (fun (path, exn) ->
+         log_visible_but_unconfirmed path exn) !primary_warning;
+       if not !saw_disk_issue then
+         note_write_success path
+     with exn ->
+       note_write_failure path exn;
+       raise exn)
 
 let save t =
   save_with ~write_file:(fun path rendered ->

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,5 @@
 (tests
  (names test_formatting test_project test_agent_contracts test_discord_rest test_gateway
-  test_runtime_settings test_bot_defaults test_session_store)
+  test_runtime_settings test_bot_defaults test_session_store test_disk_health)
  (libraries discord_agents alcotest str unix yojson eio.mock eio_main cohttp-eio
   uri mirage-crypto-rng.unix))

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,5 @@
 (tests
  (names test_formatting test_project test_agent_contracts test_discord_rest test_gateway
-  test_runtime_settings test_bot_defaults test_session_store test_disk_health)
+  test_runtime_settings test_bot_defaults test_session_store test_disk_health test_config)
  (libraries discord_agents alcotest str unix yojson eio.mock eio_main cohttp-eio
   uri mirage-crypto-rng.unix))

--- a/test/test_config.ml
+++ b/test/test_config.ml
@@ -1,0 +1,57 @@
+let rec rm_rf path =
+  match Unix.lstat path with
+  | exception Unix.Unix_error (ENOENT, _, _) -> ()
+  | { Unix.st_kind = S_DIR; _ } ->
+    Sys.readdir path
+    |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+    Unix.rmdir path
+  | _ ->
+    Unix.unlink path
+
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> Unix.putenv name ""
+
+let with_tmp_home f =
+  let home = Filename.temp_dir "discord_agents_config_" "" in
+  let old_home = Sys.getenv_opt "HOME" in
+  let old_xdg_config_home = Sys.getenv_opt "XDG_CONFIG_HOME" in
+  Fun.protect
+    ~finally:(fun () ->
+      restore_env "HOME" old_home;
+      restore_env "XDG_CONFIG_HOME" old_xdg_config_home;
+      rm_rf home)
+    (fun () ->
+      Unix.putenv "HOME" home;
+      Unix.putenv "XDG_CONFIG_HOME" "";
+      f home)
+
+let config_path home =
+  Filename.concat home ".config/discord-agents/config.json"
+
+let test_save_reaps_stale_atomic_temp () =
+  with_tmp_home (fun home ->
+    let path = config_path home in
+    Discord_agents.Resource.ensure_parent_dir path;
+    let stale = Filename.concat (Filename.dirname path)
+      "config.json.tmp.stale" in
+    let oc = open_out stale in
+    output_string oc "stale";
+    close_out oc;
+    Discord_agents.Config.save {
+      Discord_agents.Config.default with
+      discord_token = "test-token";
+      guild_id = "guild";
+    };
+    Alcotest.(check bool) "config written" true (Sys.file_exists path);
+    Alcotest.(check bool) "stale temp removed" false (Sys.file_exists stale);
+    let mode = (Unix.stat path).Unix.st_perm land 0o777 in
+    Alcotest.(check int) "config mode remains private" 0o600 mode)
+
+let () =
+  Alcotest.run "config" [
+    ("persistence", [
+      Alcotest.test_case "save reaps stale atomic temp" `Quick
+        test_save_reaps_stale_atomic_temp;
+    ]);
+  ]

--- a/test/test_disk_health.ml
+++ b/test/test_disk_health.ml
@@ -1,0 +1,83 @@
+let test_mode_of_available_bytes () =
+  let open Discord_agents.Disk_health in
+  Alcotest.(check string) "healthy"
+    "healthy"
+    (string_of_mode (mode_of_available_bytes (mib 256)));
+  Alcotest.(check string) "warning"
+    "warning"
+    (string_of_mode (mode_of_available_bytes (mib 96)));
+  Alcotest.(check string) "read_only"
+    "read_only"
+    (string_of_mode (mode_of_available_bytes (mib 32)))
+
+let test_preflight_available_bytes_updates_snapshot () =
+  let open Discord_agents.Disk_health in
+  reset_for_tests ();
+  match update_from_available_bytes ~path:"/tmp/state" (mib 48) with
+  | Ok () -> Alcotest.fail "expected read-only preflight failure"
+  | Error err ->
+    Alcotest.(check bool) "mentions read-only" true
+      (String.contains err 'r');
+    let snap = snapshot () in
+    Alcotest.(check string) "mode"
+      "read_only" (string_of_mode snap.mode);
+    Alcotest.(check (option string)) "path"
+      (Some "/tmp/state") snap.checked_path
+
+let test_classify_write_failure_variants () =
+  let open Discord_agents.Disk_health in
+  let code exn =
+    match classify_write_failure exn with
+    | Some failure -> failure.code
+    | None -> Alcotest.fail "expected classified disk failure"
+  in
+  Alcotest.(check string) "enospc"
+    "ENOSPC"
+    (code (Unix.Unix_error (Unix.ENOSPC, "write", "/tmp/x")));
+  Alcotest.(check string) "edquot"
+    "EDQUOT"
+    (code (Sys_error "Disk quota exceeded"));
+  Alcotest.(check string) "erofs"
+    "EROFS"
+    (code (Unix.Unix_error (Unix.EROFS, "write", "/tmp/x")));
+  Alcotest.(check string) "partial write"
+    "PARTIAL_WRITE"
+    (code (Failure "resource: short write"))
+
+let test_note_write_failure_marks_read_only () =
+  let open Discord_agents.Disk_health in
+  reset_for_tests ();
+  note_write_failure "/tmp/state"
+    (Unix.Unix_error (Unix.ENOSPC, "write", "/tmp/state"));
+  let snap = snapshot () in
+  Alcotest.(check string) "mode"
+    "read_only" (string_of_mode snap.mode);
+  Alcotest.(check bool) "reason recorded"
+    true (Option.is_some snap.last_error)
+
+let test_new_session_block_message_uses_preflight () =
+  let open Discord_agents.Disk_health in
+  reset_for_tests ();
+  let blocked =
+    new_session_block_message
+      ~preflight:(fun () -> Error "disk probe says read-only")
+      ()
+  in
+  Alcotest.(check (option string)) "preflight error surfaces"
+    (Some "disk probe says read-only") blocked
+
+let () =
+  Alcotest.run "disk_health" [
+    ("health", [
+      Alcotest.test_case "mode of available bytes" `Quick
+        test_mode_of_available_bytes;
+      Alcotest.test_case "preflight updates snapshot" `Quick
+        test_preflight_available_bytes_updates_snapshot;
+      Alcotest.test_case "classify write failure variants" `Quick
+        test_classify_write_failure_variants;
+      Alcotest.test_case "write failure marks read only" `Quick
+        test_note_write_failure_marks_read_only;
+      Alcotest.test_case "new session block message re-probes" `Quick
+        test_new_session_block_message_uses_preflight;
+    ]);
+  ]

--- a/test/test_disk_health.ml
+++ b/test/test_disk_health.ml
@@ -1,5 +1,30 @@
+let contains_substring text needle =
+  let text_len = String.length text in
+  let needle_len = String.length needle in
+  let rec loop i =
+    if i + needle_len > text_len then false
+    else if String.sub text i needle_len = needle then true
+    else loop (i + 1)
+  in
+  needle_len = 0 || loop 0
+
+let rec rm_rf path =
+  match Unix.lstat path with
+  | exception Unix.Unix_error (ENOENT, _, _) -> ()
+  | { Unix.st_kind = S_DIR; _ } ->
+    Sys.readdir path
+    |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+    Unix.rmdir path
+  | _ ->
+    Unix.unlink path
+
+let with_tmp_dir f =
+  let dir = Filename.temp_dir "discord_agents_disk_health_" "" in
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
 let test_mode_of_available_bytes () =
   let open Discord_agents.Disk_health in
+  let open For_testing in
   Alcotest.(check string) "healthy"
     "healthy"
     (string_of_mode (mode_of_available_bytes (mib 256)));
@@ -12,20 +37,144 @@ let test_mode_of_available_bytes () =
 
 let test_preflight_available_bytes_updates_snapshot () =
   let open Discord_agents.Disk_health in
-  reset_for_tests ();
+  let open For_testing in
+  reset ();
   match update_from_available_bytes ~path:"/tmp/state" (mib 48) with
   | Ok () -> Alcotest.fail "expected read-only preflight failure"
   | Error err ->
     Alcotest.(check bool) "mentions read-only" true
-      (String.contains err 'r');
+      (contains_substring err "read-only");
     let snap = snapshot () in
     Alcotest.(check string) "mode"
       "read_only" (string_of_mode snap.mode);
     Alcotest.(check (option string)) "path"
       (Some "/tmp/state") snap.checked_path
 
+let test_healthy_probe_does_not_clear_unrelated_read_only_path () =
+  let open Discord_agents.Disk_health in
+  let open For_testing in
+  reset ();
+  ignore (update_from_available_bytes ~path:"/project" (mib 32));
+  ignore (update_from_available_bytes ~path:"/config" (mib 512));
+  let snap = snapshot () in
+  Alcotest.(check string) "mode remains read-only"
+    "read_only" (string_of_mode snap.mode);
+  Alcotest.(check (option string)) "path remains project"
+    (Some "/project") snap.checked_path;
+  ignore (update_from_available_bytes ~path:"/project" (mib 512));
+  let snap = snapshot () in
+  Alcotest.(check string) "path recovers independently"
+    "healthy" (string_of_mode snap.mode)
+
+let test_write_failure_survives_healthy_probe_until_write_success () =
+  let open Discord_agents.Disk_health in
+  let open For_testing in
+  with_tmp_dir (fun dir ->
+    reset ();
+    note_write_failure dir
+      (Unix.Unix_error (Unix.EUNKNOWNERR 122, "write", dir));
+    ignore (preflight_path_with
+      ~available_bytes_of_path:(fun _ -> mib 512)
+      dir);
+    let snap = snapshot () in
+    Alcotest.(check string) "healthy probe does not clear quota"
+      "read_only" (string_of_mode snap.mode);
+    let quota_reason =
+      match snap.last_error with
+      | Some err -> contains_substring err "EDQUOT"
+      | None -> false
+    in
+    Alcotest.(check bool) "quota reason remains"
+      true quota_reason;
+    note_write_success dir;
+    let snap = snapshot () in
+    Alcotest.(check string) "successful write clears sticky failure"
+      "healthy" (string_of_mode snap.mode))
+
+let test_write_failure_survives_warning_probe_until_write_success () =
+  let open Discord_agents.Disk_health in
+  let open For_testing in
+  with_tmp_dir (fun dir ->
+    reset ();
+    note_write_failure dir
+      (Unix.Unix_error (Unix.EUNKNOWNERR 122, "write", dir));
+    ignore (preflight_path_with
+      ~available_bytes_of_path:(fun _ -> mib 96)
+      dir);
+    let snap = snapshot () in
+    Alcotest.(check string) "warning probe does not downgrade quota"
+      "read_only" (string_of_mode snap.mode);
+    let quota_reason =
+      match snap.last_error with
+      | Some err -> contains_substring err "EDQUOT"
+      | None -> false
+    in
+    Alcotest.(check bool) "quota reason remains"
+      true quota_reason)
+
+let test_first_write_failure_clears_after_file_is_created () =
+  let open Discord_agents.Disk_health in
+  let open For_testing in
+  with_tmp_dir (fun dir ->
+    let file_path = Filename.concat dir "new-file.json" in
+    reset ();
+    note_write_failure file_path
+      (Unix.Unix_error (Unix.EUNKNOWNERR 122, "write", file_path));
+    ignore (preflight_path_with
+      ~available_bytes_of_path:(fun _ -> mib 512)
+      file_path);
+    let snap = snapshot () in
+    Alcotest.(check string) "first-write quota sticks"
+      "read_only" (string_of_mode snap.mode);
+    let oc = open_out file_path in
+    output_string oc "{}\n";
+    close_out oc;
+    note_write_success file_path;
+    let snap = snapshot () in
+    Alcotest.(check string) "creating file then writing clears sticky failure"
+      "healthy" (string_of_mode snap.mode))
+
+let test_deleted_pressure_path_is_evicted_on_refresh () =
+  let open Discord_agents.Disk_health in
+  let open For_testing in
+  with_tmp_dir (fun dir ->
+    let child = Filename.concat dir "deleted-child" in
+    Unix.mkdir child 0o755;
+    reset ();
+    ignore (update_from_available_bytes ~path:child (mib 32));
+    Unix.rmdir child;
+    ignore (preflight_path_with
+      ~available_bytes_of_path:(fun path ->
+        Alcotest.(check string) "probe falls back to parent" dir path;
+        mib 512)
+      child);
+    let snap = snapshot () in
+    Alcotest.(check string) "deleted pressure path evicted"
+      "healthy" (string_of_mode snap.mode);
+    Alcotest.(check (option string)) "parent path recorded"
+      (Some dir) snap.checked_path)
+
+let test_probe_error_clears_after_successful_probe () =
+  let open Discord_agents.Disk_health in
+  let open For_testing in
+  with_tmp_dir (fun dir ->
+    reset ();
+    ignore (preflight_path_with
+      ~available_bytes_of_path:(fun _ -> failwith "probe exploded")
+      dir);
+    let snap = snapshot () in
+    Alcotest.(check bool) "probe error recorded"
+      true (Option.is_some snap.last_error);
+    ignore (preflight_path_with
+      ~available_bytes_of_path:(fun _ -> mib 512)
+      dir);
+    let snap = snapshot () in
+    Alcotest.(check (option string)) "probe error cleared"
+      None snap.last_error)
+
 let test_classify_write_failure_variants () =
   let open Discord_agents.Disk_health in
+  let open For_testing in
   let code exn =
     match classify_write_failure exn with
     | Some failure -> failure.code
@@ -37,6 +186,9 @@ let test_classify_write_failure_variants () =
   Alcotest.(check string) "edquot"
     "EDQUOT"
     (code (Sys_error "Disk quota exceeded"));
+  Alcotest.(check string) "edquot unix unknown errno"
+    "EDQUOT"
+    (code (Unix.Unix_error (Unix.EUNKNOWNERR 122, "write", "/tmp/x")));
   Alcotest.(check string) "erofs"
     "EROFS"
     (code (Unix.Unix_error (Unix.EROFS, "write", "/tmp/x")));
@@ -46,7 +198,8 @@ let test_classify_write_failure_variants () =
 
 let test_note_write_failure_marks_read_only () =
   let open Discord_agents.Disk_health in
-  reset_for_tests ();
+  let open For_testing in
+  reset ();
   note_write_failure "/tmp/state"
     (Unix.Unix_error (Unix.ENOSPC, "write", "/tmp/state"));
   let snap = snapshot () in
@@ -57,7 +210,8 @@ let test_note_write_failure_marks_read_only () =
 
 let test_new_session_block_message_uses_preflight () =
   let open Discord_agents.Disk_health in
-  reset_for_tests ();
+  let open For_testing in
+  reset ();
   let blocked =
     new_session_block_message
       ~preflight:(fun () -> Error "disk probe says read-only")
@@ -73,6 +227,18 @@ let () =
         test_mode_of_available_bytes;
       Alcotest.test_case "preflight updates snapshot" `Quick
         test_preflight_available_bytes_updates_snapshot;
+      Alcotest.test_case "healthy probe preserves other read-only path" `Quick
+        test_healthy_probe_does_not_clear_unrelated_read_only_path;
+      Alcotest.test_case "quota write failure survives healthy probe" `Quick
+        test_write_failure_survives_healthy_probe_until_write_success;
+      Alcotest.test_case "quota write failure survives warning probe" `Quick
+        test_write_failure_survives_warning_probe_until_write_success;
+      Alcotest.test_case "first write failure clears after file creation" `Quick
+        test_first_write_failure_clears_after_file_is_created;
+      Alcotest.test_case "deleted pressure path is evicted" `Quick
+        test_deleted_pressure_path_is_evicted_on_refresh;
+      Alcotest.test_case "probe error clears after success" `Quick
+        test_probe_error_clears_after_successful_probe;
       Alcotest.test_case "classify write failure variants" `Quick
         test_classify_write_failure_variants;
       Alcotest.test_case "write failure marks read only" `Quick

--- a/test/test_project.ml
+++ b/test/test_project.ml
@@ -173,6 +173,27 @@ let make_git_repo_with_remote path ~remote_url =
   run (Printf.sprintf "git -C %s remote add origin %s"
     (Filename.quote path) (Filename.quote remote_url))
 
+let make_git_repo_with_commit path =
+  mkdir_p path;
+  let run cmd =
+    let exit_code = Sys.command (Printf.sprintf "%s 2>/dev/null" cmd) in
+    if exit_code <> 0 then
+      Alcotest.failf "setup command failed (%d): %s" exit_code cmd
+  in
+  run (Printf.sprintf "git -C %s init -q --initial-branch=main"
+    (Filename.quote path));
+  run (Printf.sprintf "git -C %s config user.email test@example.invalid"
+    (Filename.quote path));
+  run (Printf.sprintf "git -C %s config user.name 'Discord Agents Test'"
+    (Filename.quote path));
+  let readme = Filename.concat path "README.md" in
+  let oc = open_out readme in
+  output_string oc "test repo\n";
+  close_out oc;
+  run (Printf.sprintf "git -C %s add README.md" (Filename.quote path));
+  run (Printf.sprintf "git -C %s commit -q -m initial"
+    (Filename.quote path))
+
 let test_cluster_preserves_parent_with_remote () =
   (* Real bug from code review: when a clustered repo has a remote URL,
      the old dedup path renamed it to just the remote-basename and dropped
@@ -223,6 +244,59 @@ let test_permission_error_skipped () =
       Alcotest.(check bool) "readable cluster child discovered"
         true (List.mem "cluster/readable" (names_of ps))))
 
+let test_remove_worktree_deletes_worktree_and_branch () =
+  with_tmpdir (fun base ->
+    let repo = Filename.concat base "repo" in
+    make_git_repo_with_commit repo;
+    let project =
+      P.{ name = "repo"; path = repo; is_bare = false; remote_url = None }
+    in
+    let branch_name = "agent/test-cleanup" in
+    match P.create_worktree project ~branch_name with
+    | Error err -> Alcotest.failf "create_worktree failed: %s" err
+    | Ok worktree_path ->
+      Alcotest.(check bool) "worktree exists"
+        true (Sys.file_exists worktree_path);
+      (match P.remove_worktree project ~branch_name ~worktree_path with
+       | Ok () -> ()
+       | Error err -> Alcotest.failf "remove_worktree failed: %s" err);
+      Alcotest.(check bool) "worktree removed"
+        false (Sys.file_exists worktree_path);
+      let branch_exists =
+        Sys.command (Printf.sprintf
+          "git -C %s rev-parse --verify %s >/dev/null 2>&1"
+          (Filename.quote repo) (Filename.quote branch_name)) = 0
+      in
+      Alcotest.(check bool) "branch removed" false branch_exists)
+
+let test_remove_worktree_prunes_missing_worktree_registration () =
+  with_tmpdir (fun base ->
+    let repo = Filename.concat base "repo" in
+    make_git_repo_with_commit repo;
+    let project =
+      P.{ name = "repo"; path = repo; is_bare = false; remote_url = None }
+    in
+    let branch_name = "agent/test-stale-cleanup" in
+    match P.create_worktree project ~branch_name with
+    | Error err -> Alcotest.failf "create_worktree failed: %s" err
+    | Ok worktree_path ->
+      rm_rf worktree_path;
+      (match P.remove_worktree project ~branch_name ~worktree_path with
+       | Ok () -> ()
+       | Error err -> Alcotest.failf "remove_worktree failed: %s" err);
+      let branch_exists =
+        Sys.command (Printf.sprintf
+          "git -C %s rev-parse --verify %s >/dev/null 2>&1"
+          (Filename.quote repo) (Filename.quote branch_name)) = 0
+      in
+      Alcotest.(check bool) "branch removed after prune" false branch_exists;
+      let registered =
+        Sys.command (Printf.sprintf
+          "git -C %s worktree list --porcelain | grep -F %s >/dev/null 2>&1"
+          (Filename.quote repo) (Filename.quote worktree_path)) = 0
+      in
+      Alcotest.(check bool) "stale registration pruned" false registered)
+
 let discovery_tests = [
   Alcotest.test_case "flat repo" `Quick test_flat_repo;
   Alcotest.test_case "bare repo" `Quick test_bare_repo;
@@ -249,4 +323,10 @@ let discovery_tests = [
 let () =
   Alcotest.run "discord_project" [
     "discovery", discovery_tests;
+    "worktrees", [
+      Alcotest.test_case "remove worktree deletes branch" `Quick
+        test_remove_worktree_deletes_worktree_and_branch;
+      Alcotest.test_case "remove missing worktree prunes registration" `Quick
+        test_remove_worktree_prunes_missing_worktree_registration;
+    ];
   ]

--- a/test/test_runtime_settings.ml
+++ b/test/test_runtime_settings.ml
@@ -122,6 +122,25 @@ let test_save_reaps_stale_atomic_write_temps () =
       Alcotest.(check bool) "stale temp removed"
         false (Sys.file_exists (stale_temp_path home)))
 
+let test_save_refuses_read_only_preflight () =
+  with_tmp_home (fun home ->
+    let settings = Discord_agents.Runtime_settings.load () in
+    settings.default_agent <- Discord_agents.Config.Codex;
+    let write_attempted = ref false in
+    let write_file _path _content =
+      write_attempted := true;
+      failwith "write should not be attempted"
+    in
+    match Discord_agents.Runtime_settings.save_with
+            ~preflight_write:(fun _ -> Error "disk is read-only")
+            ~write_file settings with
+    | Ok () -> Alcotest.fail "save_with unexpectedly succeeded"
+    | Error err ->
+      Alcotest.(check string) "preflight error" "disk is read-only" err;
+      Alcotest.(check bool) "write skipped" false !write_attempted;
+      Alcotest.(check bool) "primary absent"
+        false (Sys.file_exists (settings_path home)))
+
 let test_xdg_config_home_without_home () =
   let xdg_root = make_tmp_dir "discord_agents_xdg_" in
   Fun.protect
@@ -179,6 +198,8 @@ let () =
         test_save_with_visible_but_unconfirmed_primary_updates_backup;
       Alcotest.test_case "save reaps stale atomic write temps" `Quick
         test_save_reaps_stale_atomic_write_temps;
+      Alcotest.test_case "save refuses read-only preflight" `Quick
+        test_save_refuses_read_only_preflight;
       Alcotest.test_case "xdg config home without home" `Quick
         test_xdg_config_home_without_home;
       Alcotest.test_case "xdg falls back to existing legacy home" `Quick

--- a/test/test_session_store.ml
+++ b/test/test_session_store.ml
@@ -133,6 +133,34 @@ let test_save_with_visible_but_unconfirmed_primary_updates_backup () =
     Alcotest.(check bool) "backup captured updated stop_requested"
       true recovered.Discord_agents.Session_store.stop_requested)
 
+let test_save_refuses_read_only_preflight () =
+  with_tmp_home (fun home ->
+    let store = Discord_agents.Session_store.create () in
+    let session = make_session () in
+    store.Discord_agents.Session_store.sessions <-
+      Discord_agents.Session_store.SessionMap.add
+        "control" session store.sessions;
+    let write_attempted = ref false in
+    let write_file _path _content =
+      write_attempted := true;
+      failwith "write should not be attempted"
+    in
+    (match
+       try
+         Discord_agents.Session_store.save_with
+           ~preflight_write:(fun _ -> Error "disk is read-only")
+           ~write_file store;
+         None
+       with Failure msg -> Some msg
+     with
+     | Some err ->
+       Alcotest.(check string) "preflight error" "disk is read-only" err
+     | None ->
+       Alcotest.fail "save_with unexpectedly succeeded");
+    Alcotest.(check bool) "write skipped" false !write_attempted;
+    Alcotest.(check bool) "primary absent"
+      false (Sys.file_exists (sessions_path home)))
+
 let () =
   Alcotest.run "session_store" [
     ("persistence", [
@@ -146,5 +174,7 @@ let () =
         test_load_uses_backup_when_primary_missing;
       Alcotest.test_case "visible but unconfirmed primary still updates backup" `Quick
         test_save_with_visible_but_unconfirmed_primary_updates_backup;
+      Alcotest.test_case "save refuses read-only preflight" `Quick
+        test_save_refuses_read_only_preflight;
     ]);
   ]


### PR DESCRIPTION
## Summary
- add shared disk-pressure tracking and degraded/read-only health surfaces
- gate new session creation on live disk-state probes and harden write paths to classify disk failures
- avoid orphaning Discord threads when session persistence fails and add disk-pressure persistence tests

## Testing
- nix develop --command dune build --build-dir _build_disk1
- nix develop --command dune runtest --build-dir _build_disk1