### PR TITLE
fix: make disk policy updates replay-safe

### DIFF
--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -75,6 +75,7 @@ let projects t = t.project_state.projects
 let channels t = t.project_state.channels
 let default_agent t = t.settings.default_agent
 let rescue_agent t = t.settings.rescue_agent
+let policy_sync_pending t = t.settings.policy_sync_pending
 let new_session_block_message () = Disk_health.new_session_block_message ()
 let pending_default_rotation kind =
   Session_store.{ kind; origin = Default_rotation }
@@ -522,134 +523,180 @@ let replace_session_agent t (session : Session_store.session)
   with exn ->
     Error (Printexc.to_string exn)
 
+let replacement_session_for_agent t (session : Session_store.session)
+    ~agent_kind ~session_override_kind =
+  let replacement = {
+    (fresh_session_like session ~agent_kind ~session_override_kind) with
+    system_prompt = refreshed_system_prompt t session;
+  } in
+  replacement
+
 let align_persistent_sessions_to_agent t ~current_channel_id ~new_agent =
-  let clear_redundant_default_rotation thread_id (session : Session_store.session) =
-    if is_persistent_session t ~thread_id session
-       && (Config.equal_agent_kind session.agent_kind new_agent
-           || Option.is_some session.session_override_kind)
-    then
-      match session.pending_agent_change with
-      | Some { origin = Session_store.Default_rotation; _ } ->
-        Session_store.set_pending_agent_change t.sessions session None
-        |> Result.map_error (fun err ->
-          Printf.sprintf
-            "failed to clear a completed default-agent rotation for channel %s: %s"
-            thread_id err)
-      | _ -> Ok ()
-    else
-      Ok ()
-  in
+  let store : Session_store.t = t.sessions in
+  let session_entries = Session_store.bindings store in
   let current_override_kind = ref None in
   (match current_channel_id with
    | Some thread_id ->
-     (match Session_store.find_opt t.sessions ~thread_id with
+     (match Session_store.find_opt store ~thread_id with
       | Some session ->
         current_override_kind := session.session_override_kind
       | None -> ())
    | None -> ());
-  let stale_sessions =
-    Session_store.bindings t.sessions
-    |> List.filter (fun (thread_id, (session : Session_store.session)) ->
-      is_persistent_session t ~thread_id session
-      && Option.is_none session.session_override_kind
-      && not (Config.equal_agent_kind session.agent_kind new_agent))
-  in
   let current_busy_kind = ref None in
   let reset_count = ref 0 in
   let busy_count = ref 0 in
-  let rec clear_redundant = function
-    | [] -> Ok ()
-    | (thread_id, session) :: rest ->
-      (match clear_redundant_default_rotation thread_id session with
-       | Error _ as err -> err
-       | Ok () -> clear_redundant rest)
+  let changed = ref false in
+  let new_sessions = ref store.sessions in
+  let scroll_states_to_clear = ref [] in
+  let rollback_actions = ref [] in
+  let rollback () =
+    List.iter (fun undo -> undo ()) !rollback_actions
   in
-  let rec align = function
-    | [] ->
-      Ok {
-        reset_count = !reset_count;
-        busy_count = !busy_count;
-        current_busy_kind = !current_busy_kind;
-        current_override_kind = !current_override_kind;
-      }
-    | (thread_id, (session : Session_store.session)) :: rest ->
-      if session.processing || not (Queue.is_empty session.pending_queue) then begin
+  let set_pending_agent_change
+      (session : Session_store.session) pending_agent_change =
+    if session.pending_agent_change <> pending_agent_change then begin
+      let prior = session.pending_agent_change in
+      rollback_actions :=
+        (fun () -> session.pending_agent_change <- prior) :: !rollback_actions;
+      session.pending_agent_change <- pending_agent_change;
+      changed := true
+    end
+  in
+  List.iter (fun (thread_id, (session : Session_store.session)) ->
+    if is_persistent_session t ~thread_id session then begin
+      if (Config.equal_agent_kind session.agent_kind new_agent
+          || Option.is_some session.session_override_kind)
+      then
+        (match session.pending_agent_change with
+         | Some { origin = Session_store.Default_rotation; _ } ->
+           set_pending_agent_change session None
+         | _ -> ());
+      if Option.is_none session.session_override_kind
+         && not (Config.equal_agent_kind session.agent_kind new_agent)
+      then if session.processing || not (Queue.is_empty session.pending_queue) then begin
         match session.pending_agent_change with
         | Some { origin = Session_store.Session_override; kind } ->
           (match current_channel_id with
            | Some current_channel_id when thread_id = current_channel_id ->
              current_override_kind := Some kind
-           | _ -> ());
-          align rest
+           | _ -> ())
         | _ ->
           let target = pending_default_rotation new_agent in
-          let scheduled =
-            Session_store.set_pending_agent_change t.sessions session (Some target)
-            |> Result.map_error (fun err ->
-              Printf.sprintf
-                "failed to persist a deferred default-agent rotation for channel %s: %s"
-                thread_id err)
-          in
+          set_pending_agent_change session (Some target);
           (match current_channel_id with
            | Some current_channel_id when thread_id = current_channel_id ->
              current_busy_kind := Some session.agent_kind
            | _ -> ());
-          match scheduled with
-          | Error _ as err -> err
-          | Ok () ->
-            incr busy_count;
-            align rest
-      end else
-        match replace_session_agent t session
-                ~agent_kind:new_agent ~session_override_kind:None with
-        | Error err ->
-          Error (Printf.sprintf
-            "failed to start a fresh %s session for channel %s: %s"
-            (Config.string_of_agent_kind new_agent) thread_id err)
-        | Ok () ->
-          incr reset_count;
-          align rest
+          incr busy_count
+      end else begin
+        let replacement =
+          replacement_session_for_agent t session
+            ~agent_kind:new_agent ~session_override_kind:None
+        in
+        new_sessions :=
+          Session_store.SessionMap.add thread_id replacement !new_sessions;
+        scroll_states_to_clear := thread_id :: !scroll_states_to_clear;
+        changed := true;
+        incr reset_count
+      end
+    end
+  ) session_entries;
+  let rotation = {
+    reset_count = !reset_count;
+    busy_count = !busy_count;
+    current_busy_kind = !current_busy_kind;
+    current_override_kind = !current_override_kind;
+  } in
+  if not !changed then
+    Ok rotation
+  else
+    match Session_store.replace_sessions_with
+            ~rollback store !new_sessions with
+    | Error err ->
+      Error (Printf.sprintf
+        "failed to persist top-level session policy for `%s`: %s"
+        (Config.string_of_agent_kind new_agent) err)
+    | Ok () ->
+      List.iter (Hashtbl.remove t.scroll_states) !scroll_states_to_clear;
+      Ok rotation
+
+let clear_policy_sync_pending t =
+  if policy_sync_pending t then
+    Runtime_settings.set_policy_sync_pending t.settings false
+  else
+    Ok ()
+
+let run_top_level_policy_change t ~current_channel_id
+    ~default_agent ~rescue_agent ~new_agent ~summary ~policy_label =
+  let policy_changed =
+    not (Config.equal_agent_kind t.settings.default_agent default_agent)
+    || not (Option.equal Config.equal_agent_kind
+              t.settings.rescue_agent rescue_agent)
   in
-  match clear_redundant (Session_store.bindings t.sessions) with
-  | Error _ as err -> err
-  | Ok () -> align stale_sessions
+  let must_stage_pending = policy_changed || policy_sync_pending t in
+  let stage_result =
+    if must_stage_pending then
+      Runtime_settings.set_top_level_policy t.settings
+        ~default_agent ~rescue_agent ~policy_sync_pending:true
+    else
+      Ok ()
+  in
+  match stage_result with
+  | Error err ->
+    Error (Printf.sprintf
+      "Failed to persist the pending %s policy state: %s"
+      policy_label err)
+  | Ok () ->
+    (match align_persistent_sessions_to_agent t
+             ~current_channel_id ~new_agent with
+     | Error err ->
+       Error (Printf.sprintf "%s, but top-level session rotation was incomplete: %s"
+         summary err)
+     | Ok rotation ->
+       if must_stage_pending then
+         match clear_policy_sync_pending t with
+         | Ok () -> Ok rotation
+         | Error err ->
+           Error (Printf.sprintf
+             "%s, and top-level sessions were updated, but the policy sync marker could not be cleared: %s"
+             summary err)
+       else
+         Ok rotation)
 
 let set_default_agent t ?(current_channel_id=None) kind =
   refresh_top_level_disk_state t;
-  match Runtime_settings.set_default_agent t.settings kind with
-  | Error err ->
-    Error (Printf.sprintf "Failed to persist the default agent setting: %s" err)
-  | Ok () ->
-    (match align_persistent_sessions_to_agent t
-             ~current_channel_id ~new_agent:(effective_top_level_agent t) with
-     | Ok rotation -> Ok rotation
-     | Error err ->
-       Error (Printf.sprintf
-         "Default agent is now `%s`, but top-level session rotation was incomplete: %s"
-         (Config.string_of_agent_kind kind) err))
+  let simulated_settings : Runtime_settings.t = {
+    t.settings with default_agent = kind;
+  } in
+  run_top_level_policy_change t ~current_channel_id
+    ~default_agent:kind
+    ~rescue_agent:t.settings.rescue_agent
+    ~new_agent:(effective_top_level_agent_from_snapshot
+      simulated_settings (Disk_health.snapshot ()))
+    ~summary:(Printf.sprintf "Default agent is now `%s`"
+      (Config.string_of_agent_kind kind))
+    ~policy_label:"default-agent"
 
 let set_rescue_agent t ?(current_channel_id=None) kind =
   refresh_top_level_disk_state t;
-  match Runtime_settings.set_rescue_agent t.settings kind with
-  | Error err ->
-    Error (Printf.sprintf "Failed to persist the rescue agent setting: %s" err)
-  | Ok () ->
-    let effective = effective_top_level_agent t in
-    let summary =
-      match kind with
-      | Some kind ->
-        Printf.sprintf "Rescue agent is now `%s`"
-          (Config.string_of_agent_kind kind)
-      | None ->
-        "Rescue agent is now disabled"
-    in
-    (match align_persistent_sessions_to_agent t
-             ~current_channel_id ~new_agent:effective with
-     | Ok rotation -> Ok rotation
-     | Error err ->
-       Error (Printf.sprintf
-         "%s, but top-level session rotation was incomplete: %s"
-         summary err))
+  let simulated_settings : Runtime_settings.t = {
+    t.settings with rescue_agent = kind;
+  } in
+  let summary =
+    match kind with
+    | Some kind ->
+      Printf.sprintf "Rescue agent is now `%s`"
+        (Config.string_of_agent_kind kind)
+    | None ->
+      "Rescue agent is now disabled"
+  in
+  run_top_level_policy_change t ~current_channel_id
+    ~default_agent:t.settings.default_agent
+    ~rescue_agent:kind
+    ~new_agent:(effective_top_level_agent_from_snapshot
+      simulated_settings (Disk_health.snapshot ()))
+    ~summary
+    ~policy_label:"rescue-agent"
 
 let maybe_apply_pending_session_agent_change t (session : Session_store.session) =
   match session.pending_agent_change with
@@ -756,10 +803,20 @@ let reconcile_persisted_pending_agent_changes t =
   refresh_top_level_disk_state t;
   Session_store.bindings t.sessions
   |> List.iter (fun (_thread_id, (session : Session_store.session)) ->
-    maybe_apply_pending_session_agent_change t session);
+    match session.pending_agent_change with
+    | Some { origin = Session_store.Session_override; _ } ->
+      maybe_apply_pending_session_agent_change t session
+    | Some { origin = Session_store.Default_rotation; _ }
+    | None -> ());
   match align_persistent_sessions_to_agent t
           ~current_channel_id:None ~new_agent:(effective_top_level_agent t) with
-  | Ok _ -> ()
+  | Ok _ ->
+    (match clear_policy_sync_pending t with
+     | Ok () -> ()
+     | Error err ->
+       Logs.warn (fun m ->
+         m "bot: failed to clear top-level policy sync marker after reconcile: %s"
+           err))
   | Error err ->
     Logs.warn (fun m ->
       m "bot: failed to reconcile top-level default agent sessions: %s" err)
@@ -1657,6 +1714,8 @@ let handle_command t msg cmd =
            | None -> "Rescue agent: disabled");
           Printf.sprintf "Effective top-level agent: %s"
             (Config.string_of_agent_kind (effective_top_level_agent t));
+          Printf.sprintf "Top-level policy sync: %s"
+            (if policy_sync_pending t then "pending" else "clean");
           Disk_health.status_summary ();
           Printf.sprintf "Sessions: %d (%d processing)"
             (Session_store.count t.sessions)
@@ -2008,9 +2067,18 @@ let ensure_channel_session t ~channel_id ~project_name ~working_dir ~system_prom
 
 let sync_top_level_agent_policy t =
   refresh_top_level_disk_state t;
-  align_persistent_sessions_to_agent t
-    ~current_channel_id:None
-    ~new_agent:(effective_top_level_agent t)
+  match align_persistent_sessions_to_agent t
+          ~current_channel_id:None
+          ~new_agent:(effective_top_level_agent t) with
+  | Error _ as err -> err
+  | Ok rotation ->
+    (match clear_policy_sync_pending t with
+     | Ok () -> ()
+     | Error err ->
+       Logs.warn (fun m ->
+         m "bot: failed to clear top-level policy sync marker after runtime sync: %s"
+           err));
+    Ok rotation
 
 let sync_top_level_agent_policy_best_effort t =
   match sync_top_level_agent_policy t with

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -109,6 +109,18 @@ let rescue_agent_notice t =
   | None ->
     None
 
+let reraise_if_fatal_policy_exception exn =
+  match exn with
+  | Eio.Cancel.Cancelled _ -> raise exn
+  | Out_of_memory
+  | Stack_overflow
+  | Sys.Break
+  | Assert_failure _
+  | Match_failure _
+  | Invalid_argument _ ->
+    raise exn
+  | _ -> ()
+
 let refresh_disk_state () =
   ignore (Disk_health.preflight_state_mutation ())
 
@@ -531,7 +543,9 @@ let replacement_session_for_agent t (session : Session_store.session)
   } in
   replacement
 
-let align_persistent_sessions_to_agent t ~current_channel_id ~new_agent =
+let align_persistent_sessions_to_agent
+    ?(replacement_session=replacement_session_for_agent)
+    t ~current_channel_id ~new_agent =
   let store : Session_store.t = t.sessions in
   let session_entries = Session_store.bindings store in
   let current_override_kind = ref None in
@@ -562,63 +576,77 @@ let align_persistent_sessions_to_agent t ~current_channel_id ~new_agent =
       changed := true
     end
   in
-  List.iter (fun (thread_id, (session : Session_store.session)) ->
-    if is_persistent_session t ~thread_id session then begin
-      if (Config.equal_agent_kind session.agent_kind new_agent
-          || Option.is_some session.session_override_kind)
-      then
-        (match session.pending_agent_change with
-         | Some { origin = Session_store.Default_rotation; _ } ->
-           set_pending_agent_change session None
-         | _ -> ());
-      if Option.is_none session.session_override_kind
-         && not (Config.equal_agent_kind session.agent_kind new_agent)
-      then if session.processing || not (Queue.is_empty session.pending_queue) then begin
-        match session.pending_agent_change with
-        | Some { origin = Session_store.Session_override; kind } ->
-          (match current_channel_id with
-           | Some current_channel_id when thread_id = current_channel_id ->
-             current_override_kind := Some kind
-           | _ -> ())
-        | _ ->
-          let target = pending_default_rotation new_agent in
-          set_pending_agent_change session (Some target);
-          (match current_channel_id with
-           | Some current_channel_id when thread_id = current_channel_id ->
-             current_busy_kind := Some session.agent_kind
-           | _ -> ());
-          incr busy_count
-      end else begin
-        let replacement =
-          replacement_session_for_agent t session
-            ~agent_kind:new_agent ~session_override_kind:None
-        in
-        new_sessions :=
-          Session_store.SessionMap.add thread_id replacement !new_sessions;
-        scroll_states_to_clear := thread_id :: !scroll_states_to_clear;
-        changed := true;
-        incr reset_count
-      end
-    end
-  ) session_entries;
-  let rotation = {
-    reset_count = !reset_count;
-    busy_count = !busy_count;
-    current_busy_kind = !current_busy_kind;
-    current_override_kind = !current_override_kind;
-  } in
-  if not !changed then
-    Ok rotation
-  else
-    match Session_store.replace_sessions_with
-            ~rollback store !new_sessions with
-    | Error err ->
+  let prepared =
+    try
+      List.iter (fun (thread_id, (session : Session_store.session)) ->
+        if is_persistent_session t ~thread_id session then begin
+          if (Config.equal_agent_kind session.agent_kind new_agent
+              || Option.is_some session.session_override_kind)
+          then
+            (match session.pending_agent_change with
+             | Some { origin = Session_store.Default_rotation; _ } ->
+               set_pending_agent_change session None
+             | _ -> ());
+          if Option.is_none session.session_override_kind
+             && not (Config.equal_agent_kind session.agent_kind new_agent)
+          then if session.processing || not (Queue.is_empty session.pending_queue) then begin
+            match session.pending_agent_change with
+            | Some { origin = Session_store.Session_override; kind } ->
+              (match current_channel_id with
+               | Some current_channel_id when thread_id = current_channel_id ->
+                 current_override_kind := Some kind
+               | _ -> ())
+            | _ ->
+              let target = pending_default_rotation new_agent in
+              set_pending_agent_change session (Some target);
+              (match current_channel_id with
+               | Some current_channel_id when thread_id = current_channel_id ->
+                 current_busy_kind := Some session.agent_kind
+               | _ -> ());
+              incr busy_count
+          end else begin
+            let replacement =
+              replacement_session t session
+                ~agent_kind:new_agent ~session_override_kind:None
+            in
+            new_sessions :=
+              Session_store.SessionMap.add thread_id replacement !new_sessions;
+            scroll_states_to_clear := thread_id :: !scroll_states_to_clear;
+            changed := true;
+            incr reset_count
+          end
+        end
+      ) session_entries;
+      Ok ()
+    with exn ->
+      reraise_if_fatal_policy_exception exn;
+      rollback ();
       Error (Printf.sprintf
-        "failed to persist top-level session policy for `%s`: %s"
-        (Config.string_of_agent_kind new_agent) err)
-    | Ok () ->
-      List.iter (Hashtbl.remove t.scroll_states) !scroll_states_to_clear;
+        "failed to prepare top-level session policy for `%s`: %s"
+        (Config.string_of_agent_kind new_agent)
+        (Printexc.to_string exn))
+  in
+  match prepared with
+  | Error _ as err -> err
+  | Ok () ->
+    let rotation = {
+      reset_count = !reset_count;
+      busy_count = !busy_count;
+      current_busy_kind = !current_busy_kind;
+      current_override_kind = !current_override_kind;
+    } in
+    if not !changed then
       Ok rotation
+    else
+      match Session_store.replace_sessions_with
+              ~rollback store !new_sessions with
+      | Error err ->
+        Error (Printf.sprintf
+          "failed to persist top-level session policy for `%s`: %s"
+          (Config.string_of_agent_kind new_agent) err)
+      | Ok () ->
+        List.iter (Hashtbl.remove t.scroll_states) !scroll_states_to_clear;
+        Ok rotation
 
 let clear_policy_sync_pending t =
   if policy_sync_pending t then

--- a/lib/channel_manager.ml
+++ b/lib/channel_manager.ml
@@ -16,6 +16,10 @@ let create () = { channels = ChannelMap.empty; category_id = None }
 let category_id t = t.category_id
 let set_category_id t id = t.category_id <- id
 
+(** Record or update a known project channel mapping. *)
+let add t ~project_name ~channel_id =
+  t.channels <- ChannelMap.add project_name channel_id t.channels
+
 (** Find a project's channel ID. *)
 let find t ~project_name =
   ChannelMap.find_opt project_name t.channels

--- a/lib/channel_manager.mli
+++ b/lib/channel_manager.mli
@@ -18,6 +18,9 @@ val category_id : t -> string option
 (** Set the category ID. Used during initial setup. *)
 val set_category_id : t -> string option -> unit
 
+(** Record or update a known project-channel mapping. *)
+val add : t -> project_name:string -> channel_id:string -> unit
+
 (** Find a project's channel ID by project name. *)
 val find : t -> project_name:string -> string option
 

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -199,6 +199,8 @@ let handle_health (bot : Bot.t) =
      `String (Config.string_of_agent_kind bot.settings.default_agent));
     ("effective_top_level_agent",
      `String (Config.string_of_agent_kind effective_top_level_agent));
+    ("top_level_policy_sync_pending",
+     `Bool (Bot.policy_sync_pending bot));
     ("disk_rescue_active",
      `Bool (Bot.rescue_mode_active_from_snapshot bot.settings disk));
     ("sessions", `Int (Session_store.count bot.sessions));
@@ -652,6 +654,8 @@ let handle_default_agent (bot : Bot.t) params =
       ("effective_top_level_agent",
        `String (Config.string_of_agent_kind
          (Bot.effective_top_level_agent_from_snapshot bot.settings disk)));
+      ("top_level_policy_sync_pending",
+       `Bool (Bot.policy_sync_pending bot));
       ("disk_rescue_active",
        `Bool (Bot.rescue_mode_active_from_snapshot bot.settings disk));
     ] @
@@ -667,6 +671,8 @@ let handle_default_agent (bot : Bot.t) params =
          ("agent", `String (Config.string_of_agent_kind kind));
          ("effective_top_level_agent",
           `String (Config.string_of_agent_kind (Bot.effective_top_level_agent bot)));
+         ("top_level_policy_sync_pending",
+          `Bool (Bot.policy_sync_pending bot));
          ("disk_rescue_active", `Bool (Bot.rescue_mode_active bot));
          ("reset_count", `Int rotation.Bot.reset_count);
          ("busy_count", `Int rotation.Bot.busy_count);
@@ -696,6 +702,8 @@ let handle_rescue_agent (bot : Bot.t) params =
     ok_response ([
       ("effective_top_level_agent",
        `String (Config.string_of_agent_kind (Bot.effective_top_level_agent bot)));
+      ("top_level_policy_sync_pending",
+       `Bool (Bot.policy_sync_pending bot));
       ("disk_rescue_active", `Bool (Bot.rescue_mode_active bot));
     ] @
     match bot.settings.rescue_agent with
@@ -713,6 +721,8 @@ let handle_rescue_agent (bot : Bot.t) params =
           | None -> `Null);
          ("effective_top_level_agent",
           `String (Config.string_of_agent_kind (Bot.effective_top_level_agent bot)));
+         ("top_level_policy_sync_pending",
+          `Bool (Bot.policy_sync_pending bot));
          ("disk_rescue_active", `Bool (Bot.rescue_mode_active bot));
          ("reset_count", `Int rotation.Bot.reset_count);
          ("busy_count", `Int rotation.Bot.busy_count);

--- a/lib/resource.ml
+++ b/lib/resource.ml
@@ -79,6 +79,28 @@ let read_file path =
     really_input ic s 0 n;
     Bytes.to_string s)
 
+let file_mtime_opt path =
+  try Some (Unix.stat path).Unix.st_mtime
+  with _ -> None
+
+let next_write_epoch paths =
+  let baseline = Unix.gettimeofday () in
+  let latest =
+    List.fold_left (fun acc path ->
+      match file_mtime_opt path with
+      | Some mtime -> max acc mtime
+      | None -> acc) baseline paths
+  in
+  latest +. 1.0
+
+let stamp_file_mtime path mtime =
+  let atime =
+    match Unix.stat path with
+    | stat -> stat.Unix.st_atime
+    | exception _ -> mtime
+  in
+  Unix.utimes path atime mtime
+
 exception Durable_write_visible_but_unconfirmed of string * exn
 
 (** Retry fsync across EINTR so signals do not turn a completed write

--- a/lib/runtime_settings.ml
+++ b/lib/runtime_settings.ml
@@ -6,6 +6,7 @@
 type t = {
   mutable default_agent : Config.agent_kind;
   mutable rescue_agent : Config.agent_kind option;
+  mutable policy_sync_pending : bool;
 }
 
 let settings_path () =
@@ -17,15 +18,21 @@ let backup_path () = settings_path () ^ ".bak"
 let default () = {
   default_agent = Config.Claude;
   rescue_agent = None;
+  policy_sync_pending = false;
 }
 
 let to_yojson t =
-  `Assoc ([
+  [
     ("default_agent", Config.yojson_of_agent_kind t.default_agent)
   ] @
-  match t.rescue_agent with
-  | Some agent -> [("rescue_agent", Config.yojson_of_agent_kind agent)]
-  | None -> [])
+  (match t.rescue_agent with
+   | Some agent -> [("rescue_agent", Config.yojson_of_agent_kind agent)]
+   | None -> [])
+  |> fun fields ->
+  if t.policy_sync_pending then
+    `Assoc (fields @ [("policy_sync_pending", `Bool true)])
+  else
+    `Assoc fields
 
 let of_yojson = function
   | `Assoc fields ->
@@ -43,12 +50,32 @@ let of_yojson = function
         Some (Config.agent_kind_of_yojson json)
       | Some _ -> failwith "rescue_agent: expected string or null"
     in
-    { default_agent; rescue_agent }
+    let policy_sync_pending =
+      match List.assoc_opt "policy_sync_pending" fields with
+      | Some (`Bool b) -> b
+      | Some _ -> failwith "policy_sync_pending: expected bool"
+      | None -> false
+    in
+    { default_agent; rescue_agent; policy_sync_pending }
   | _ -> failwith "runtime settings: expected object"
 
 let load_file path =
   let contents = Resource.read_file path in
   of_yojson (Yojson.Safe.from_string contents)
+
+let file_mtime path =
+  try Some (Unix.stat path).Unix.st_mtime
+  with _ -> None
+
+let backup_is_stale ~primary ~backup =
+  match file_mtime primary, file_mtime backup with
+  (* A primary that is definitely newer than the backup means we
+     observed a later primary publish without a matching backup
+     refresh, so recovering from the backup would resurrect older
+     policy state. Equal mtimes are still accepted: successful saves
+     stamp both files to the same epoch. *)
+  | Some primary_mtime, Some backup_mtime -> backup_mtime < primary_mtime
+  | _ -> false
 
 let load () =
   let path = settings_path () in
@@ -73,16 +100,22 @@ let load () =
       Logs.warn (fun m ->
         m "runtime_settings: load error from %s: %s"
           path (Printexc.to_string exn));
-      (match load_file backup with
-       | settings ->
-         Logs.warn (fun m ->
-           m "runtime_settings: recovered from backup %s" backup);
-         settings
-       | exception backup_exn ->
-         Logs.warn (fun m ->
-           m "runtime_settings: backup load error from %s: %s"
-             backup (Printexc.to_string backup_exn));
+      if backup_is_stale ~primary:path ~backup then (
+        Logs.warn (fun m ->
+          m "runtime_settings: refusing stale backup %s because it predates unreadable primary %s"
+            backup path);
         default ())
+      else
+        (match load_file backup with
+         | settings ->
+           Logs.warn (fun m ->
+             m "runtime_settings: recovered from backup %s" backup);
+           settings
+         | exception backup_exn ->
+           Logs.warn (fun m ->
+             m "runtime_settings: backup load error from %s: %s"
+               backup (Printexc.to_string backup_exn));
+          default ())
 
 let log_visible_but_unconfirmed path exn =
   Logs.warn (fun m ->
@@ -102,25 +135,50 @@ let save_with
   | Error err -> Error err
   | Ok () ->
     let saw_disk_issue = ref false in
+    let stamp_write_epoch target write_epoch =
+      try Resource.stamp_file_mtime target write_epoch with
+      | exn ->
+        Logs.warn (fun m ->
+          m "runtime_settings: failed to stamp write epoch on %s: %s"
+            target (Printexc.to_string exn))
+    in
     (try
        Resource.with_flock (lock_path ()) (fun () ->
          Resource.cleanup_atomic_write_temps path;
          Resource.cleanup_atomic_write_temps backup;
-         (try write_file path rendered with
-          | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
-            saw_disk_issue := true;
-            note_write_failure path exn;
-            primary_warning := Some (path, exn));
-         (try write_file backup rendered with
-          | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
-            saw_disk_issue := true;
-            note_write_failure path exn;
-            log_visible_but_unconfirmed path exn
-          | exn ->
-            note_write_failure backup exn;
-            Logs.warn (fun m ->
-              m "runtime_settings: failed to update backup %s: %s"
-                backup (Printexc.to_string exn))));
+         let write_epoch = Resource.next_write_epoch [path; backup] in
+         let wrote_primary =
+           try
+             write_file path rendered;
+             true
+           with
+           | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
+             saw_disk_issue := true;
+             note_write_failure path exn;
+             primary_warning := Some (path, exn);
+             true
+         in
+         if wrote_primary then
+           stamp_write_epoch path write_epoch;
+         let wrote_backup =
+           try
+             write_file backup rendered;
+             true
+           with
+           | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
+             saw_disk_issue := true;
+             note_write_failure path exn;
+             log_visible_but_unconfirmed path exn;
+             true
+           | exn ->
+             note_write_failure backup exn;
+             Logs.warn (fun m ->
+               m "runtime_settings: failed to update backup %s: %s"
+                 backup (Printexc.to_string exn));
+             false
+         in
+         if wrote_backup then
+           stamp_write_epoch backup write_epoch);
        Option.iter (fun (path, exn) ->
          log_visible_but_unconfirmed path exn) !primary_warning;
        if not !saw_disk_issue then
@@ -134,32 +192,50 @@ let save t =
   save_with ~write_file:(fun path rendered ->
     Resource.write_file_atomic path rendered) t
 
-let set_default_agent t agent =
-  if Config.equal_agent_kind t.default_agent agent then
+let persist_snapshot t next =
+  if Config.equal_agent_kind t.default_agent next.default_agent
+     && Option.equal Config.equal_agent_kind t.rescue_agent next.rescue_agent
+     && Bool.equal t.policy_sync_pending next.policy_sync_pending
+  then
     Ok ()
   else
-    let next = {
-      default_agent = agent;
-      rescue_agent = t.rescue_agent;
-    } in
     match save next with
     | Ok () as ok ->
-      t.default_agent <- agent;
+      t.default_agent <- next.default_agent;
+      t.rescue_agent <- next.rescue_agent;
+      t.policy_sync_pending <- next.policy_sync_pending;
       ok
     | Error _ as err ->
       err
 
+let set_default_agent t agent =
+  let next = {
+    default_agent = agent;
+    rescue_agent = t.rescue_agent;
+    policy_sync_pending = t.policy_sync_pending;
+  } in
+  persist_snapshot t next
+
 let set_rescue_agent t agent =
-  if Option.equal Config.equal_agent_kind t.rescue_agent agent then
-    Ok ()
-  else
-    let next = {
-      default_agent = t.default_agent;
-      rescue_agent = agent;
-    } in
-    match save next with
-    | Ok () as ok ->
-      t.rescue_agent <- agent;
-      ok
-    | Error _ as err ->
-      err
+  let next = {
+    default_agent = t.default_agent;
+    rescue_agent = agent;
+    policy_sync_pending = t.policy_sync_pending;
+  } in
+  persist_snapshot t next
+
+let set_policy_sync_pending t pending =
+  let next = {
+    default_agent = t.default_agent;
+    rescue_agent = t.rescue_agent;
+    policy_sync_pending = pending;
+  } in
+  persist_snapshot t next
+
+let set_top_level_policy t ~default_agent ~rescue_agent ~policy_sync_pending =
+  let next = {
+    default_agent;
+    rescue_agent;
+    policy_sync_pending;
+  } in
+  persist_snapshot t next

--- a/lib/session_store.ml
+++ b/lib/session_store.ml
@@ -198,25 +198,50 @@ let save_with
     failwith err
   | Ok () ->
     let saw_disk_issue = ref false in
+    let stamp_write_epoch target write_epoch =
+      try Resource.stamp_file_mtime target write_epoch with
+      | exn ->
+        Logs.warn (fun m ->
+          m "session_store: failed to stamp write epoch on %s: %s"
+            target (Printexc.to_string exn))
+    in
     (try
        Resource.with_flock (lock_file ()) (fun () ->
          Resource.cleanup_atomic_write_temps path;
          Resource.cleanup_atomic_write_temps backup;
-         (try write_file path rendered with
-          | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
-            saw_disk_issue := true;
-            note_write_failure path exn;
-            primary_warning := Some (path, exn));
-         (try write_file backup rendered with
-          | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
-            saw_disk_issue := true;
-            note_write_failure path exn;
-            log_visible_but_unconfirmed path exn
-          | exn ->
-            note_write_failure backup exn;
-            Logs.warn (fun m ->
-              m "session_store: failed to update backup %s: %s"
-                backup (Printexc.to_string exn))));
+         let write_epoch = Resource.next_write_epoch [path; backup] in
+         let wrote_primary =
+           try
+             write_file path rendered;
+             true
+           with
+           | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
+             saw_disk_issue := true;
+             note_write_failure path exn;
+             primary_warning := Some (path, exn);
+             true
+         in
+         if wrote_primary then
+           stamp_write_epoch path write_epoch;
+         let wrote_backup =
+           try
+             write_file backup rendered;
+             true
+           with
+           | Resource.Durable_write_visible_but_unconfirmed (path, exn) ->
+             saw_disk_issue := true;
+             note_write_failure path exn;
+             log_visible_but_unconfirmed path exn;
+             true
+           | exn ->
+             note_write_failure backup exn;
+             Logs.warn (fun m ->
+               m "session_store: failed to update backup %s: %s"
+                 backup (Printexc.to_string exn));
+             false
+         in
+         if wrote_backup then
+           stamp_write_epoch backup write_epoch);
        Option.iter (fun (path, exn) ->
          log_visible_but_unconfirmed path exn) !primary_warning;
        if not !saw_disk_issue then
@@ -232,6 +257,19 @@ let save t =
 let load_file path =
   let contents = Resource.read_file path in
   sessions_of_json (Yojson.Safe.from_string contents)
+
+let file_mtime path =
+  try Some (Unix.stat path).Unix.st_mtime
+  with _ -> None
+
+let backup_is_stale ~primary ~backup =
+  match file_mtime primary, file_mtime backup with
+  (* A newer primary with an older backup means the latest primary
+     publish never made it to the backup, so replaying the backup
+     would resurrect older session state. Equal mtimes are accepted
+     because successful saves stamp both files to the same epoch. *)
+  | Some primary_mtime, Some backup_mtime -> backup_mtime < primary_mtime
+  | _ -> false
 
 (** Load sessions from disk. *)
 let load_from_disk () =
@@ -257,16 +295,22 @@ let load_from_disk () =
        Logs.warn (fun m ->
          m "session_store: load error from %s: %s"
            path (Printexc.to_string exn));
-       (match load_file backup with
-        | sessions ->
-          Logs.warn (fun m ->
-            m "session_store: recovered from backup %s" backup);
-          sessions
-        | exception backup_exn ->
-          Logs.warn (fun m ->
-            m "session_store: backup load error from %s: %s"
-              backup (Printexc.to_string backup_exn));
-          SessionMap.empty))
+       if backup_is_stale ~primary:path ~backup then (
+         Logs.warn (fun m ->
+           m "session_store: refusing stale backup %s because it predates unreadable primary %s"
+             backup path);
+         SessionMap.empty)
+       else
+         (match load_file backup with
+          | sessions ->
+            Logs.warn (fun m ->
+              m "session_store: recovered from backup %s" backup);
+            sessions
+          | exception backup_exn ->
+            Logs.warn (fun m ->
+              m "session_store: backup load error from %s: %s"
+                backup (Printexc.to_string backup_exn));
+            SessionMap.empty))
 
 (** Create a session store, loading persisted sessions from disk. *)
 let create () =
@@ -308,6 +352,15 @@ let add t ~(thread_id : Discord_types.channel_id) session =
   match persist_or_rollback (fun () -> t.sessions <- prior) (fun () -> save t) with
   | Ok () -> ()
   | Error err -> failwith err
+
+let replace_sessions_with ?(rollback=(fun () -> ())) t sessions =
+  let prior = t.sessions in
+  t.sessions <- sessions;
+  persist_or_rollback
+    (fun () ->
+      t.sessions <- prior;
+      rollback ())
+    (fun () -> save t)
 
 (** Remove a session and persist to disk. *)
 let remove t ~(thread_id : Discord_types.channel_id) =

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -665,6 +665,111 @@ let test_set_default_agent_rolls_back_pending_rotation_when_session_save_fails (
            (fun pending -> kind_string pending.Discord_agents.Session_store.kind)
            saved.pending_agent_change))
 
+let test_align_rolls_back_in_memory_mutations_when_replacement_raises () =
+  with_test_bot (fun bot ->
+    let busy = make_session ~processing:true Discord_agents.Config.Claude in
+    let idle =
+      make_session ~project_name:"proj" ~thread_id:"project-thread"
+        Discord_agents.Config.Claude
+    in
+    Discord_agents.Channel_manager.add
+      bot.project_state.channels
+      ~project_name:"proj"
+      ~channel_id:"project-thread";
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" busy;
+    Discord_agents.Session_store.add
+      bot.sessions ~thread_id:"project-thread" idle;
+    let saw_busy_pending_before_failure = ref false in
+    let replacement_session _t (session : Discord_agents.Session_store.session)
+        ~agent_kind:_ ~session_override_kind:_ =
+      if String.equal session.thread_id "project-thread" then
+        (saw_busy_pending_before_failure :=
+           Option.is_some busy.pending_agent_change;
+        failwith "simulated replacement failure"
+        )
+      else
+        session
+    in
+    match Discord_agents.Bot.align_persistent_sessions_to_agent
+            ~replacement_session
+            bot ~current_channel_id:(Some "control")
+            ~new_agent:Discord_agents.Config.Codex with
+    | Ok _ ->
+      Alcotest.fail "align_persistent_sessions_to_agent unexpectedly succeeded"
+    | Error _ ->
+      Alcotest.(check bool) "busy mutation happened before failure"
+        true !saw_busy_pending_before_failure;
+      let saved_busy = find_control_session bot in
+      Alcotest.(check string) "busy session agent unchanged"
+        "claude" (kind_string saved_busy.agent_kind);
+      Alcotest.(check (option string)) "busy pending rolled back"
+        None
+        (Option.map
+           (fun pending -> kind_string pending.Discord_agents.Session_store.kind)
+           saved_busy.pending_agent_change);
+      match Discord_agents.Session_store.find_opt bot.sessions
+              ~thread_id:"project-thread" with
+      | None -> Alcotest.fail "expected project-thread session"
+      | Some saved_idle ->
+        Alcotest.(check string) "idle session unchanged"
+          "claude" (kind_string saved_idle.agent_kind))
+
+let test_align_reraises_fatal_replacement_exception () =
+  with_test_bot (fun bot ->
+    let session = make_session Discord_agents.Config.Claude in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    let replacement_session _t (_session : Discord_agents.Session_store.session)
+        ~agent_kind:_ ~session_override_kind:_ =
+      assert false
+    in
+    try
+      ignore (Discord_agents.Bot.align_persistent_sessions_to_agent
+        ~replacement_session
+        bot ~current_channel_id:(Some "control")
+        ~new_agent:Discord_agents.Config.Codex);
+      Alcotest.fail "expected Assert_failure"
+    with
+    | Assert_failure _ -> ())
+
+let test_align_rolls_back_cleared_pending_rotation_when_replacement_raises () =
+  with_test_bot (fun bot ->
+    let pending = Discord_agents.Session_store.{
+      kind = Discord_agents.Config.Codex;
+      origin = Default_rotation;
+    } in
+    let control =
+      make_session ~pending_agent_change:pending Discord_agents.Config.Codex
+    in
+    let idle =
+      make_session ~project_name:"proj" ~thread_id:"project-thread"
+        Discord_agents.Config.Claude
+    in
+    Discord_agents.Channel_manager.add
+      bot.project_state.channels
+      ~project_name:"proj"
+      ~channel_id:"project-thread";
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" control;
+    Discord_agents.Session_store.add
+      bot.sessions ~thread_id:"project-thread" idle;
+    let replacement_session _t (session : Discord_agents.Session_store.session)
+        ~agent_kind:_ ~session_override_kind:_ =
+      if String.equal session.thread_id "project-thread" then
+        failwith "simulated replacement failure"
+      else
+        session
+    in
+    match Discord_agents.Bot.align_persistent_sessions_to_agent
+            ~replacement_session
+            bot ~current_channel_id:None
+            ~new_agent:Discord_agents.Config.Codex with
+    | Ok _ ->
+      Alcotest.fail "align_persistent_sessions_to_agent unexpectedly succeeded"
+    | Error _ ->
+      let saved = find_control_session bot in
+      expect_pending saved
+        ~kind:Discord_agents.Config.Codex
+        ~origin:Discord_agents.Session_store.Default_rotation)
+
 let test_set_rescue_agent_preserves_idle_session_override_under_pressure () =
   with_test_bot (fun bot ->
     set_disk_warning_mode ();
@@ -873,6 +978,12 @@ let () =
         test_set_default_agent_defers_busy_control_session;
       Alcotest.test_case "default rotation rollback restores session state on save failure" `Quick
         test_set_default_agent_rolls_back_pending_rotation_when_session_save_fails;
+      Alcotest.test_case "alignment rollback restores in-memory mutations on replacement failure" `Quick
+        test_align_rolls_back_in_memory_mutations_when_replacement_raises;
+      Alcotest.test_case "alignment rollback restores cleared pending rotation on replacement failure" `Quick
+        test_align_rolls_back_cleared_pending_rotation_when_replacement_raises;
+      Alcotest.test_case "alignment reraises fatal replacement exceptions" `Quick
+        test_align_reraises_fatal_replacement_exception;
       Alcotest.test_case "explicit session override survives default rotation" `Quick
         test_set_default_agent_preserves_explicit_session_override;
       Alcotest.test_case "completed default rotation gets cleared" `Quick

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -39,6 +39,7 @@ let with_test_bot f =
       let settings : Discord_agents.Runtime_settings.t = {
         default_agent = Discord_agents.Config.Claude;
         rescue_agent = None;
+        policy_sync_pending = false;
       } in
       let config : Discord_agents.Config.t = {
         Discord_agents.Config.default with
@@ -172,6 +173,11 @@ let test_set_default_agent_defers_busy_control_session () =
     | Ok rotation ->
       Alcotest.(check int) "reset count" 0 rotation.reset_count;
       Alcotest.(check int) "busy count" 1 rotation.busy_count;
+      Alcotest.(check bool) "policy sync completed"
+        false bot.settings.policy_sync_pending;
+      let persisted = Discord_agents.Runtime_settings.load () in
+      Alcotest.(check bool) "persisted policy sync completed"
+        false persisted.policy_sync_pending;
       (match rotation.current_busy_kind with
        | Some kind ->
          Alcotest.(check string) "current busy kind"
@@ -399,13 +405,23 @@ let test_reconcile_preserves_idle_session_override () =
 
 let test_reconcile_rotates_idle_session_to_default_agent () =
   with_test_bot (fun bot ->
-    bot.settings.default_agent <- Discord_agents.Config.Codex;
+    (match Discord_agents.Runtime_settings.set_top_level_policy bot.settings
+             ~default_agent:Discord_agents.Config.Codex
+             ~rescue_agent:None
+             ~policy_sync_pending:true with
+     | Error err -> Alcotest.failf "set_top_level_policy failed: %s" err
+     | Ok () -> ());
     let session = make_session Discord_agents.Config.Claude in
     let original_session_id = session.session_id in
     Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
     Discord_agents.Bot.reconcile_persisted_pending_agent_changes bot;
     let saved = find_control_session bot in
     Alcotest.(check string) "agent rotated" "codex" (kind_string saved.agent_kind);
+    Alcotest.(check bool) "policy sync cleared"
+      false bot.settings.policy_sync_pending;
+    let persisted = Discord_agents.Runtime_settings.load () in
+    Alcotest.(check bool) "persisted policy sync cleared"
+      false persisted.policy_sync_pending;
     Alcotest.(check bool) "fresh session id allocated"
       true (saved.session_id <> original_session_id))
 
@@ -606,11 +622,48 @@ let test_set_rescue_agent_rotates_idle_control_session_under_pressure () =
     | Error err -> Alcotest.failf "set_rescue_agent failed: %s" err
     | Ok rotation ->
       Alcotest.(check int) "idle reset count" 1 rotation.reset_count;
+      Alcotest.(check bool) "policy sync completed"
+        false bot.settings.policy_sync_pending;
+      let persisted = Discord_agents.Runtime_settings.load () in
+      Alcotest.(check bool) "persisted policy sync completed"
+        false persisted.policy_sync_pending;
       let saved = find_control_session bot in
       Alcotest.(check string) "agent rotated to rescue"
         "codex" (kind_string saved.agent_kind);
       Alcotest.(check bool) "fresh session id allocated"
         true (saved.session_id <> original_session_id))
+
+let test_set_default_agent_rolls_back_pending_rotation_when_session_save_fails () =
+  with_test_bot (fun bot ->
+    let session = make_session ~processing:true Discord_agents.Config.Claude in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    let sessions_path = Discord_agents.Session_store.sessions_file () in
+    Sys.remove sessions_path;
+    Unix.mkdir sessions_path 0o700;
+    match Discord_agents.Bot.set_default_agent bot
+            ~current_channel_id:(Some "control")
+            Discord_agents.Config.Codex with
+    | Ok _ ->
+      Alcotest.fail "set_default_agent unexpectedly succeeded"
+    | Error _ ->
+      Alcotest.(check string) "staged default agent persisted"
+        "codex" (kind_string bot.settings.default_agent);
+      Alcotest.(check bool) "policy sync left pending"
+        true bot.settings.policy_sync_pending;
+      let persisted = Discord_agents.Runtime_settings.load () in
+      Alcotest.(check string) "persisted default agent"
+        "codex"
+        (Discord_agents.Config.string_of_agent_kind persisted.default_agent);
+      Alcotest.(check bool) "persisted policy sync pending"
+        true persisted.policy_sync_pending;
+      let saved = find_control_session bot in
+      Alcotest.(check string) "session agent rolled back"
+        "claude" (kind_string saved.agent_kind);
+      Alcotest.(check (option string)) "pending change rolled back"
+        None
+        (Option.map
+           (fun pending -> kind_string pending.Discord_agents.Session_store.kind)
+           saved.pending_agent_change))
 
 let test_set_rescue_agent_preserves_idle_session_override_under_pressure () =
   with_test_bot (fun bot ->
@@ -818,6 +871,8 @@ let () =
     ("default agent", [
       Alcotest.test_case "busy control session defers default rotation" `Quick
         test_set_default_agent_defers_busy_control_session;
+      Alcotest.test_case "default rotation rollback restores session state on save failure" `Quick
+        test_set_default_agent_rolls_back_pending_rotation_when_session_save_fails;
       Alcotest.test_case "explicit session override survives default rotation" `Quick
         test_set_default_agent_preserves_explicit_session_override;
       Alcotest.test_case "completed default rotation gets cleared" `Quick

--- a/test/test_runtime_settings.ml
+++ b/test/test_runtime_settings.ml
@@ -53,7 +53,9 @@ let test_load_defaults_to_claude () =
       (Discord_agents.Config.string_of_agent_kind settings.default_agent);
     Alcotest.(check (option string)) "rescue agent defaults to none"
       None
-      (Option.map Discord_agents.Config.string_of_agent_kind settings.rescue_agent))
+      (Option.map Discord_agents.Config.string_of_agent_kind settings.rescue_agent);
+    Alcotest.(check bool) "policy sync defaults clean"
+      false settings.policy_sync_pending)
 
 let test_save_and_reload_roundtrip () =
   with_tmp_home (fun home ->
@@ -65,6 +67,9 @@ let test_save_and_reload_roundtrip () =
       (match Discord_agents.Runtime_settings.set_rescue_agent
                settings (Some Discord_agents.Config.Gemini) with
        | Error err -> Alcotest.failf "rescue save failed: %s" err
+       | Ok () -> ());
+      (match Discord_agents.Runtime_settings.set_policy_sync_pending settings true with
+       | Error err -> Alcotest.failf "pending save failed: %s" err
        | Ok () -> ());
       Alcotest.(check bool) "backup exists"
         true (Sys.file_exists (backup_path home));
@@ -79,7 +84,9 @@ let test_save_and_reload_roundtrip () =
         (Some "gemini")
         (Option.map
            Discord_agents.Config.string_of_agent_kind
-           reloaded.rescue_agent))
+           reloaded.rescue_agent);
+      Alcotest.(check bool) "saved pending policy flag"
+        true reloaded.policy_sync_pending)
 
 let test_load_uses_backup_when_primary_corrupt () =
   with_tmp_home (fun home ->
@@ -91,6 +98,11 @@ let test_load_uses_backup_when_primary_corrupt () =
       let oc = open_out (settings_path home) in
       output_string oc "{ definitely not json";
       close_out oc;
+      let backup_stat = Unix.stat (backup_path home) in
+      Unix.utimes
+        (settings_path home)
+        backup_stat.Unix.st_atime
+        backup_stat.Unix.st_mtime;
       let recovered = Discord_agents.Runtime_settings.load () in
       Alcotest.(check string) "recovered default agent"
         "codex"
@@ -120,6 +132,83 @@ let test_save_with_visible_but_unconfirmed_primary_updates_backup () =
       Alcotest.(check string) "reloaded default agent"
         "codex"
         (Discord_agents.Config.string_of_agent_kind recovered.default_agent))
+
+let test_save_marks_primary_newer_when_backup_update_fails () =
+  with_tmp_home (fun home ->
+    let settings = Discord_agents.Runtime_settings.load () in
+    match Discord_agents.Runtime_settings.set_default_agent
+            settings Discord_agents.Config.Codex with
+    | Error err -> Alcotest.failf "initial save failed: %s" err
+    | Ok () ->
+      settings.default_agent <- Discord_agents.Config.Gemini;
+      let write_file path content =
+        if String.equal path (backup_path home) then
+          failwith "backup write failed"
+        else
+          Discord_agents.Resource.write_file_atomic path content
+      in
+      (match Discord_agents.Runtime_settings.save_with ~write_file settings with
+       | Error err -> Alcotest.failf "save_with failed: %s" err
+       | Ok () -> ());
+      let primary_stat = Unix.stat (settings_path home) in
+      let backup_stat = Unix.stat (backup_path home) in
+      Alcotest.(check bool) "primary stamped newer than stale backup"
+        true (primary_stat.Unix.st_mtime > backup_stat.Unix.st_mtime))
+
+let test_set_top_level_policy_failure_leaves_settings_unchanged () =
+  with_tmp_home (fun home ->
+    let settings = Discord_agents.Runtime_settings.load () in
+    Discord_agents.Resource.ensure_parent_dir (settings_path home);
+    Unix.mkdir (settings_path home) 0o700;
+    match Discord_agents.Runtime_settings.set_top_level_policy settings
+            ~default_agent:Discord_agents.Config.Codex
+            ~rescue_agent:(Some Discord_agents.Config.Gemini)
+            ~policy_sync_pending:true with
+    | Ok () ->
+      Alcotest.fail "set_top_level_policy unexpectedly succeeded"
+    | Error _ ->
+      Alcotest.(check string) "default agent unchanged"
+        "claude"
+        (Discord_agents.Config.string_of_agent_kind settings.default_agent);
+      Alcotest.(check (option string)) "rescue agent unchanged"
+        None
+        (Option.map
+           Discord_agents.Config.string_of_agent_kind
+           settings.rescue_agent);
+      Alcotest.(check bool) "policy sync unchanged"
+        false settings.policy_sync_pending)
+
+let test_load_ignores_stale_backup_when_primary_is_newer_and_corrupt () =
+  with_tmp_home (fun home ->
+    let settings = Discord_agents.Runtime_settings.load () in
+    match Discord_agents.Runtime_settings.set_default_agent
+            settings Discord_agents.Config.Codex with
+    | Error err -> Alcotest.failf "initial save failed: %s" err
+    | Ok () ->
+      settings.default_agent <- Discord_agents.Config.Gemini;
+      let write_file path content =
+        if String.equal path (backup_path home) then
+          failwith "backup write failed"
+        else
+          Discord_agents.Resource.write_file_atomic path content
+      in
+      (match Discord_agents.Runtime_settings.save_with ~write_file settings with
+       | Error err -> Alcotest.failf "save_with failed: %s" err
+       | Ok () -> ());
+      let oc = open_out (settings_path home) in
+      output_string oc "{ definitely not json";
+      close_out oc;
+      let backup_stat = Unix.stat (backup_path home) in
+      Unix.utimes
+        (settings_path home)
+        backup_stat.Unix.st_atime
+        (backup_stat.Unix.st_mtime +. 10.0);
+      let recovered = Discord_agents.Runtime_settings.load () in
+      Alcotest.(check string) "stale backup ignored"
+        "claude"
+        (Discord_agents.Config.string_of_agent_kind recovered.default_agent);
+      Alcotest.(check bool) "pending policy defaults clean after stale backup"
+        false recovered.policy_sync_pending)
 
 let test_save_reaps_stale_atomic_write_temps () =
   with_tmp_home (fun home ->
@@ -210,6 +299,12 @@ let () =
         test_load_uses_backup_when_primary_corrupt;
       Alcotest.test_case "visible but unconfirmed primary still updates backup" `Quick
         test_save_with_visible_but_unconfirmed_primary_updates_backup;
+      Alcotest.test_case "failed backup leaves primary newer" `Quick
+        test_save_marks_primary_newer_when_backup_update_fails;
+      Alcotest.test_case "set_top_level_policy failure leaves settings unchanged" `Quick
+        test_set_top_level_policy_failure_leaves_settings_unchanged;
+      Alcotest.test_case "load ignores stale backup when primary is newer and corrupt" `Quick
+        test_load_ignores_stale_backup_when_primary_is_newer_and_corrupt;
       Alcotest.test_case "save reaps stale atomic write temps" `Quick
         test_save_reaps_stale_atomic_write_temps;
       Alcotest.test_case "save refuses read-only preflight" `Quick

--- a/test/test_session_store.ml
+++ b/test/test_session_store.ml
@@ -75,6 +75,11 @@ let test_load_uses_backup_when_primary_corrupt () =
     let oc = open_out primary in
     output_string oc "{ definitely not json";
     close_out oc;
+    let backup_stat = Unix.stat (backup_path home) in
+    Unix.utimes
+      primary
+      backup_stat.Unix.st_atime
+      backup_stat.Unix.st_mtime;
     let reloaded = Discord_agents.Session_store.create () in
     let recovered = find_control_session reloaded in
     Alcotest.(check bool) "stop_requested recovered from backup"
@@ -133,6 +138,51 @@ let test_save_with_visible_but_unconfirmed_primary_updates_backup () =
     Alcotest.(check bool) "backup captured updated stop_requested"
       true recovered.Discord_agents.Session_store.stop_requested)
 
+let test_save_marks_primary_newer_when_backup_update_fails () =
+  with_tmp_home (fun home ->
+    let store = Discord_agents.Session_store.create () in
+    let session = make_session () in
+    Discord_agents.Session_store.add store ~thread_id:"control" session;
+    session.stop_requested <- true;
+    let write_file path content =
+      if String.equal path (backup_path home) then
+        failwith "backup write failed"
+      else
+        Discord_agents.Resource.write_file_atomic path content
+    in
+    Discord_agents.Session_store.save_with ~write_file store;
+    let primary_stat = Unix.stat (sessions_path home) in
+    let backup_stat = Unix.stat (backup_path home) in
+    Alcotest.(check bool) "primary stamped newer than stale backup"
+      true (primary_stat.Unix.st_mtime > backup_stat.Unix.st_mtime))
+
+let test_load_ignores_stale_backup_when_primary_is_newer_and_corrupt () =
+  with_tmp_home (fun home ->
+    let store = Discord_agents.Session_store.create () in
+    let session = make_session () in
+    Discord_agents.Session_store.add store ~thread_id:"control" session;
+    session.stop_requested <- true;
+    let write_file path content =
+      if String.equal path (backup_path home) then
+        failwith "backup write failed"
+      else
+        Discord_agents.Resource.write_file_atomic path content
+    in
+    Discord_agents.Session_store.save_with ~write_file store;
+    let oc = open_out (sessions_path home) in
+    output_string oc "{ definitely not json";
+    close_out oc;
+    let backup_stat = Unix.stat (backup_path home) in
+    Unix.utimes
+      (sessions_path home)
+      backup_stat.Unix.st_atime
+      (backup_stat.Unix.st_mtime +. 10.0);
+    let reloaded = Discord_agents.Session_store.create () in
+    Alcotest.(check bool) "stale backup ignored"
+      true
+      (Option.is_none
+         (Discord_agents.Session_store.find_opt reloaded ~thread_id:"control")))
+
 let test_save_refuses_read_only_preflight () =
   with_tmp_home (fun home ->
     let store = Discord_agents.Session_store.create () in
@@ -174,6 +224,10 @@ let () =
         test_load_uses_backup_when_primary_missing;
       Alcotest.test_case "visible but unconfirmed primary still updates backup" `Quick
         test_save_with_visible_but_unconfirmed_primary_updates_backup;
+      Alcotest.test_case "failed backup leaves primary newer" `Quick
+        test_save_marks_primary_newer_when_backup_update_fails;
+      Alcotest.test_case "load ignores stale backup when primary is newer and corrupt" `Quick
+        test_load_ignores_stale_backup_when_primary_is_newer_and_corrupt;
       Alcotest.test_case "save refuses read-only preflight" `Quick
         test_save_refuses_read_only_preflight;
     ]);


### PR DESCRIPTION
## Summary
- make top-level default/rescue policy changes replay-safe with a persisted policy_sync_pending marker
- batch top-level session rotations into one persisted session-store replacement with rollback on save failure and harden the pre-persist rollback path for preparation-time exceptions
- harden stale-backup recovery by refusing older backups after a newer primary publish and by stamping matched write epochs onto successful primary/backup pairs
- add transaction and exception-path coverage for marker persistence, rollback, stale-backup handling, fatal re-raise behavior, and rescue/default policy recovery

## Testing
- nix develop --command dune runtest --build-dir _build_policytx9
- nix develop --command dune build --build-dir _build_policytx9

Closes #55
Refs #53
Refs #58