### PR TITLE
feat: add rescue-agent disk-pressure failover

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,15 +70,16 @@ test/test_formatting.ml  — Tests for formatting, wrapping, escaping, command p
 
 Commands require a `!` prefix:
 
-- `start <project> [agent]` — start a session (agent ∈ {claude, codex, gemini}; defaults to the current default agent)
+- `start <project> [agent]` — start a session (agent ∈ {claude, codex, gemini}; defaults to the current effective top-level agent)
 - `start` — show numbered project list
-- `resume [agent] <session_id>` — resume an existing session (agent defaults to none; tries the current default agent first, then the others)
+- `resume [agent] <session_id>` — resume an existing session (agent defaults to none; tries the current effective top-level agent first, then the others)
 - `projects` — list discovered projects with numbers
 - `sessions` — list active bot sessions
 - `claude-sessions` — list recent Claude Code sessions on this machine
 - `codex-sessions` — list recent Codex CLI sessions on this machine
 - `gemini-sessions` — list recent Gemini CLI sessions on this machine
 - `default-agent [agent]` — show or set the default agent for new top-level sessions
+- `rescue-agent [agent|off]` — show, set, or disable the rescue agent used under disk pressure
 - `session-agent [agent]` — show or set the current channel session agent
 - `stop <thread_id>` — stop a session
 - `rename [thread_id] <name>` — rename a thread
@@ -91,7 +92,7 @@ Commands require a `!` prefix:
 - `restart` — rebuild and restart the bot
 - `help` — command reference
 
-Non-command messages in control/project channels are routed to the channel's current session automatically. New top-level sessions start with the current default agent unless you set a `session-agent` override on that session.
+Non-command messages in control/project channels are routed to the channel's current session automatically. New top-level sessions start with the current effective top-level agent unless you set a `session-agent` override on that session. Normally that is the default agent; under disk pressure, a configured rescue agent takes over automatically.
 
 ## Key behaviors
 
@@ -164,7 +165,7 @@ Per-session system prompts (set via `Session_store.session.system_prompt`) tell 
 - **Claude** — `--append-system-prompt <text>` flag (persistent across all turns).
 - **Codex / Gemini** — neither CLI exposes a system-instruction flag, so the bot prepends the prompt as a `<bot-context>...</bot-context>` block to the user's first-turn message. The conversation history carries it forward on subsequent turns. See `Agent_process.compose_session_prompt`.
 
-Today only the control/project channel sessions (created by `ensure_channel_session`) set a system prompt. Those sessions now start with the current default agent rather than being hardcoded to Claude, and the Codex/Gemini paths are wired and tested for that flow.
+Today only the control/project channel sessions (created by `ensure_channel_session`) set a system prompt. Those sessions now start with the current effective top-level agent rather than being hardcoded to Claude, and the Codex/Gemini paths are wired and tested for that flow.
 
 ## Bare repo / worktree setup
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Commands require a `!` prefix:
 - `codex-sessions` — list recent Codex CLI sessions on this machine
 - `gemini-sessions` — list recent Gemini CLI sessions on this machine
 - `default-agent [agent]` — show or set the default agent for new top-level sessions
-- `rescue-agent [agent|off]` — show, set, or disable the rescue agent used under disk pressure
+- `rescue-agent [agent|off]` — show, set, or disable the rescue agent used at warning-level disk pressure
 - `session-agent [agent]` — show or set the current channel session agent
 - `stop <thread_id>` — stop a session
 - `rename [thread_id] <name>` — rename a thread
@@ -92,7 +92,7 @@ Commands require a `!` prefix:
 - `restart` — rebuild and restart the bot
 - `help` — command reference
 
-Non-command messages in control/project channels are routed to the channel's current session automatically. New top-level sessions start with the current effective top-level agent unless you set a `session-agent` override on that session. Normally that is the default agent; under disk pressure, a configured rescue agent takes over automatically.
+Non-command messages in control/project channels are routed to the channel's current session automatically. New top-level sessions start with the current effective top-level agent unless you set a `session-agent` override on that session. Normally that is the default agent; at warning-level disk pressure, a configured rescue agent takes over automatically. Read-only disk mode still blocks new stateful session creation until space is freed.
 
 ## Key behaviors
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ All commands use a `!` prefix:
 
 | Command | Description |
 |---------|-------------|
-| `!start <project> [agent]` | Start a session with the current default agent or explicit agent |
+| `!start <project> [agent]` | Start a session with the current effective top-level agent or explicit agent |
 | `!default-agent [agent]` | Show or set the default agent (`claude`, `codex`, `gemini`) |
+| `!rescue-agent [agent|off]` | Show, set, or disable the rescue agent used under disk pressure |
 | `!session-agent [agent]` | Show or set the current channel's session agent |
 | `!start` | Show numbered project list |
 | `!resume [agent] <session_id>` | Resume an existing session |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ All commands use a `!` prefix:
 |---------|-------------|
 | `!start <project> [agent]` | Start a session with the current effective top-level agent or explicit agent |
 | `!default-agent [agent]` | Show or set the default agent (`claude`, `codex`, `gemini`) |
-| `!rescue-agent [agent|off]` | Show, set, or disable the rescue agent used under disk pressure |
+| `!rescue-agent [agent|off]` | Show, set, or disable the rescue agent used at warning-level disk pressure |
 | `!session-agent [agent]` | Show or set the current channel's session agent |
 | `!start` | Show numbered project list |
 | `!resume [agent] <session_id>` | Resume an existing session |
@@ -66,7 +66,7 @@ All commands use a `!` prefix:
 | `!restart` | Rebuild and restart the bot |
 | `!help` | Command reference |
 
-All channels -- control and project -- have the same capabilities. The agent knows which channel it's in and has context about the associated project. Non-command messages are routed to the channel's current session automatically; new top-level channel sessions start with the current effective top-level agent. Normally that is the default agent, but if you configure a rescue agent and disk pressure is active, the rescue agent takes over automatically unless you set a `!session-agent` override on that session.
+All channels -- control and project -- have the same capabilities. The agent knows which channel it's in and has context about the associated project. Non-command messages are routed to the channel's current session automatically; new top-level channel sessions start with the current effective top-level agent. Normally that is the default agent, but if you configure a rescue agent and warning-level disk pressure is active, the rescue agent takes over automatically unless you set a `!session-agent` override on that session. Read-only disk mode still blocks new stateful session creation until space is freed.
 
 `!default_agent`, `!rescue_agent`, and `!session_agent` are accepted as underscore aliases.
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ All commands use a `!` prefix:
 | `!restart` | Rebuild and restart the bot |
 | `!help` | Command reference |
 
-All channels -- control and project -- have the same capabilities. The agent knows which channel it's in and has context about the associated project. Non-command messages are routed to the channel's current session automatically; new top-level channel sessions start with the current default agent unless you set a `!session-agent` override on that session.
+All channels -- control and project -- have the same capabilities. The agent knows which channel it's in and has context about the associated project. Non-command messages are routed to the channel's current session automatically; new top-level channel sessions start with the current effective top-level agent. Normally that is the default agent, but if you configure a rescue agent and disk pressure is active, the rescue agent takes over automatically unless you set a `!session-agent` override on that session.
 
-`!default_agent` and `!session_agent` are accepted as underscore aliases.
+`!default_agent`, `!rescue_agent`, and `!session_agent` are accepted as underscore aliases.
 
 Changing an agent starts a fresh backend session for that channel. It does not migrate conversation state between Claude, Codex, and Gemini.
 

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -405,7 +405,7 @@ You have MCP tools available:
 - list_claude_sessions: Find recent Claude Code sessions to resume
 - list_codex_sessions: Find recent Codex CLI sessions to resume
 - list_gemini_sessions: Find recent Gemini CLI sessions to resume
-- resume_session: Resume an existing session (pass kind=claude, kind=codex, or kind=gemini to disambiguate; default tries the current default agent first)
+- resume_session: Resume an existing session (pass kind=claude, kind=codex, or kind=gemini to disambiguate; default tries the current effective top-level agent first)
 - default_agent: Show or set the default agent used for new top-level sessions
 - rescue_agent: Show or set the rescue agent automatically used for new top-level sessions under disk pressure
 - restart_bot: Rebuild and restart the bot
@@ -445,7 +445,7 @@ You have MCP tools available:
 - list_claude_sessions: Find recent Claude Code sessions to resume
 - list_codex_sessions: Find recent Codex CLI sessions to resume
 - list_gemini_sessions: Find recent Gemini CLI sessions to resume
-- resume_session: Resume an existing session (pass kind=claude, kind=codex, or kind=gemini to disambiguate; default tries the current default agent first)
+- resume_session: Resume an existing session (pass kind=claude, kind=codex, or kind=gemini to disambiguate; default tries the current effective top-level agent first)
 - default_agent: Show or set the default agent used for new top-level sessions
 - rescue_agent: Show or set the rescue agent automatically used for new top-level sessions under disk pressure
 - rename_thread: Rename a Discord thread
@@ -634,6 +634,16 @@ let maybe_apply_pending_session_agent_change t (session : Session_store.session)
   match session.pending_agent_change with
   | None -> ()
   | Some pending ->
+    let target_kind =
+      match pending.origin with
+      | Session_store.Session_override -> pending.kind
+      | Session_store.Default_rotation ->
+        (* Default rotations follow the live top-level policy. The persisted
+           kind is only the scheduling-time target and can become stale when
+           disk pressure changes before a busy session finishes. *)
+        refresh_disk_state ();
+        effective_top_level_agent t
+    in
     if pending.origin = Session_store.Default_rotation
        && Option.is_some session.session_override_kind
     then
@@ -643,7 +653,7 @@ let maybe_apply_pending_session_agent_change t (session : Session_store.session)
          Logs.warn (fun m ->
            m "bot: failed to clear stale default-agent rotation for override %s: %s"
              session.thread_id err))
-    else if Config.equal_agent_kind session.agent_kind pending.kind
+    else if Config.equal_agent_kind session.agent_kind target_kind
             && pending.origin = Session_store.Default_rotation
     then
       (match Session_store.set_pending_agent_change t.sessions session None with
@@ -674,17 +684,17 @@ let maybe_apply_pending_session_agent_change t (session : Session_store.session)
         | Session_store.Default_rotation -> None
       in
       match replace_session_agent t session
-              ~agent_kind:pending.kind
+              ~agent_kind:target_kind
               ~session_override_kind with
       | Ok () ->
          Logs.info (fun m ->
            m "bot: switched channel %s to %s after pending agent change"
-             session.thread_id (Config.string_of_agent_kind pending.kind))
+             session.thread_id (Config.string_of_agent_kind target_kind))
       | Error err ->
         Logs.warn (fun m ->
           m "bot: failed to switch channel %s to %s: %s"
             session.thread_id
-            (Config.string_of_agent_kind pending.kind)
+            (Config.string_of_agent_kind target_kind)
             err)
     end
 
@@ -721,10 +731,10 @@ let reconcile_persisted_stop_requests t =
             session.thread_id err))
 
 let reconcile_persisted_pending_agent_changes t =
+  refresh_disk_state ();
   Session_store.bindings t.sessions
   |> List.iter (fun (_thread_id, (session : Session_store.session)) ->
     maybe_apply_pending_session_agent_change t session);
-  ignore (Disk_health.preflight_state_mutation ());
   match align_persistent_sessions_to_agent t
           ~current_channel_id:None ~new_agent:(effective_top_level_agent t) with
   | Ok _ -> ()
@@ -1200,8 +1210,8 @@ let handle_command t msg cmd =
       | Some msg ->
         reply msg
       | None ->
-      (* Locate the session in the requested store, or try the
-         current default first if [kind] is unspecified. *)
+      (* Locate the session in the requested store, or try the current
+         effective top-level agent first if [kind] is unspecified. *)
       let try_claude () =
         match Claude_sessions.find_by_prefix session_id with
         | Some (sid, wd) -> Some (Config.Claude, sid, wd)
@@ -1222,8 +1232,8 @@ let handle_command t msg cmd =
         | Config.Codex -> try_codex ()
         | Config.Gemini -> try_gemini ()
       in
-      (* Explicit kind hits exactly one store; otherwise try the
-         current default first, then the remaining stores. *)
+      (* Explicit kind hits exactly one store; otherwise try the current
+         effective top-level agent first, then the remaining stores. *)
       let found = match kind with
         | Some k -> try_kind k
         | None -> Config.find_with_preferred_agent (effective_top_level_agent t) try_kind
@@ -1650,11 +1660,11 @@ let handle_command t msg cmd =
       "`!claude-sessions` — list recent Claude sessions";
       "`!codex-sessions` — list recent Codex sessions";
       "`!gemini-sessions` — list recent Gemini sessions";
-      "`!start <project> [agent]` — start a session (defaults to the current default agent)";
+      "`!start <project> [agent]` — start a session (defaults to the current effective top-level agent)";
       "`!default-agent [agent]` / `!default_agent [agent]` — show or set the default agent (claude|codex|gemini)";
       "`!rescue-agent [agent|off]` / `!rescue_agent [agent|off]` — show or set the rescue agent used under disk pressure";
       "`!session-agent [agent]` / `!session_agent [agent]` — show or set the current channel session agent";
-      "`!resume [agent] <session_id>` — resume a session (no agent = try the current default first)";
+      "`!resume [agent] <session_id>` — resume a session (no agent = try the current effective top-level agent first)";
       "`!stop <thread_id>` — stop a session";
       "`!rename [thread_id] <name>` — rename a thread";
       "`!status` — bot status and running processes";
@@ -1954,7 +1964,7 @@ let fork_initial_prompt_run t ~session ~msg =
       process_session_message t session msg None))
 
 (** Ensure a session exists for a channel (control or project channels).
-    Creates a persistent session using the current default agent. *)
+    Creates a persistent session using the current effective top-level agent. *)
 let ensure_channel_session t ~channel_id ~project_name ~working_dir ~system_prompt =
   match Session_store.find_opt t.sessions ~thread_id:channel_id with
   | Some _ -> Ok ()

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -102,8 +102,9 @@ let rescue_agent_notice t =
     Some (Printf.sprintf
       "Disk pressure is active, so new top-level sessions currently use rescue agent `%s`."
       (Config.string_of_agent_kind kind))
-  | Some _ ->
-    Some "Inactive until disk pressure."
+  | Some kind ->
+    Some (Printf.sprintf "Rescue agent `%s` is inactive until disk pressure."
+      (Config.string_of_agent_kind kind))
   | None ->
     None
 
@@ -121,13 +122,22 @@ let is_project_channel t ~(channel_id : Discord_types.channel_id) =
 let is_persistent_channel t ~(channel_id : Discord_types.channel_id) =
   is_control_channel t ~channel_id || is_project_channel t ~channel_id
 
+let is_known_project_name t project_name =
+  List.exists (fun (project : Project.t) ->
+    String.equal project.Project.name project_name) (projects t)
+
+let is_persistent_session t ~thread_id (session : Session_store.session) =
+  is_persistent_channel t ~channel_id:thread_id
+  || (Option.is_some session.system_prompt
+      && is_known_project_name t session.project_name)
+
 let refresh_session_disk_state (session : Session_store.session) =
   ignore (Disk_health.preflight_write session.working_dir)
 
 let refresh_persistent_session_disk_state t =
   Session_store.bindings t.sessions
   |> List.iter (fun (thread_id, (session : Session_store.session)) ->
-    if is_persistent_channel t ~channel_id:thread_id then
+    if is_persistent_session t ~thread_id session then
       refresh_session_disk_state session)
 
 let refresh_top_level_disk_state t =
@@ -514,7 +524,7 @@ let replace_session_agent t (session : Session_store.session)
 
 let align_persistent_sessions_to_agent t ~current_channel_id ~new_agent =
   let clear_redundant_default_rotation thread_id (session : Session_store.session) =
-    if is_persistent_channel t ~channel_id:thread_id
+    if is_persistent_session t ~thread_id session
        && (Config.equal_agent_kind session.agent_kind new_agent
            || Option.is_some session.session_override_kind)
     then
@@ -540,7 +550,7 @@ let align_persistent_sessions_to_agent t ~current_channel_id ~new_agent =
   let stale_sessions =
     Session_store.bindings t.sessions
     |> List.filter (fun (thread_id, (session : Session_store.session)) ->
-      is_persistent_channel t ~channel_id:thread_id
+      is_persistent_session t ~thread_id session
       && Option.is_none session.session_override_kind
       && not (Config.equal_agent_kind session.agent_kind new_agent))
   in
@@ -1412,6 +1422,7 @@ let handle_command t msg cmd =
       | Some kind -> Printf.sprintf "`%s`" (Config.string_of_agent_kind kind)
       | None -> "disabled"
     in
+    let rescue_was_active = rescue_mode_active t in
     (match set_rescue_agent t ~current_channel_id:(Some channel_id) requested with
      | Error err -> reply err
      | Ok rotation ->
@@ -1436,7 +1447,7 @@ let handle_command t msg cmd =
            Printf.sprintf
              " Disk pressure is active, so top-level sessions are currently using `%s`."
              (Config.string_of_agent_kind effective)
-         | None when rescue_mode_active t ->
+         | None when rescue_was_active ->
            Printf.sprintf
              " Disk pressure is active, so top-level sessions are currently using the default agent `%s`."
              (Config.string_of_agent_kind effective)
@@ -1996,7 +2007,7 @@ let ensure_channel_session t ~channel_id ~project_name ~working_dir ~system_prom
            (Printexc.to_string exn)))
 
 let sync_top_level_agent_policy t =
-  ignore (Disk_health.preflight_state_mutation ());
+  refresh_top_level_disk_state t;
   align_persistent_sessions_to_agent t
     ~current_channel_id:None
     ~new_agent:(effective_top_level_agent t)

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -74,11 +74,43 @@ type t = {
 let projects t = t.project_state.projects
 let channels t = t.project_state.channels
 let default_agent t = t.settings.default_agent
+let rescue_agent t = t.settings.rescue_agent
 let new_session_block_message () = Disk_health.new_session_block_message ()
 let pending_default_rotation kind =
   Session_store.{ kind; origin = Default_rotation }
 let pending_session_override kind =
   Session_store.{ kind; origin = Session_override }
+
+let rescue_mode_active_from_snapshot (settings : Runtime_settings.t) disk =
+  Disk_health.pressure disk && Option.is_some settings.rescue_agent
+
+let effective_top_level_agent_from_snapshot (settings : Runtime_settings.t) disk =
+  match settings.rescue_agent with
+  | Some kind when Disk_health.pressure disk -> kind
+  | _ -> settings.default_agent
+
+let effective_top_level_agent t =
+  effective_top_level_agent_from_snapshot t.settings (Disk_health.snapshot ())
+
+let rescue_mode_active t =
+  rescue_mode_active_from_snapshot t.settings (Disk_health.snapshot ())
+
+let rescue_agent_notice t =
+  let disk = Disk_health.snapshot () in
+  match t.settings.rescue_agent with
+  | Some kind when Disk_health.pressure disk ->
+    Some (Printf.sprintf
+      "Disk pressure is active, so new top-level sessions currently use rescue agent `%s`."
+      (Config.string_of_agent_kind kind))
+  | Some kind ->
+    Some (Printf.sprintf
+      "Rescue agent: `%s` (inactive until disk pressure)."
+      (Config.string_of_agent_kind kind))
+  | None ->
+    None
+
+let refresh_disk_state () =
+  ignore (Disk_health.preflight_state_mutation ())
 
 let is_control_channel t ~(channel_id : Discord_types.channel_id) =
   match t.config.control_channel_id with
@@ -375,6 +407,7 @@ You have MCP tools available:
 - list_gemini_sessions: Find recent Gemini CLI sessions to resume
 - resume_session: Resume an existing session (pass kind=claude, kind=codex, or kind=gemini to disambiguate; default tries the current default agent first)
 - default_agent: Show or set the default agent used for new top-level sessions
+- rescue_agent: Show or set the rescue agent automatically used for new top-level sessions under disk pressure
 - restart_bot: Rebuild and restart the bot
 - rename_thread: Rename a Discord thread
 - cleanup_channels: Delete stale Discord channels
@@ -414,6 +447,7 @@ You have MCP tools available:
 - list_gemini_sessions: Find recent Gemini CLI sessions to resume
 - resume_session: Resume an existing session (pass kind=claude, kind=codex, or kind=gemini to disambiguate; default tries the current default agent first)
 - default_agent: Show or set the default agent used for new top-level sessions
+- rescue_agent: Show or set the rescue agent automatically used for new top-level sessions under disk pressure
 - rename_thread: Rename a Discord thread
 - restart_bot: Rebuild and restart the bot
 - cleanup_channels: Delete stale Discord channels
@@ -467,7 +501,7 @@ let replace_session_agent t (session : Session_store.session)
   with exn ->
     Error (Printexc.to_string exn)
 
-let align_persistent_sessions_to_default t ~current_channel_id ~new_agent =
+let align_persistent_sessions_to_agent t ~current_channel_id ~new_agent =
   let clear_redundant_default_rotation thread_id (session : Session_store.session) =
     if is_persistent_channel t ~channel_id:thread_id
        && (Config.equal_agent_kind session.agent_kind new_agent
@@ -484,6 +518,14 @@ let align_persistent_sessions_to_default t ~current_channel_id ~new_agent =
     else
       Ok ()
   in
+  let current_override_kind = ref None in
+  (match current_channel_id with
+   | Some thread_id ->
+     (match Session_store.find_opt t.sessions ~thread_id with
+      | Some session ->
+        current_override_kind := session.session_override_kind
+      | None -> ())
+   | None -> ());
   let stale_sessions =
     Session_store.bindings t.sessions
     |> List.filter (fun (thread_id, (session : Session_store.session)) ->
@@ -492,14 +534,6 @@ let align_persistent_sessions_to_default t ~current_channel_id ~new_agent =
       && not (Config.equal_agent_kind session.agent_kind new_agent))
   in
   let current_busy_kind = ref None in
-  let current_override_kind =
-    match current_channel_id with
-    | Some current_channel_id ->
-      (match Session_store.find_opt t.sessions ~thread_id:current_channel_id with
-       | Some session -> ref session.session_override_kind
-       | None -> ref None)
-    | None -> ref None
-  in
   let reset_count = ref 0 in
   let busy_count = ref 0 in
   let rec clear_redundant = function
@@ -545,8 +579,8 @@ let align_persistent_sessions_to_default t ~current_channel_id ~new_agent =
             incr busy_count;
             align rest
       end else
-        match replace_session_agent t session ~agent_kind:new_agent
-                ~session_override_kind:None with
+        match replace_session_agent t session
+                ~agent_kind:new_agent ~session_override_kind:None with
         | Error err ->
           Error (Printf.sprintf
             "failed to start a fresh %s session for channel %s: %s"
@@ -560,17 +594,41 @@ let align_persistent_sessions_to_default t ~current_channel_id ~new_agent =
   | Ok () -> align stale_sessions
 
 let set_default_agent t ?(current_channel_id=None) kind =
+  refresh_disk_state ();
   match Runtime_settings.set_default_agent t.settings kind with
   | Error err ->
     Error (Printf.sprintf "Failed to persist the default agent setting: %s" err)
   | Ok () ->
-    (match align_persistent_sessions_to_default t
-             ~current_channel_id ~new_agent:kind with
+    (match align_persistent_sessions_to_agent t
+             ~current_channel_id ~new_agent:(effective_top_level_agent t) with
      | Ok rotation -> Ok rotation
      | Error err ->
        Error (Printf.sprintf
          "Default agent is now `%s`, but top-level session rotation was incomplete: %s"
          (Config.string_of_agent_kind kind) err))
+
+let set_rescue_agent t ?(current_channel_id=None) kind =
+  refresh_disk_state ();
+  match Runtime_settings.set_rescue_agent t.settings kind with
+  | Error err ->
+    Error (Printf.sprintf "Failed to persist the rescue agent setting: %s" err)
+  | Ok () ->
+    let effective = effective_top_level_agent t in
+    let summary =
+      match kind with
+      | Some kind ->
+        Printf.sprintf "Rescue agent is now `%s`"
+          (Config.string_of_agent_kind kind)
+      | None ->
+        "Rescue agent is now disabled"
+    in
+    (match align_persistent_sessions_to_agent t
+             ~current_channel_id ~new_agent:effective with
+     | Ok rotation -> Ok rotation
+     | Error err ->
+       Error (Printf.sprintf
+         "%s, but top-level session rotation was incomplete: %s"
+         summary err))
 
 let maybe_apply_pending_session_agent_change t (session : Session_store.session) =
   match session.pending_agent_change with
@@ -666,8 +724,9 @@ let reconcile_persisted_pending_agent_changes t =
   Session_store.bindings t.sessions
   |> List.iter (fun (_thread_id, (session : Session_store.session)) ->
     maybe_apply_pending_session_agent_change t session);
-  match align_persistent_sessions_to_default t
-          ~current_channel_id:None ~new_agent:(default_agent t) with
+  ignore (Disk_health.preflight_state_mutation ());
+  match align_persistent_sessions_to_agent t
+          ~current_channel_id:None ~new_agent:(effective_top_level_agent t) with
   | Ok _ -> ()
   | Error err ->
     Logs.warn (fun m ->
@@ -929,7 +988,8 @@ let create_explicit_channel_session t ~channel_id ~agent_kind =
     create_persistent_channel_session t ~channel_id
       ~project_name:"control" ~working_dir:(Sys.getcwd ())
       ~system_prompt:(Some (control_system_prompt (projects t)))
-      ~agent_kind ~session_override_kind:(Some agent_kind);
+      ~agent_kind
+      ~session_override_kind:(Some agent_kind);
     true
   end else
     match Channel_manager.project_for_channel (channels t) ~channel_id with
@@ -946,7 +1006,8 @@ let create_explicit_channel_session t ~channel_id ~agent_kind =
         create_persistent_channel_session t ~channel_id
           ~project_name:p.name ~working_dir
           ~system_prompt:(Some (project_system_prompt p))
-          ~agent_kind ~session_override_kind:(Some agent_kind);
+          ~agent_kind
+          ~session_override_kind:(Some agent_kind);
         true
 
 let cleanup_orphan_thread t ~thread_id ~context =
@@ -1036,11 +1097,11 @@ let handle_command t msg cmd =
       reply (format_session_listing ~label:"Claude"
         ~resume_hint:"!resume <session_id_prefix>" entries))
   | Command.Start_agent { project; kind } ->
-    let kind = Option.value kind ~default:(default_agent t) in
     (match new_session_block_message () with
      | Some msg ->
        reply msg
      | None ->
+       let kind = Option.value kind ~default:(effective_top_level_agent t) in
        let proj = Command.find_project_fuzzy (projects t) project in
        match proj with
        | None ->
@@ -1165,7 +1226,7 @@ let handle_command t msg cmd =
          current default first, then the remaining stores. *)
       let found = match kind with
         | Some k -> try_kind k
-        | None -> Config.find_with_preferred_agent (default_agent t) try_kind
+        | None -> Config.find_with_preferred_agent (effective_top_level_agent t) try_kind
       in
       match found with
       | None ->
@@ -1254,8 +1315,12 @@ let handle_command t msg cmd =
      | Session_stop_failed err ->
        reply (Printf.sprintf "Failed to stop session: %s" err))
   | Command.Default_agent None ->
-    reply (Printf.sprintf "Default agent: `%s`."
-      (Config.string_of_agent_kind (default_agent t)))
+    refresh_disk_state ();
+    let base = Printf.sprintf "Default agent: `%s`."
+      (Config.string_of_agent_kind (default_agent t)) in
+    reply (match rescue_agent_notice t with
+      | Some notice -> base ^ " " ^ notice
+      | None -> base)
   | Command.Default_agent (Some kind) ->
     let kind_str = Config.string_of_agent_kind kind in
     (match set_default_agent t ~current_channel_id:(Some channel_id) kind with
@@ -1301,17 +1366,72 @@ let handle_command t msg cmd =
                rotation.busy_count
                (if rotation.busy_count = 1 then "" else "s")
       in
-       reply (Printf.sprintf "Default agent set to `%s`.%s%s"
-         kind_str reset_suffix busy_suffix))
+       let rescue_suffix =
+         match rescue_agent_notice t with
+         | Some notice when not (Config.equal_agent_kind (effective_top_level_agent t) kind) ->
+           " " ^ notice
+         | _ -> ""
+       in
+       reply (Printf.sprintf "Default agent set to `%s`.%s%s%s"
+         kind_str reset_suffix busy_suffix rescue_suffix))
+  | Command.Rescue_agent None ->
+    refresh_disk_state ();
+    (match rescue_agent t with
+     | Some kind ->
+       let base = Printf.sprintf "Rescue agent: `%s`."
+         (Config.string_of_agent_kind kind) in
+       reply (match rescue_agent_notice t with
+         | Some notice when rescue_mode_active t -> base ^ " " ^ notice
+         | Some notice -> base ^ " " ^ notice
+         | None -> base)
+     | None ->
+       reply "Rescue agent: disabled.")
+  | Command.Rescue_agent (Some requested) ->
+    let requested_label = match requested with
+      | Some kind -> Printf.sprintf "`%s`" (Config.string_of_agent_kind kind)
+      | None -> "disabled"
+    in
+    (match set_rescue_agent t ~current_channel_id:(Some channel_id) requested with
+     | Error err -> reply err
+     | Ok rotation ->
+       let reset_suffix =
+         if rotation.reset_count = 0 then ""
+         else
+           Printf.sprintf " Reset %d top-level session%s immediately."
+             rotation.reset_count
+             (if rotation.reset_count = 1 then "" else "s")
+       in
+       let busy_suffix =
+         if rotation.busy_count = 0 then ""
+         else
+           Printf.sprintf " %d busy top-level session%s will switch after their queued work finishes."
+             rotation.busy_count
+             (if rotation.busy_count = 1 then "" else "s")
+       in
+       let effective_suffix =
+         let effective = effective_top_level_agent t in
+         match requested with
+         | Some _ when rescue_mode_active t ->
+           Printf.sprintf
+             " Disk pressure is active, so top-level sessions are currently using `%s`."
+             (Config.string_of_agent_kind effective)
+         | None when rescue_mode_active t ->
+           Printf.sprintf
+             " Disk pressure is active, so top-level sessions are currently using the default agent `%s`."
+             (Config.string_of_agent_kind effective)
+         | _ -> ""
+       in
+       reply (Printf.sprintf "Rescue agent set to %s.%s%s%s"
+         requested_label reset_suffix busy_suffix effective_suffix))
   | Command.Session_agent None ->
     (match Session_store.find_opt t.sessions ~thread_id:channel_id with
      | Some session ->
        (match session.pending_agent_change with
-       | Some pending when not (Config.equal_agent_kind pending.kind session.agent_kind) ->
+        | Some { origin = Session_store.Session_override; kind } ->
           reply (Printf.sprintf
             "Session agent: `%s` (will start a fresh `%s` session after queued work finishes)."
             (Config.string_of_agent_kind session.agent_kind)
-            (Config.string_of_agent_kind pending.kind))
+            (Config.string_of_agent_kind kind))
         | _ when Option.is_some session.session_override_kind ->
           reply (Printf.sprintf "Session agent: `%s` (session override)."
             (Config.string_of_agent_kind session.agent_kind))
@@ -1320,8 +1440,8 @@ let handle_command t msg cmd =
             (Config.string_of_agent_kind session.agent_kind)))
      | None when is_persistent_channel t ~channel_id ->
        reply (Printf.sprintf
-         "No session exists in this channel yet. It will start with default agent `%s`."
-         (Config.string_of_agent_kind (default_agent t)))
+         "No session exists in this channel yet. It will start with top-level agent `%s`."
+         (Config.string_of_agent_kind (effective_top_level_agent t)))
      | None ->
        reply "No session exists in this channel.")
   | Command.Session_agent (Some kind) ->
@@ -1496,6 +1616,14 @@ let handle_command t msg cmd =
           Printf.sprintf "**%s** (pid %d, up %s)" (Build_info.version_string ()) pid uptime_str;
           Printf.sprintf "Default agent: %s"
             (Config.string_of_agent_kind (default_agent t));
+          (match rescue_agent t with
+           | Some kind ->
+             Printf.sprintf "Rescue agent: %s%s"
+               (Config.string_of_agent_kind kind)
+               (if rescue_mode_active t then " (active)" else "")
+           | None -> "Rescue agent: disabled");
+          Printf.sprintf "Effective top-level agent: %s"
+            (Config.string_of_agent_kind (effective_top_level_agent t));
           Disk_health.status_summary ();
           Printf.sprintf "Sessions: %d (%d processing)"
             (Session_store.count t.sessions)
@@ -1524,6 +1652,7 @@ let handle_command t msg cmd =
       "`!gemini-sessions` — list recent Gemini sessions";
       "`!start <project> [agent]` — start a session (defaults to the current default agent)";
       "`!default-agent [agent]` / `!default_agent [agent]` — show or set the default agent (claude|codex|gemini)";
+      "`!rescue-agent [agent|off]` / `!rescue_agent [agent|off]` — show or set the rescue agent used under disk pressure";
       "`!session-agent [agent]` / `!session_agent [agent]` — show or set the current channel session agent";
       "`!resume [agent] <session_id>` — resume a session (no agent = try the current default first)";
       "`!stop <thread_id>` — stop a session";
@@ -1835,13 +1964,20 @@ let ensure_channel_session t ~channel_id ~project_name ~working_dir ~system_prom
     | None ->
       (try
          create_persistent_channel_session t ~channel_id ~project_name
-           ~working_dir ~system_prompt ~agent_kind:(default_agent t)
+           ~working_dir ~system_prompt
+           ~agent_kind:(effective_top_level_agent t)
            ~session_override_kind:None;
          Logs.info (fun m -> m "bot: auto-created session for %s" project_name);
          Ok ()
        with exn ->
          Error (Printf.sprintf "Failed to persist session: %s"
            (Printexc.to_string exn)))
+
+let sync_top_level_agent_policy t =
+  ignore (Disk_health.preflight_state_mutation ());
+  align_persistent_sessions_to_agent t
+    ~current_channel_id:None
+    ~new_agent:(effective_top_level_agent t)
 
 let handle_command_safely t msg cmd =
   try
@@ -1885,32 +2021,42 @@ let handle_message t (msg : Discord_types.message) =
     let project_for_channel =
       Channel_manager.project_for_channel (channels t) ~channel_id:msg.channel_id in
     if is_control then begin
-      match ensure_channel_session t ~channel_id:msg.channel_id
-              ~project_name:"control" ~working_dir:(Sys.getcwd ())
-              ~system_prompt:(Some (control_system_prompt (projects t))) with
-      | Ok () -> handle_thread_message t msg ()
+      match sync_top_level_agent_policy t with
       | Error err ->
         ignore (Discord_rest.create_message t.rest
           ~channel_id:msg.channel_id ~content:err ())
+      | Ok _ ->
+        (match ensure_channel_session t ~channel_id:msg.channel_id
+                ~project_name:"control" ~working_dir:(Sys.getcwd ())
+                ~system_prompt:(Some (control_system_prompt (projects t))) with
+        | Ok () -> handle_thread_message t msg ()
+        | Error err ->
+          ignore (Discord_rest.create_message t.rest
+            ~channel_id:msg.channel_id ~content:err ()))
     end else match project_for_channel with
     | Some proj_name ->
-      (* Message in a project channel — persistent session (like control channel).
-         The project Claude can create threads via MCP tools when needed. *)
-      let proj = List.find_opt (fun (p : Project.t) -> p.name = proj_name) (projects t) in
-      (match proj with
-       | Some p ->
-         let wd = match working_dir_of_project p with Ok d -> d | Error _ -> p.path in
-         (match ensure_channel_session t ~channel_id:msg.channel_id
-                  ~project_name:p.name ~working_dir:wd
-                  ~system_prompt:(Some (project_system_prompt p)) with
-          | Ok () ->
-            Channel_manager.bump ~rest:t.rest ~guild_id:t.config.guild_id
-              ~project_name:p.name (channels t);
-            handle_thread_message t msg ()
-          | Error err ->
-            ignore (Discord_rest.create_message t.rest
-              ~channel_id:msg.channel_id ~content:err ()))
-       | None -> ())
+      (match sync_top_level_agent_policy t with
+       | Error err ->
+         ignore (Discord_rest.create_message t.rest
+           ~channel_id:msg.channel_id ~content:err ())
+       | Ok _ ->
+         (* Message in a project channel — persistent session (like control channel).
+            The project Claude can create threads via MCP tools when needed. *)
+         let proj = List.find_opt (fun (p : Project.t) -> p.name = proj_name) (projects t) in
+         (match proj with
+          | Some p ->
+            let wd = match working_dir_of_project p with Ok d -> d | Error _ -> p.path in
+            (match ensure_channel_session t ~channel_id:msg.channel_id
+                     ~project_name:p.name ~working_dir:wd
+                     ~system_prompt:(Some (project_system_prompt p)) with
+             | Ok () ->
+               Channel_manager.bump ~rest:t.rest ~guild_id:t.config.guild_id
+                 ~project_name:p.name (channels t);
+               handle_thread_message t msg ()
+             | Error err ->
+               ignore (Discord_rest.create_message t.rest
+                 ~channel_id:msg.channel_id ~content:err ()))
+          | None -> ()))
     | None ->
       (* Check if this is a thread under a project channel.
          Since the control API creates sessions directly in bot memory,

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -102,10 +102,8 @@ let rescue_agent_notice t =
     Some (Printf.sprintf
       "Disk pressure is active, so new top-level sessions currently use rescue agent `%s`."
       (Config.string_of_agent_kind kind))
-  | Some kind ->
-    Some (Printf.sprintf
-      "Rescue agent: `%s` (inactive until disk pressure)."
-      (Config.string_of_agent_kind kind))
+  | Some _ ->
+    Some "Inactive until disk pressure."
   | None ->
     None
 
@@ -122,6 +120,19 @@ let is_project_channel t ~(channel_id : Discord_types.channel_id) =
 
 let is_persistent_channel t ~(channel_id : Discord_types.channel_id) =
   is_control_channel t ~channel_id || is_project_channel t ~channel_id
+
+let refresh_session_disk_state (session : Session_store.session) =
+  ignore (Disk_health.preflight_write session.working_dir)
+
+let refresh_persistent_session_disk_state t =
+  Session_store.bindings t.sessions
+  |> List.iter (fun (thread_id, (session : Session_store.session)) ->
+    if is_persistent_channel t ~channel_id:thread_id then
+      refresh_session_disk_state session)
+
+let refresh_top_level_disk_state t =
+  refresh_disk_state ();
+  refresh_persistent_session_disk_state t
 
 type persistent_rotation = {
   reset_count : int;
@@ -594,7 +605,7 @@ let align_persistent_sessions_to_agent t ~current_channel_id ~new_agent =
   | Ok () -> align stale_sessions
 
 let set_default_agent t ?(current_channel_id=None) kind =
-  refresh_disk_state ();
+  refresh_top_level_disk_state t;
   match Runtime_settings.set_default_agent t.settings kind with
   | Error err ->
     Error (Printf.sprintf "Failed to persist the default agent setting: %s" err)
@@ -608,7 +619,7 @@ let set_default_agent t ?(current_channel_id=None) kind =
          (Config.string_of_agent_kind kind) err))
 
 let set_rescue_agent t ?(current_channel_id=None) kind =
-  refresh_disk_state ();
+  refresh_top_level_disk_state t;
   match Runtime_settings.set_rescue_agent t.settings kind with
   | Error err ->
     Error (Printf.sprintf "Failed to persist the rescue agent setting: %s" err)
@@ -642,6 +653,7 @@ let maybe_apply_pending_session_agent_change t (session : Session_store.session)
            kind is only the scheduling-time target and can become stale when
            disk pressure changes before a busy session finishes. *)
         refresh_disk_state ();
+        refresh_session_disk_state session;
         effective_top_level_agent t
     in
     if pending.origin = Session_store.Default_rotation
@@ -731,7 +743,7 @@ let reconcile_persisted_stop_requests t =
             session.thread_id err))
 
 let reconcile_persisted_pending_agent_changes t =
-  refresh_disk_state ();
+  refresh_top_level_disk_state t;
   Session_store.bindings t.sessions
   |> List.iter (fun (_thread_id, (session : Session_store.session)) ->
     maybe_apply_pending_session_agent_change t session);
@@ -1367,7 +1379,7 @@ let handle_command t msg cmd =
                  (if other_busy = 1 then "" else "s")
            in
            Printf.sprintf
-             " This channel is still running `%s`; it will reset to the new default after its queued work finishes.%s"
+             " This channel is still running `%s`; it will follow the effective top-level agent after its queued work finishes.%s"
              (Config.string_of_agent_kind current_kind) others
          | None, None ->
            if rotation.busy_count = 0 then ""
@@ -1391,7 +1403,6 @@ let handle_command t msg cmd =
        let base = Printf.sprintf "Rescue agent: `%s`."
          (Config.string_of_agent_kind kind) in
        reply (match rescue_agent_notice t with
-         | Some notice when rescue_mode_active t -> base ^ " " ^ notice
          | Some notice -> base ^ " " ^ notice
          | None -> base)
      | None ->
@@ -1548,6 +1559,7 @@ let handle_command t msg cmd =
     Eio.Fiber.fork ~sw:t.sw (fun () ->
       let status_lines = Eio_unix.run_in_systhread (fun () ->
         ignore (Disk_health.preflight_state_mutation ());
+        refresh_persistent_session_disk_state t;
         let pid = Unix.getpid () in
         let uptime_sec = int_of_float (Unix.gettimeofday () -. t.started_at) in
         let hours = uptime_sec / 3600 in
@@ -1989,6 +2001,13 @@ let sync_top_level_agent_policy t =
     ~current_channel_id:None
     ~new_agent:(effective_top_level_agent t)
 
+let sync_top_level_agent_policy_best_effort t =
+  match sync_top_level_agent_policy t with
+  | Ok _ -> ()
+  | Error err ->
+    Logs.warn (fun m ->
+      m "bot: top-level policy sync skipped during message routing: %s" err)
+
 let handle_command_safely t msg cmd =
   try
     handle_command t msg cmd
@@ -2031,42 +2050,34 @@ let handle_message t (msg : Discord_types.message) =
     let project_for_channel =
       Channel_manager.project_for_channel (channels t) ~channel_id:msg.channel_id in
     if is_control then begin
-      match sync_top_level_agent_policy t with
-      | Error err ->
-        ignore (Discord_rest.create_message t.rest
-          ~channel_id:msg.channel_id ~content:err ())
-      | Ok _ ->
-        (match ensure_channel_session t ~channel_id:msg.channel_id
-                ~project_name:"control" ~working_dir:(Sys.getcwd ())
-                ~system_prompt:(Some (control_system_prompt (projects t))) with
-        | Ok () -> handle_thread_message t msg ()
-        | Error err ->
-          ignore (Discord_rest.create_message t.rest
-            ~channel_id:msg.channel_id ~content:err ()))
-    end else match project_for_channel with
-    | Some proj_name ->
-      (match sync_top_level_agent_policy t with
+      sync_top_level_agent_policy_best_effort t;
+      (match ensure_channel_session t ~channel_id:msg.channel_id
+              ~project_name:"control" ~working_dir:(Sys.getcwd ())
+              ~system_prompt:(Some (control_system_prompt (projects t))) with
+       | Ok () -> handle_thread_message t msg ()
        | Error err ->
          ignore (Discord_rest.create_message t.rest
-           ~channel_id:msg.channel_id ~content:err ())
-       | Ok _ ->
-         (* Message in a project channel — persistent session (like control channel).
-            The project Claude can create threads via MCP tools when needed. *)
-         let proj = List.find_opt (fun (p : Project.t) -> p.name = proj_name) (projects t) in
-         (match proj with
-          | Some p ->
-            let wd = match working_dir_of_project p with Ok d -> d | Error _ -> p.path in
-            (match ensure_channel_session t ~channel_id:msg.channel_id
-                     ~project_name:p.name ~working_dir:wd
-                     ~system_prompt:(Some (project_system_prompt p)) with
-             | Ok () ->
-               Channel_manager.bump ~rest:t.rest ~guild_id:t.config.guild_id
-                 ~project_name:p.name (channels t);
-               handle_thread_message t msg ()
-             | Error err ->
-               ignore (Discord_rest.create_message t.rest
-                 ~channel_id:msg.channel_id ~content:err ()))
-          | None -> ()))
+           ~channel_id:msg.channel_id ~content:err ()))
+    end else match project_for_channel with
+    | Some proj_name ->
+      sync_top_level_agent_policy_best_effort t;
+      (* Message in a project channel — persistent session (like control channel).
+         The project Claude can create threads via MCP tools when needed. *)
+      let proj = List.find_opt (fun (p : Project.t) -> p.name = proj_name) (projects t) in
+      (match proj with
+       | Some p ->
+         let wd = match working_dir_of_project p with Ok d -> d | Error _ -> p.path in
+         (match ensure_channel_session t ~channel_id:msg.channel_id
+                  ~project_name:p.name ~working_dir:wd
+                  ~system_prompt:(Some (project_system_prompt p)) with
+          | Ok () ->
+            Channel_manager.bump ~rest:t.rest ~guild_id:t.config.guild_id
+              ~project_name:p.name (channels t);
+            handle_thread_message t msg ()
+          | Error err ->
+            ignore (Discord_rest.create_message t.rest
+              ~channel_id:msg.channel_id ~content:err ()))
+       | None -> ())
     | None ->
       (* Check if this is a thread under a project channel.
          Since the control API creates sessions directly in bot memory,

--- a/lib/command.ml
+++ b/lib/command.ml
@@ -66,13 +66,14 @@ let parse content =
      | Ok k -> Default_agent (Some k)
      | Error _ -> Unknown content)
   | ["rescue-agent"] | ["rescue_agent"] -> Rescue_agent None
-  | ["rescue-agent"; "off"] | ["rescue_agent"; "off"]
-  | ["rescue-agent"; "none"] | ["rescue_agent"; "none"] ->
-    Rescue_agent (Some None)
   | ["rescue-agent"; kind_str] | ["rescue_agent"; kind_str] ->
-    (match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with
-     | Ok k -> Rescue_agent (Some (Some k))
-     | Error _ -> Unknown content)
+    let kind_str = String.lowercase_ascii kind_str in
+    if kind_str = "off" || kind_str = "none" then
+      Rescue_agent (Some None)
+    else
+      (match Config.agent_kind_of_string kind_str with
+       | Ok k -> Rescue_agent (Some (Some k))
+       | Error _ -> Unknown content)
   | ["session-agent"] | ["session_agent"] -> Session_agent None
   | ["session-agent"; kind_str] | ["session_agent"; kind_str] ->
     (match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with

--- a/lib/command.ml
+++ b/lib/command.ml
@@ -16,6 +16,7 @@ type t =
   | Stop_session of { thread_id : string }
   | Cleanup_channels
   | Default_agent of Config.agent_kind option
+  | Rescue_agent of Config.agent_kind option option
   | Session_agent of Config.agent_kind option
   | Restart
   | Refresh
@@ -64,6 +65,14 @@ let parse content =
   | ["default-agent"; kind_str] | ["default_agent"; kind_str] ->
     (match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with
      | Ok k -> Default_agent (Some k)
+     | Error _ -> Unknown content)
+  | ["rescue-agent"] | ["rescue_agent"] -> Rescue_agent None
+  | ["rescue-agent"; "off"] | ["rescue_agent"; "off"]
+  | ["rescue-agent"; "none"] | ["rescue_agent"; "none"] ->
+    Rescue_agent (Some None)
+  | ["rescue-agent"; kind_str] | ["rescue_agent"; kind_str] ->
+    (match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with
+     | Ok k -> Rescue_agent (Some (Some k))
      | Error _ -> Unknown content)
   | ["session-agent"] | ["session_agent"] -> Session_agent None
   | ["session-agent"; kind_str] | ["session_agent"; kind_str] ->

--- a/lib/command.ml
+++ b/lib/command.ml
@@ -10,8 +10,7 @@ type t =
   | List_codex_sessions
   | List_gemini_sessions
   | Start_agent of { project : string; kind : Config.agent_kind option }
-  (** [kind = None] means "try the current default agent first, then
-      the remaining agent stores". *)
+  (** [kind = None] means use the current effective top-level agent. *)
   | Resume_session of { session_id : string; kind : Config.agent_kind option }
   | Stop_session of { thread_id : string }
   | Cleanup_channels

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -541,8 +541,8 @@ let handle_resume_session (bot : Bot.t) params =
            | Ok k -> Some k | Error _ -> None)
       in
       (* Mirror Bot.handle_command's Resume_session dispatch: explicit
-         kind looks up its own store; None tries the current default
-         first, then the remaining stores. *)
+         kind looks up its own store; None tries the current effective
+         top-level agent first, then the remaining stores. *)
       let try_claude () =
         match Claude_sessions.find_by_prefix sid_prefix with
         | Some (sid, wd) -> Some (Config.Claude, sid, wd) | None -> None

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -117,6 +117,9 @@ let handle_health (bot : Bot.t) =
     Disk_health.preflight_state_mutation ()));
   let uptime = int_of_float (Unix.gettimeofday () -. bot.started_at) in
   let disk = Disk_health.snapshot () in
+  let effective_top_level_agent =
+    Bot.effective_top_level_agent_from_snapshot bot.settings disk
+  in
   let rest_failures = Discord_rest.consecutive_rest_failures bot.rest in
   let transport_failures =
     Discord_rest.consecutive_transport_failures bot.rest
@@ -194,13 +197,22 @@ let handle_health (bot : Bot.t) =
     ("uptime_seconds", `Int uptime);
     ("default_agent",
      `String (Config.string_of_agent_kind bot.settings.default_agent));
+    ("effective_top_level_agent",
+     `String (Config.string_of_agent_kind effective_top_level_agent));
+    ("disk_rescue_active",
+     `Bool (Bot.rescue_mode_active_from_snapshot bot.settings disk));
     ("sessions", `Int (Session_store.count bot.sessions));
     ("projects", `Int (List.length (Bot.projects bot)));
     ("channels", `Int (Channel_manager.count (Bot.channels bot)));
   ] @ rest_fields @ optional_rest_fields
     @ optional_transport_fields
     @ gateway_fields @ optional_gateway_fields
-    @ disk_fields @ optional_disk_fields)
+    @ disk_fields @ optional_disk_fields
+    @
+    match bot.settings.rescue_agent with
+    | Some kind ->
+      [("rescue_agent", `String (Config.string_of_agent_kind kind))]
+    | None -> [])
 
 let handle_list_projects (bot : Bot.t) =
   let projects = List.map (fun (p : Project.t) ->
@@ -304,7 +316,7 @@ let handle_start_session (bot : Bot.t) params =
       let kind_str = match params |> member "agent" |> to_string_option with
         | Some s -> s
         | None ->
-          Config.string_of_agent_kind bot.settings.default_agent
+          Config.string_of_agent_kind (Bot.effective_top_level_agent bot)
       in
       let kind = match Config.agent_kind_of_string kind_str with
         | Ok k -> k | Error _ -> failwith ("unknown agent: " ^ kind_str) in
@@ -551,7 +563,8 @@ let handle_resume_session (bot : Bot.t) params =
       let found = match kind with
         | Some k -> try_kind k
         | None ->
-          Config.find_with_preferred_agent bot.settings.default_agent try_kind
+          Config.find_with_preferred_agent
+            (Bot.effective_top_level_agent bot) try_kind
       in
       match found with
       | None ->
@@ -618,6 +631,7 @@ let handle_resume_session (bot : Bot.t) params =
 
 let handle_default_agent (bot : Bot.t) params =
   let open Yojson.Safe.Util in
+  ignore (Disk_health.preflight_state_mutation ());
   let requested =
     match params with
     | Some p ->
@@ -631,16 +645,75 @@ let handle_default_agent (bot : Bot.t) params =
   in
   match requested with
   | None ->
-    ok_response [
+    let disk = Disk_health.snapshot () in
+    ok_response ([
       ("agent",
        `String (Config.string_of_agent_kind bot.settings.default_agent));
-    ]
+      ("effective_top_level_agent",
+       `String (Config.string_of_agent_kind
+         (Bot.effective_top_level_agent_from_snapshot bot.settings disk)));
+      ("disk_rescue_active",
+       `Bool (Bot.rescue_mode_active_from_snapshot bot.settings disk));
+    ] @
+    match bot.settings.rescue_agent with
+    | Some kind ->
+      [("rescue_agent", `String (Config.string_of_agent_kind kind))]
+    | None -> [])
   | Some kind ->
     (match Bot.set_default_agent bot kind with
      | Error err -> error_response err
      | Ok rotation ->
-       ok_response [
+       ok_response ([
          ("agent", `String (Config.string_of_agent_kind kind));
+         ("effective_top_level_agent",
+          `String (Config.string_of_agent_kind (Bot.effective_top_level_agent bot)));
+         ("disk_rescue_active", `Bool (Bot.rescue_mode_active bot));
+         ("reset_count", `Int rotation.Bot.reset_count);
+         ("busy_count", `Int rotation.Bot.busy_count);
+       ] @
+       match bot.settings.rescue_agent with
+       | Some rescue ->
+         [("rescue_agent", `String (Config.string_of_agent_kind rescue))]
+       | None -> []))
+
+let handle_rescue_agent (bot : Bot.t) params =
+  let open Yojson.Safe.Util in
+  ignore (Disk_health.preflight_state_mutation ());
+  let requested =
+    match params with
+    | Some p ->
+      (match p |> member "agent" |> to_string_option with
+       | None -> None
+       | Some s when String.equal (String.lowercase_ascii s) "off" -> Some None
+       | Some s ->
+         (match Config.agent_kind_of_string (String.lowercase_ascii s) with
+          | Ok kind -> Some (Some kind)
+          | Error msg -> failwith msg))
+    | None -> None
+  in
+  match requested with
+  | None ->
+    ok_response ([
+      ("effective_top_level_agent",
+       `String (Config.string_of_agent_kind (Bot.effective_top_level_agent bot)));
+      ("disk_rescue_active", `Bool (Bot.rescue_mode_active bot));
+    ] @
+    match bot.settings.rescue_agent with
+    | Some kind ->
+      [("agent", `String (Config.string_of_agent_kind kind))]
+    | None -> [("agent", `Null)])
+  | Some kind ->
+    (match Bot.set_rescue_agent bot kind with
+     | Error err -> error_response err
+     | Ok rotation ->
+       ok_response [
+         ("agent",
+          match kind with
+          | Some kind -> `String (Config.string_of_agent_kind kind)
+          | None -> `Null);
+         ("effective_top_level_agent",
+          `String (Config.string_of_agent_kind (Bot.effective_top_level_agent bot)));
+         ("disk_rescue_active", `Bool (Bot.rescue_mode_active bot));
          ("reset_count", `Int rotation.Bot.reset_count);
          ("busy_count", `Int rotation.Bot.busy_count);
        ])
@@ -745,6 +818,7 @@ let dispatch (bot : Bot.t) method_ params =
     | "resume_session" -> handle_resume_session bot params
     | "stop_session" -> handle_stop_session bot params
     | "default_agent" -> handle_default_agent bot params
+    | "rescue_agent" -> handle_rescue_agent bot params
     | "restart" -> handle_restart bot
     | "rename_thread" -> handle_rename_thread bot params
     | "cleanup_channels" -> handle_cleanup_channels bot

--- a/lib/disk_health.ml
+++ b/lib/disk_health.ml
@@ -55,6 +55,7 @@ let warning_threshold_bytes = mib 128
 let read_only_threshold_bytes = mib 64
 
 let state_mu = Mutex.create ()
+let probe_available_bytes_override = ref None
 
 let state = ref {
   observations = [];
@@ -222,10 +223,20 @@ let is_read_only () =
 
 let reset_for_tests () =
   with_state (fun state ->
+    probe_available_bytes_override := None;
     state := {
       observations = [];
       last_probe_error = None;
     })
+
+let set_probe_available_bytes_for_tests f =
+  with_state (fun _state ->
+    probe_available_bytes_override := Some f)
+
+let probe_available_bytes path =
+  match !probe_available_bytes_override with
+  | Some probe -> probe path
+  | None -> statvfs_available_bytes path
 
 let update_from_available_bytes ?(force = false) ~path available_bytes =
   let mode = mode_of_available_bytes available_bytes in
@@ -275,9 +286,6 @@ let note_probe_failure ~path exn =
           probe_checked_at = Unix.gettimeofday ();
         };
     })
-
-let probe_available_bytes path =
-  statvfs_available_bytes path
 
 let preflight_path_with ~available_bytes_of_path path =
   let requested_path = path in
@@ -464,4 +472,5 @@ module For_testing = struct
   let new_session_block_message = new_session_block_message
   let preflight_path_with = preflight_path_with
   let note_write_success = note_write_success
+  let set_probe_available_bytes = set_probe_available_bytes_for_tests
 end

--- a/lib/disk_health.mli
+++ b/lib/disk_health.mli
@@ -48,4 +48,5 @@ module For_testing : sig
     available_bytes_of_path:(string -> int64) ->
     string ->
     (unit, string) result
+  val set_probe_available_bytes : (string -> int64) -> unit
 end

--- a/lib/runtime_settings.ml
+++ b/lib/runtime_settings.ml
@@ -5,6 +5,7 @@
 
 type t = {
   mutable default_agent : Config.agent_kind;
+  mutable rescue_agent : Config.agent_kind option;
 }
 
 let settings_path () =
@@ -15,18 +16,34 @@ let backup_path () = settings_path () ^ ".bak"
 
 let default () = {
   default_agent = Config.Claude;
+  rescue_agent = None;
 }
 
 let to_yojson t =
-  `Assoc [("default_agent", Config.yojson_of_agent_kind t.default_agent)]
+  `Assoc ([
+    ("default_agent", Config.yojson_of_agent_kind t.default_agent)
+  ] @
+  match t.rescue_agent with
+  | Some agent -> [("rescue_agent", Config.yojson_of_agent_kind agent)]
+  | None -> [])
 
 let of_yojson = function
   | `Assoc fields ->
-    (match List.assoc_opt "default_agent" fields with
-     | Some (`String _ as json) ->
-       { default_agent = Config.agent_kind_of_yojson json }
-     | Some _ -> failwith "default_agent: expected string"
-     | None -> default ())
+    let default_agent =
+      match List.assoc_opt "default_agent" fields with
+      | Some (`String _ as json) ->
+        Config.agent_kind_of_yojson json
+      | Some _ -> failwith "default_agent: expected string"
+      | None -> (default ()).default_agent
+    in
+    let rescue_agent =
+      match List.assoc_opt "rescue_agent" fields with
+      | Some `Null | None -> None
+      | Some (`String _ as json) ->
+        Some (Config.agent_kind_of_yojson json)
+      | Some _ -> failwith "rescue_agent: expected string or null"
+    in
+    { default_agent; rescue_agent }
   | _ -> failwith "runtime settings: expected object"
 
 let load_file path =
@@ -121,10 +138,28 @@ let set_default_agent t agent =
   if Config.equal_agent_kind t.default_agent agent then
     Ok ()
   else
-    let next = { default_agent = agent } in
+    let next = {
+      default_agent = agent;
+      rescue_agent = t.rescue_agent;
+    } in
     match save next with
     | Ok () as ok ->
       t.default_agent <- agent;
+      ok
+    | Error _ as err ->
+      err
+
+let set_rescue_agent t agent =
+  if t.rescue_agent = agent then
+    Ok ()
+  else
+    let next = {
+      default_agent = t.default_agent;
+      rescue_agent = agent;
+    } in
+    match save next with
+    | Ok () as ok ->
+      t.rescue_agent <- agent;
       ok
     | Error _ as err ->
       err

--- a/lib/runtime_settings.ml
+++ b/lib/runtime_settings.ml
@@ -150,7 +150,7 @@ let set_default_agent t agent =
       err
 
 let set_rescue_agent t agent =
-  if t.rescue_agent = agent then
+  if Option.equal Config.equal_agent_kind t.rescue_agent agent then
     Ok ()
   else
     let next = {

--- a/lib/session_store.ml
+++ b/lib/session_store.ml
@@ -45,7 +45,7 @@ type session = {
   working_dir : string;
   agent_kind : Config.agent_kind;
   (* Persisted top-level session pin set via [!session-agent]. When
-     present, default-agent rotations must leave this session on the
+     present, default/rescue rotations must leave this session on the
      recorded agent kind. *)
   mutable session_override_kind : Config.agent_kind option;
   (* Mutable because Codex and Gemini assign their session ids
@@ -95,13 +95,13 @@ let sessions_to_json sessions =
       ("session_id_confirmed", `Bool s.session_id_confirmed);
       ("thread_id", `String s.thread_id);
       ("message_count", `Int s.message_count);
-    ] @ (match s.system_prompt with
-         | Some sp -> [("system_prompt", `String sp)]
-         | None -> [])
-      @ (match s.session_override_kind with
+    ] @ (match s.session_override_kind with
          | Some kind ->
            [("session_override_kind",
              `String (Config.string_of_agent_kind kind))]
+         | None -> [])
+      @ (match s.system_prompt with
+         | Some sp -> [("system_prompt", `String sp)]
          | None -> [])
       @ (match s.pending_agent_change with
          | Some pending ->

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -97,7 +97,7 @@ TOOLS = [
                 },
                 "agent": {
                     "type": "string",
-                    "description": "Agent type: claude, codex, or gemini. If omitted, uses the bot's current default agent.",
+                    "description": "Agent type: claude, codex, or gemini. If omitted, uses the bot's current effective top-level agent (default agent unless a rescue agent is active under disk pressure).",
                     "enum": ["claude", "codex", "gemini"]
                 },
                 "thread_name": {
@@ -201,8 +201,22 @@ TOOLS = [
         }
     },
     {
+        "name": "rescue_agent",
+        "description": "Show or set the rescue agent automatically used for new top-level sessions under disk pressure. Use agent=off to disable it.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent": {
+                    "type": "string",
+                    "description": "Agent type to use as the rescue agent, or off to disable rescue mode. Omit to read the current setting.",
+                    "enum": ["claude", "codex", "gemini", "off"]
+                }
+            }
+        }
+    },
+    {
         "name": "resume_session",
-        "description": "Resume an existing Claude, Codex, or Gemini session in a new Discord thread. Use list_claude_sessions / list_codex_sessions / list_gemini_sessions to find a session ID. With kind unspecified, the bot tries the current default agent first, then the others.",
+        "description": "Resume an existing Claude, Codex, or Gemini session in a new Discord thread. Use list_claude_sessions / list_codex_sessions / list_gemini_sessions to find a session ID. With kind unspecified, the bot tries the current effective top-level agent first, then the others.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -370,8 +384,17 @@ def handle_tool_call(name, arguments):
         if "error" in result:
             return result["error"]
         agent = result.get("agent", "")
+        effective = result.get("effective_top_level_agent", agent)
+        rescue = result.get("rescue_agent")
+        rescue_active = result.get("disk_rescue_active", False)
         if (arguments or {}).get("agent") is None:
-            return f"Default agent: `{agent}`."
+            parts = [f"Default agent: `{agent}`."]
+            if rescue:
+                suffix = " (active)" if rescue_active else ""
+                parts.append(f"Rescue agent: `{rescue}`{suffix}.")
+            if effective and effective != agent:
+                parts.append(f"Effective top-level agent: `{effective}`.")
+            return " ".join(parts)
         reset_count = result.get("reset_count", 0)
         busy_count = result.get("busy_count", 0)
         parts = [f"Default agent set to `{agent}`."]
@@ -381,6 +404,36 @@ def handle_tool_call(name, arguments):
         if busy_count:
             noun = "session" if busy_count == 1 else "sessions"
             parts.append(f"{busy_count} busy top-level {noun} will switch after queued work finishes.")
+        if rescue_active and effective and effective != agent:
+            parts.append(f"Disk pressure is active, so top-level sessions currently use rescue agent `{effective}`.")
+        return " ".join(parts)
+
+    elif name == "rescue_agent":
+        result = control_request("rescue_agent", arguments)
+        if "error" in result:
+            return result["error"]
+        agent = result.get("agent")
+        effective = result.get("effective_top_level_agent", "")
+        rescue_active = result.get("disk_rescue_active", False)
+        if "agent" not in (arguments or {}):
+            if agent:
+                parts = [f"Rescue agent: `{agent}`."]
+            else:
+                parts = ["Rescue agent: disabled."]
+            if rescue_active and effective:
+                parts.append(f"Disk pressure is active, so top-level sessions currently use `{effective}`.")
+            return " ".join(parts)
+        reset_count = result.get("reset_count", 0)
+        busy_count = result.get("busy_count", 0)
+        parts = [f"Rescue agent set to `{agent}`." if agent else "Rescue agent disabled."]
+        if reset_count:
+            noun = "session" if reset_count == 1 else "sessions"
+            parts.append(f"Reset {reset_count} idle top-level {noun} immediately.")
+        if busy_count:
+            noun = "session" if busy_count == 1 else "sessions"
+            parts.append(f"{busy_count} busy top-level {noun} will switch after queued work finishes.")
+        if rescue_active and effective:
+            parts.append(f"Disk pressure is active, so top-level sessions currently use `{effective}`.")
         return " ".join(parts)
 
     elif name == "restart_bot":

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -227,7 +227,7 @@ TOOLS = [
                 "kind": {
                     "type": "string",
                     "enum": ["claude", "codex", "gemini"],
-                    "description": "Which session store to search. Omit to try the current default agent first, then the others."
+                    "description": "Which session store to search. Omit to try the current effective top-level agent first, then the others."
                 }
             },
             "required": ["session_id"]

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -79,19 +79,24 @@ let set_disk_warning_mode () =
   Discord_agents.Disk_health.For_testing.set_probe_available_bytes
     (fun _path -> Discord_agents.Disk_health.For_testing.mib 96)
 
+let set_disk_read_only_mode () =
+  Discord_agents.Disk_health.For_testing.set_probe_available_bytes
+    (fun _path -> Discord_agents.Disk_health.For_testing.mib 32)
+
 let set_disk_healthy_mode () =
   Discord_agents.Disk_health.For_testing.set_probe_available_bytes
     (fun _path -> Discord_agents.Disk_health.For_testing.mib 512)
 
-let make_session ?(processing=false) ?session_override_kind ?pending_agent_change
-    agent_kind =
+let make_session ?(project_name="control") ?(working_dir="/tmp/project")
+    ?(thread_id="control") ?(processing=false) ?session_override_kind
+    ?pending_agent_change agent_kind =
   let session = Discord_agents.Session_store.make_session
-    ~project_name:"control"
-    ~working_dir:"/tmp/project"
+    ~project_name
+    ~working_dir
     ~agent_kind
     ?session_override_kind
     ~session_id:"session-1"
-    ~thread_id:"control"
+    ~thread_id
     ~system_prompt:(Some "prompt")
     ~initial_prompt:None
     ()
@@ -386,6 +391,76 @@ let test_reconcile_rotates_idle_session_to_default_agent () =
     Alcotest.(check bool) "fresh session id allocated"
       true (saved.session_id <> original_session_id))
 
+let test_best_effort_policy_sync_does_not_raise_in_read_only_mode () =
+  with_test_bot (fun bot ->
+    bot.settings.rescue_agent <- Some Discord_agents.Config.Codex;
+    let session = make_session Discord_agents.Config.Claude in
+    let original_session_id = session.session_id in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    set_disk_read_only_mode ();
+    ignore (Discord_agents.Disk_health.preflight_state_mutation ());
+    Discord_agents.Bot.sync_top_level_agent_policy_best_effort bot;
+    let saved = find_control_session bot in
+    Alcotest.(check string) "agent unchanged after failed best-effort sync"
+      "claude" (kind_string saved.agent_kind);
+    Alcotest.(check string) "session id unchanged"
+      original_session_id saved.session_id)
+
+let test_reconcile_clears_stale_rescue_rotation_after_pressure_clears () =
+  with_test_bot (fun bot ->
+    bot.settings.rescue_agent <- Some Discord_agents.Config.Codex;
+    set_disk_healthy_mode ();
+    let pending = Discord_agents.Session_store.{
+      kind = Discord_agents.Config.Codex;
+      origin = Default_rotation;
+    } in
+    let session =
+      make_session ~pending_agent_change:pending Discord_agents.Config.Claude
+    in
+    let original_session_id = session.session_id in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    Discord_agents.Bot.reconcile_persisted_pending_agent_changes bot;
+    let saved = find_control_session bot in
+    Alcotest.(check string) "agent follows recovered default policy"
+      "claude" (kind_string saved.agent_kind);
+    Alcotest.(check string) "session id unchanged"
+      original_session_id saved.session_id;
+    Alcotest.(check (option string)) "stale rescue rotation cleared"
+      None
+      (Option.map
+         (fun pending -> kind_string pending.Discord_agents.Session_store.kind)
+         saved.pending_agent_change))
+
+let test_reconcile_keeps_rescue_when_persistent_workdir_still_under_pressure () =
+  with_test_bot (fun bot ->
+    bot.settings.rescue_agent <- Some Discord_agents.Config.Codex;
+    let project_dir = make_tmp_dir "discord_agents_low_space_project_" in
+    Fun.protect
+      ~finally:(fun () -> rm_rf project_dir)
+      (fun () ->
+        Discord_agents.Disk_health.For_testing.set_probe_available_bytes
+          (fun path ->
+             if String.equal path project_dir then
+               Discord_agents.Disk_health.For_testing.mib 96
+             else
+               Discord_agents.Disk_health.For_testing.mib 512);
+        let session =
+          make_session
+            ~working_dir:project_dir
+            Discord_agents.Config.Codex
+        in
+        let original_session_id = session.session_id in
+        Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+        Discord_agents.Bot.reconcile_persisted_pending_agent_changes bot;
+        let saved = find_control_session bot in
+        Alcotest.(check string) "effective policy observes workdir pressure"
+          "codex"
+          (kind_string (Discord_agents.Bot.effective_top_level_agent bot));
+        Alcotest.(check string) "agent stays on rescue"
+          "codex" (kind_string saved.agent_kind);
+        Alcotest.(check string) "session id unchanged"
+          original_session_id saved.session_id))
+
 let test_reconcile_applies_persisted_pending_default_rotation () =
   with_test_bot (fun bot ->
     bot.settings.default_agent <- Discord_agents.Config.Codex;
@@ -639,6 +714,12 @@ let () =
         test_reconcile_preserves_idle_session_override;
       Alcotest.test_case "reconcile rotates idle session to default" `Quick
         test_reconcile_rotates_idle_session_to_default_agent;
+      Alcotest.test_case "best-effort policy sync does not raise in read-only mode" `Quick
+        test_best_effort_policy_sync_does_not_raise_in_read_only_mode;
+      Alcotest.test_case "startup reconcile clears stale rescue rotation after pressure clears" `Quick
+        test_reconcile_clears_stale_rescue_rotation_after_pressure_clears;
+      Alcotest.test_case "startup reconcile probes persistent workdir pressure before failback" `Quick
+        test_reconcile_keeps_rescue_when_persistent_workdir_still_under_pressure;
       Alcotest.test_case "reconcile applies persisted default rotation" `Quick
         test_reconcile_applies_persisted_pending_default_rotation;
       Alcotest.test_case "effective top-level agent uses rescue under pressure" `Quick

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -87,9 +87,21 @@ let set_disk_healthy_mode () =
   Discord_agents.Disk_health.For_testing.set_probe_available_bytes
     (fun _path -> Discord_agents.Disk_health.For_testing.mib 512)
 
+let make_project ~name ~path =
+  Discord_agents.Project.{
+    name;
+    path;
+    is_bare = false;
+    remote_url = None;
+  }
+
+let set_projects bot projects =
+  bot.Discord_agents.Bot.project_state <-
+    { bot.Discord_agents.Bot.project_state with projects }
+
 let make_session ?(project_name="control") ?(working_dir="/tmp/project")
     ?(thread_id="control") ?(processing=false) ?session_override_kind
-    ?pending_agent_change agent_kind =
+    ?pending_agent_change ?(system_prompt=Some "prompt") agent_kind =
   let session = Discord_agents.Session_store.make_session
     ~project_name
     ~working_dir
@@ -97,7 +109,7 @@ let make_session ?(project_name="control") ?(working_dir="/tmp/project")
     ?session_override_kind
     ~session_id:"session-1"
     ~thread_id
-    ~system_prompt:(Some "prompt")
+    ~system_prompt
     ~initial_prompt:None
     ()
   in
@@ -142,6 +154,12 @@ let find_control_session bot =
           ~thread_id:"control" with
   | Some session -> session
   | None -> Alcotest.fail "expected a control-channel session"
+
+let find_session bot thread_id =
+  match Discord_agents.Session_store.find_opt bot.Discord_agents.Bot.sessions
+          ~thread_id with
+  | Some session -> session
+  | None -> Alcotest.failf "expected session %s" thread_id
 
 let test_set_default_agent_defers_busy_control_session () =
   with_test_bot (fun bot ->
@@ -461,6 +479,91 @@ let test_reconcile_keeps_rescue_when_persistent_workdir_still_under_pressure () 
         Alcotest.(check string) "session id unchanged"
           original_session_id saved.session_id))
 
+let test_reconcile_rotates_project_session_without_channel_map () =
+  with_test_bot (fun bot ->
+    bot.settings.default_agent <- Discord_agents.Config.Codex;
+    let project_dir = make_tmp_dir "discord_agents_project_session_" in
+    Fun.protect
+      ~finally:(fun () -> rm_rf project_dir)
+      (fun () ->
+        set_projects bot [make_project ~name:"demo" ~path:project_dir];
+        let session =
+          make_session
+            ~project_name:"demo"
+            ~working_dir:project_dir
+            ~thread_id:"project-channel"
+            Discord_agents.Config.Claude
+        in
+        let original_session_id = session.session_id in
+        Discord_agents.Session_store.add bot.sessions
+          ~thread_id:"project-channel" session;
+        Discord_agents.Bot.reconcile_persisted_pending_agent_changes bot;
+        let saved = find_session bot "project-channel" in
+        Alcotest.(check string) "project session rotated"
+          "codex" (kind_string saved.agent_kind);
+        Alcotest.(check bool) "fresh session id allocated"
+          true (saved.session_id <> original_session_id)))
+
+let test_reconcile_does_not_rotate_thread_session_without_channel_map () =
+  with_test_bot (fun bot ->
+    bot.settings.default_agent <- Discord_agents.Config.Codex;
+    let project_dir = make_tmp_dir "discord_agents_thread_session_" in
+    Fun.protect
+      ~finally:(fun () -> rm_rf project_dir)
+      (fun () ->
+        set_projects bot [make_project ~name:"demo" ~path:project_dir];
+        let session =
+          make_session
+            ~project_name:"demo"
+            ~working_dir:project_dir
+            ~thread_id:"thread-1"
+            ~system_prompt:None
+            Discord_agents.Config.Claude
+        in
+        let original_session_id = session.session_id in
+        Discord_agents.Session_store.add bot.sessions
+          ~thread_id:"thread-1" session;
+        Discord_agents.Bot.reconcile_persisted_pending_agent_changes bot;
+        let saved = find_session bot "thread-1" in
+        Alcotest.(check string) "thread session agent preserved"
+          "claude" (kind_string saved.agent_kind);
+        Alcotest.(check string) "session id unchanged"
+          original_session_id saved.session_id))
+
+let test_best_effort_sync_observes_project_workdir_pressure () =
+  with_test_bot (fun bot ->
+    bot.settings.rescue_agent <- Some Discord_agents.Config.Codex;
+    let project_dir = make_tmp_dir "discord_agents_sync_project_pressure_" in
+    Fun.protect
+      ~finally:(fun () -> rm_rf project_dir)
+      (fun () ->
+        set_projects bot [make_project ~name:"demo" ~path:project_dir];
+        Discord_agents.Disk_health.For_testing.set_probe_available_bytes
+          (fun path ->
+             if String.equal path project_dir then
+               Discord_agents.Disk_health.For_testing.mib 96
+             else
+               Discord_agents.Disk_health.For_testing.mib 512);
+        let session =
+          make_session
+            ~project_name:"demo"
+            ~working_dir:project_dir
+            ~thread_id:"project-channel"
+            Discord_agents.Config.Claude
+        in
+        let original_session_id = session.session_id in
+        Discord_agents.Session_store.add bot.sessions
+          ~thread_id:"project-channel" session;
+        Discord_agents.Bot.sync_top_level_agent_policy_best_effort bot;
+        let saved = find_session bot "project-channel" in
+        Alcotest.(check string) "effective policy observes workdir pressure"
+          "codex"
+          (kind_string (Discord_agents.Bot.effective_top_level_agent bot));
+        Alcotest.(check string) "session rotated to rescue"
+          "codex" (kind_string saved.agent_kind);
+        Alcotest.(check bool) "fresh session id allocated"
+          true (saved.session_id <> original_session_id)))
+
 let test_reconcile_applies_persisted_pending_default_rotation () =
   with_test_bot (fun bot ->
     bot.settings.default_agent <- Discord_agents.Config.Codex;
@@ -534,6 +637,27 @@ let test_set_rescue_agent_preserves_idle_session_override_under_pressure () =
         "gemini" (kind_string saved.agent_kind);
       Alcotest.(check string) "session id unchanged"
         original_session_id saved.session_id)
+
+let test_disable_rescue_agent_rotates_idle_session_to_default_under_pressure () =
+  with_test_bot (fun bot ->
+    bot.settings.default_agent <- Discord_agents.Config.Claude;
+    bot.settings.rescue_agent <- Some Discord_agents.Config.Codex;
+    set_disk_warning_mode ();
+    ignore (Discord_agents.Disk_health.preflight_state_mutation ());
+    let session = make_session Discord_agents.Config.Codex in
+    let original_session_id = session.session_id in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    match Discord_agents.Bot.set_rescue_agent bot
+            ~current_channel_id:(Some "control")
+            None with
+    | Error err -> Alcotest.failf "disable rescue agent failed: %s" err
+    | Ok rotation ->
+      Alcotest.(check int) "idle reset count" 1 rotation.reset_count;
+      let saved = find_control_session bot in
+      Alcotest.(check string) "agent rotated to default"
+        "claude" (kind_string saved.agent_kind);
+      Alcotest.(check bool) "fresh session id allocated"
+        true (saved.session_id <> original_session_id))
 
 let test_set_default_agent_under_active_rescue_preserves_rescue_target () =
   with_test_bot (fun bot ->
@@ -720,6 +844,12 @@ let () =
         test_reconcile_clears_stale_rescue_rotation_after_pressure_clears;
       Alcotest.test_case "startup reconcile probes persistent workdir pressure before failback" `Quick
         test_reconcile_keeps_rescue_when_persistent_workdir_still_under_pressure;
+      Alcotest.test_case "startup reconcile rotates project session without channel map" `Quick
+        test_reconcile_rotates_project_session_without_channel_map;
+      Alcotest.test_case "startup reconcile ignores thread session without channel map" `Quick
+        test_reconcile_does_not_rotate_thread_session_without_channel_map;
+      Alcotest.test_case "best-effort sync observes project workdir pressure" `Quick
+        test_best_effort_sync_observes_project_workdir_pressure;
       Alcotest.test_case "reconcile applies persisted default rotation" `Quick
         test_reconcile_applies_persisted_pending_default_rotation;
       Alcotest.test_case "effective top-level agent uses rescue under pressure" `Quick
@@ -728,6 +858,8 @@ let () =
         test_set_rescue_agent_rotates_idle_control_session_under_pressure;
       Alcotest.test_case "set rescue agent preserves idle session override under pressure" `Quick
         test_set_rescue_agent_preserves_idle_session_override_under_pressure;
+      Alcotest.test_case "disable rescue agent rotates idle session to default under pressure" `Quick
+        test_disable_rescue_agent_rotates_idle_session_to_default_under_pressure;
       Alcotest.test_case "set default agent under active rescue preserves rescue target" `Quick
         test_set_default_agent_under_active_rescue_preserves_rescue_target;
       Alcotest.test_case "reconcile rotates idle session to rescue under pressure" `Quick

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -35,8 +35,10 @@ let with_test_bot f =
   with_tmp_home (fun () ->
     Eio_main.run @@ fun env ->
     Eio.Switch.run @@ fun sw ->
+      Discord_agents.Disk_health.For_testing.reset ();
       let settings : Discord_agents.Runtime_settings.t = {
         default_agent = Discord_agents.Config.Claude;
+        rescue_agent = None;
       } in
       let config : Discord_agents.Config.t = {
         Discord_agents.Config.default with
@@ -67,12 +69,18 @@ let with_test_bot f =
         output_lines = Discord_agents.Agent_process.default_output_lines;
         scroll_states = Hashtbl.create 8;
       } in
-      f bot)
+      Fun.protect
+        ~finally:(fun () -> Discord_agents.Disk_health.For_testing.reset ())
+        (fun () -> f bot))
 
 let kind_string = Discord_agents.Config.string_of_agent_kind
 
-let make_session ?(processing=false) ?session_override_kind
-    ?pending_agent_change agent_kind =
+let set_disk_warning_mode () =
+  Discord_agents.Disk_health.For_testing.set_probe_available_bytes
+    (fun _path -> Discord_agents.Disk_health.For_testing.mib 96)
+
+let make_session ?(processing=false) ?session_override_kind ?pending_agent_change
+    agent_kind =
   let session = Discord_agents.Session_store.make_session
     ~project_name:"control"
     ~working_dir:"/tmp/project"
@@ -239,7 +247,7 @@ let test_apply_pending_same_kind_session_override_pins_existing_session () =
     Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
     Discord_agents.Bot.maybe_apply_pending_session_agent_change bot session;
     let saved = find_control_session bot in
-    Alcotest.(check string) "agent unchanged" "codex" (kind_string saved.agent_kind);
+    Alcotest.(check string) "agent stays codex" "codex" (kind_string saved.agent_kind);
     Alcotest.(check (option string)) "session override persisted"
       (Some "codex")
       (Option.map kind_string saved.session_override_kind);
@@ -338,6 +346,93 @@ let test_reconcile_applies_persisted_pending_default_rotation () =
       (Option.map
          (fun pending -> kind_string pending.Discord_agents.Session_store.kind)
          saved.pending_agent_change))
+
+let test_effective_top_level_agent_uses_rescue_under_pressure () =
+  with_test_bot (fun bot ->
+    bot.settings.rescue_agent <- Some Discord_agents.Config.Codex;
+    set_disk_warning_mode ();
+    ignore (Discord_agents.Disk_health.preflight_state_mutation ());
+    Alcotest.(check string) "effective top-level agent"
+      "codex"
+      (kind_string (Discord_agents.Bot.effective_top_level_agent bot)))
+
+let test_set_rescue_agent_rotates_idle_control_session_under_pressure () =
+  with_test_bot (fun bot ->
+    set_disk_warning_mode ();
+    ignore (Discord_agents.Disk_health.preflight_state_mutation ());
+    let session = make_session Discord_agents.Config.Claude in
+    let original_session_id = session.session_id in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    match Discord_agents.Bot.set_rescue_agent bot
+            ~current_channel_id:(Some "control")
+            (Some Discord_agents.Config.Codex) with
+    | Error err -> Alcotest.failf "set_rescue_agent failed: %s" err
+    | Ok rotation ->
+      Alcotest.(check int) "idle reset count" 1 rotation.reset_count;
+      let saved = find_control_session bot in
+      Alcotest.(check string) "agent rotated to rescue"
+        "codex" (kind_string saved.agent_kind);
+      Alcotest.(check bool) "fresh session id allocated"
+        true (saved.session_id <> original_session_id))
+
+let test_set_rescue_agent_preserves_idle_session_override_under_pressure () =
+  with_test_bot (fun bot ->
+    set_disk_warning_mode ();
+    ignore (Discord_agents.Disk_health.preflight_state_mutation ());
+    let session =
+      make_session
+        ~session_override_kind:(Some Discord_agents.Config.Gemini)
+        Discord_agents.Config.Gemini
+    in
+    let original_session_id = session.session_id in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    match Discord_agents.Bot.set_rescue_agent bot
+            ~current_channel_id:(Some "control")
+            (Some Discord_agents.Config.Codex) with
+    | Error err -> Alcotest.failf "set_rescue_agent failed: %s" err
+    | Ok rotation ->
+      Alcotest.(check int) "override reset count" 0 rotation.reset_count;
+      Alcotest.(check (option string)) "current override kind"
+        (Some "gemini")
+        (Option.map kind_string rotation.current_override_kind);
+      let saved = find_control_session bot in
+      Alcotest.(check string) "session override agent preserved"
+        "gemini" (kind_string saved.agent_kind);
+      Alcotest.(check string) "session id unchanged"
+        original_session_id saved.session_id)
+
+let test_set_default_agent_under_active_rescue_preserves_rescue_target () =
+  with_test_bot (fun bot ->
+    bot.settings.rescue_agent <- Some Discord_agents.Config.Codex;
+    set_disk_warning_mode ();
+    ignore (Discord_agents.Disk_health.preflight_state_mutation ());
+    let session = make_session Discord_agents.Config.Claude in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    match Discord_agents.Bot.set_default_agent bot
+            ~current_channel_id:(Some "control")
+            Discord_agents.Config.Gemini with
+    | Error err -> Alcotest.failf "set_default_agent failed: %s" err
+    | Ok rotation ->
+      Alcotest.(check int) "idle reset count" 1 rotation.reset_count;
+      Alcotest.(check string) "default persisted"
+        "gemini" (kind_string bot.settings.default_agent);
+      let saved = find_control_session bot in
+      Alcotest.(check string) "session still uses rescue agent"
+        "codex" (kind_string saved.agent_kind))
+
+let test_reconcile_rotates_idle_session_to_rescue_agent_under_pressure () =
+  with_test_bot (fun bot ->
+    bot.settings.rescue_agent <- Some Discord_agents.Config.Codex;
+    set_disk_warning_mode ();
+    ignore (Discord_agents.Disk_health.preflight_state_mutation ());
+    let session = make_session Discord_agents.Config.Claude in
+    let original_session_id = session.session_id in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    Discord_agents.Bot.reconcile_persisted_pending_agent_changes bot;
+    let saved = find_control_session bot in
+    Alcotest.(check string) "agent rotated" "codex" (kind_string saved.agent_kind);
+    Alcotest.(check bool) "fresh session id allocated"
+      true (saved.session_id <> original_session_id))
 
 let test_stop_idle_session_removes_it () =
   with_test_bot (fun bot ->
@@ -483,6 +578,16 @@ let () =
         test_reconcile_rotates_idle_session_to_default_agent;
       Alcotest.test_case "reconcile applies persisted default rotation" `Quick
         test_reconcile_applies_persisted_pending_default_rotation;
+      Alcotest.test_case "effective top-level agent uses rescue under pressure" `Quick
+        test_effective_top_level_agent_uses_rescue_under_pressure;
+      Alcotest.test_case "set rescue agent rotates idle top-level session under pressure" `Quick
+        test_set_rescue_agent_rotates_idle_control_session_under_pressure;
+      Alcotest.test_case "set rescue agent preserves idle session override under pressure" `Quick
+        test_set_rescue_agent_preserves_idle_session_override_under_pressure;
+      Alcotest.test_case "set default agent under active rescue preserves rescue target" `Quick
+        test_set_default_agent_under_active_rescue_preserves_rescue_target;
+      Alcotest.test_case "reconcile rotates idle session to rescue under pressure" `Quick
+        test_reconcile_rotates_idle_session_to_rescue_agent_under_pressure;
       Alcotest.test_case "stop idle session removes it" `Quick
         test_stop_idle_session_removes_it;
       Alcotest.test_case "stop idle queued session clears and removes it" `Quick

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -79,6 +79,10 @@ let set_disk_warning_mode () =
   Discord_agents.Disk_health.For_testing.set_probe_available_bytes
     (fun _path -> Discord_agents.Disk_health.For_testing.mib 96)
 
+let set_disk_healthy_mode () =
+  Discord_agents.Disk_health.For_testing.set_probe_available_bytes
+    (fun _path -> Discord_agents.Disk_health.For_testing.mib 512)
+
 let make_session ?(processing=false) ?session_override_kind ?pending_agent_change
     agent_kind =
   let session = Discord_agents.Session_store.make_session
@@ -294,6 +298,61 @@ let test_apply_pending_busy_session_leaves_pending_intact () =
     expect_pending saved
       ~kind:Discord_agents.Config.Gemini
       ~origin:Discord_agents.Session_store.Session_override)
+
+let test_finalize_pending_default_rotation_uses_current_policy_after_pressure_clears () =
+  with_test_bot (fun bot ->
+    bot.settings.rescue_agent <- Some Discord_agents.Config.Codex;
+    set_disk_warning_mode ();
+    ignore (Discord_agents.Disk_health.preflight_state_mutation ());
+    let pending = Discord_agents.Session_store.{
+      kind = Discord_agents.Config.Codex;
+      origin = Default_rotation;
+    } in
+    let session =
+      make_session ~processing:true ~pending_agent_change:pending
+        Discord_agents.Config.Claude
+    in
+    let original_session_id = session.session_id in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    set_disk_healthy_mode ();
+    Discord_agents.Bot.finalize_session_run ~notify_stopped:false bot session;
+    let saved = find_control_session bot in
+    Alcotest.(check string) "agent follows recovered default policy"
+      "claude" (kind_string saved.agent_kind);
+    Alcotest.(check string) "session id unchanged"
+      original_session_id saved.session_id;
+    Alcotest.(check (option string)) "stale pending cleared"
+      None
+      (Option.map
+         (fun pending -> kind_string pending.Discord_agents.Session_store.kind)
+         saved.pending_agent_change))
+
+let test_finalize_pending_default_rotation_uses_current_rescue_policy () =
+  with_test_bot (fun bot ->
+    bot.settings.default_agent <- Discord_agents.Config.Gemini;
+    bot.settings.rescue_agent <- Some Discord_agents.Config.Codex;
+    let pending = Discord_agents.Session_store.{
+      kind = Discord_agents.Config.Gemini;
+      origin = Default_rotation;
+    } in
+    let session =
+      make_session ~processing:true ~pending_agent_change:pending
+        Discord_agents.Config.Claude
+    in
+    let original_session_id = session.session_id in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    set_disk_warning_mode ();
+    Discord_agents.Bot.finalize_session_run ~notify_stopped:false bot session;
+    let saved = find_control_session bot in
+    Alcotest.(check string) "agent follows current rescue policy"
+      "codex" (kind_string saved.agent_kind);
+    Alcotest.(check bool) "fresh session id allocated"
+      true (saved.session_id <> original_session_id);
+    Alcotest.(check (option string)) "pending cleared"
+      None
+      (Option.map
+         (fun pending -> kind_string pending.Discord_agents.Session_store.kind)
+         saved.pending_agent_change))
 
 let test_reconcile_preserves_idle_session_override () =
   with_test_bot (fun bot ->
@@ -572,6 +631,10 @@ let () =
         test_apply_pending_same_kind_session_override_pins_existing_session;
       Alcotest.test_case "busy pending change stays pending" `Quick
         test_apply_pending_busy_session_leaves_pending_intact;
+      Alcotest.test_case "default rotation rechecks policy after pressure clears" `Quick
+        test_finalize_pending_default_rotation_uses_current_policy_after_pressure_clears;
+      Alcotest.test_case "default rotation rechecks active rescue policy" `Quick
+        test_finalize_pending_default_rotation_uses_current_rescue_policy;
       Alcotest.test_case "reconcile preserves idle session override" `Quick
         test_reconcile_preserves_idle_session_override;
       Alcotest.test_case "reconcile rotates idle session to default" `Quick

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -682,6 +682,11 @@ let cmd_testable =
       | Default_agent (Some k) ->
         Printf.sprintf "Default_agent(%s)"
           (Discord_agents.Config.string_of_agent_kind k)
+      | Rescue_agent None -> "Rescue_agent"
+      | Rescue_agent (Some None) -> "Rescue_agent(off)"
+      | Rescue_agent (Some (Some k)) ->
+        Printf.sprintf "Rescue_agent(%s)"
+          (Discord_agents.Config.string_of_agent_kind k)
       | Session_agent None -> "Session_agent"
       | Session_agent (Some k) ->
         Printf.sprintf "Session_agent(%s)"
@@ -870,6 +875,34 @@ let test_parse_default_agent_invalid_kind () =
     Alcotest.(check pass) "invalid default agent is Unknown" () ()
   | _ -> Alcotest.fail "expected Unknown for invalid default agent kind"
 
+let test_parse_rescue_agent_no_arg () =
+  Alcotest.(check cmd_testable) "rescue-agent no arg"
+    (Discord_agents.Command.Rescue_agent None)
+    (Discord_agents.Command.parse "!rescue-agent")
+
+let test_parse_rescue_agent_set () =
+  Alcotest.(check cmd_testable) "rescue-agent codex"
+    (Discord_agents.Command.Rescue_agent
+       (Some (Some Discord_agents.Config.Codex)))
+    (Discord_agents.Command.parse "!rescue-agent codex")
+
+let test_parse_rescue_agent_clear () =
+  Alcotest.(check cmd_testable) "rescue-agent off"
+    (Discord_agents.Command.Rescue_agent (Some None))
+    (Discord_agents.Command.parse "!rescue-agent off")
+
+let test_parse_rescue_agent_underscore_alias () =
+  Alcotest.(check cmd_testable) "rescue_agent alias"
+    (Discord_agents.Command.Rescue_agent
+       (Some (Some Discord_agents.Config.Gemini)))
+    (Discord_agents.Command.parse "!rescue_agent gemini")
+
+let test_parse_rescue_agent_invalid_kind () =
+  match Discord_agents.Command.parse "!rescue-agent nonesuch" with
+  | Discord_agents.Command.Unknown _ ->
+    Alcotest.(check pass) "invalid rescue agent is Unknown" () ()
+  | _ -> Alcotest.fail "expected Unknown for invalid rescue agent kind"
+
 let test_parse_session_agent_no_arg () =
   Alcotest.(check cmd_testable) "session-agent no arg"
     (Discord_agents.Command.Session_agent None)
@@ -922,6 +955,11 @@ let command_tests = [
   Alcotest.test_case "default-agent set" `Quick test_parse_default_agent_set;
   Alcotest.test_case "default_agent alias" `Quick test_parse_default_agent_underscore_alias;
   Alcotest.test_case "default-agent invalid kind" `Quick test_parse_default_agent_invalid_kind;
+  Alcotest.test_case "rescue-agent no arg" `Quick test_parse_rescue_agent_no_arg;
+  Alcotest.test_case "rescue-agent set" `Quick test_parse_rescue_agent_set;
+  Alcotest.test_case "rescue-agent clear" `Quick test_parse_rescue_agent_clear;
+  Alcotest.test_case "rescue_agent alias" `Quick test_parse_rescue_agent_underscore_alias;
+  Alcotest.test_case "rescue-agent invalid kind" `Quick test_parse_rescue_agent_invalid_kind;
   Alcotest.test_case "session-agent no arg" `Quick test_parse_session_agent_no_arg;
   Alcotest.test_case "session-agent set" `Quick test_parse_session_agent_set;
   Alcotest.test_case "session_agent alias" `Quick test_parse_session_agent_underscore_alias;
@@ -1644,6 +1682,10 @@ let test_pending_agent_kind_roundtrip () =
           | Discord_agents.Session_store.Session_override -> "session_override")
         s.pending_agent_change
     in
+    let session_override_kind =
+      Option.map Discord_agents.Config.string_of_agent_kind
+        s.session_override_kind
+    in
     Alcotest.(check (option string))
       "session override kind survives roundtrip"
       (Some "gemini")
@@ -1654,7 +1696,10 @@ let test_pending_agent_kind_roundtrip () =
       (Some "codex") pending_kind;
     Alcotest.(check (option string))
       "pending agent origin survives roundtrip"
-      (Some "session_override") pending_origin
+      (Some "session_override") pending_origin;
+    Alcotest.(check (option string))
+      "session override survives roundtrip"
+      (Some "gemini") session_override_kind
   | _ -> Alcotest.fail "expected exactly one session"
 
 let test_legacy_pending_agent_defaults_to_default_rotation () =

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -889,7 +889,13 @@ let test_parse_rescue_agent_set () =
 let test_parse_rescue_agent_clear () =
   Alcotest.(check cmd_testable) "rescue-agent off"
     (Discord_agents.Command.Rescue_agent (Some None))
-    (Discord_agents.Command.parse "!rescue-agent off")
+    (Discord_agents.Command.parse "!rescue-agent off");
+  Alcotest.(check cmd_testable) "rescue-agent Off"
+    (Discord_agents.Command.Rescue_agent (Some None))
+    (Discord_agents.Command.parse "!rescue-agent Off");
+  Alcotest.(check cmd_testable) "rescue-agent NONE"
+    (Discord_agents.Command.Rescue_agent (Some None))
+    (Discord_agents.Command.parse "!rescue-agent NONE")
 
 let test_parse_rescue_agent_underscore_alias () =
   Alcotest.(check cmd_testable) "rescue_agent alias"

--- a/test/test_runtime_settings.ml
+++ b/test/test_runtime_settings.ml
@@ -50,15 +50,22 @@ let test_load_defaults_to_claude () =
     let settings = Discord_agents.Runtime_settings.load () in
     Alcotest.(check string) "default agent"
       "claude"
-      (Discord_agents.Config.string_of_agent_kind settings.default_agent))
+      (Discord_agents.Config.string_of_agent_kind settings.default_agent);
+    Alcotest.(check (option string)) "rescue agent defaults to none"
+      None
+      (Option.map Discord_agents.Config.string_of_agent_kind settings.rescue_agent))
 
 let test_save_and_reload_roundtrip () =
   with_tmp_home (fun home ->
     let settings = Discord_agents.Runtime_settings.load () in
     match Discord_agents.Runtime_settings.set_default_agent
             settings Discord_agents.Config.Codex with
-    | Error err -> Alcotest.failf "save failed: %s" err
+    | Error err -> Alcotest.failf "default save failed: %s" err
     | Ok () ->
+      (match Discord_agents.Runtime_settings.set_rescue_agent
+               settings (Some Discord_agents.Config.Gemini) with
+       | Error err -> Alcotest.failf "rescue save failed: %s" err
+       | Ok () -> ());
       Alcotest.(check bool) "backup exists"
         true (Sys.file_exists (backup_path home));
       Alcotest.(check string) "backup mirrors primary"
@@ -67,7 +74,12 @@ let test_save_and_reload_roundtrip () =
       let reloaded = Discord_agents.Runtime_settings.load () in
       Alcotest.(check string) "saved default agent"
         "codex"
-        (Discord_agents.Config.string_of_agent_kind reloaded.default_agent))
+        (Discord_agents.Config.string_of_agent_kind reloaded.default_agent);
+      Alcotest.(check (option string)) "saved rescue agent"
+        (Some "gemini")
+        (Option.map
+           Discord_agents.Config.string_of_agent_kind
+           reloaded.rescue_agent))
 
 let test_load_uses_backup_when_primary_corrupt () =
   with_tmp_home (fun home ->
@@ -88,6 +100,7 @@ let test_save_with_visible_but_unconfirmed_primary_updates_backup () =
   with_tmp_home (fun home ->
     let settings = Discord_agents.Runtime_settings.load () in
     settings.default_agent <- Discord_agents.Config.Codex;
+    settings.rescue_agent <- Some Discord_agents.Config.Gemini;
     let write_file path content =
       if String.equal path (settings_path home) then
         Discord_agents.Resource.write_file_atomic
@@ -126,6 +139,7 @@ let test_save_refuses_read_only_preflight () =
   with_tmp_home (fun home ->
     let settings = Discord_agents.Runtime_settings.load () in
     settings.default_agent <- Discord_agents.Config.Codex;
+    settings.rescue_agent <- Some Discord_agents.Config.Gemini;
     let write_attempted = ref false in
     let write_file _path _content =
       write_attempted := true;


### PR DESCRIPTION
## Summary
- add a persisted rescue-agent setting plus Discord/MCP control surfaces
- route top-level session creation and resume preference through the effective top-level agent under disk pressure
- preserve explicit `!session-agent` overrides across startup and policy sync, with regression coverage

## Testing
- nix develop --command dune build --build-dir _build_rescue1
- nix develop --command dune runtest --build-dir _build_rescue1

Closes #42