### PR TITLE
fix: report live top-level policy sync state

### DIFF
--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -67,8 +67,14 @@ type t = {
   mutable wrap_width : int;
   mutable refreshing : bool;
   mutable output_lines : int;
+  mutable policy_sync_clear_last_warning : (string * string) option;
   scroll_states : (Discord_types.channel_id, scroll_state) Hashtbl.t;
 }
+
+type top_level_policy_sync_state =
+  | Policy_sync_clean
+  | Policy_sync_rotation_pending
+  | Policy_sync_marker_clear_pending
 
 (** Convenience accessors for the current project state snapshot. *)
 let projects t = t.project_state.projects
@@ -108,6 +114,11 @@ let rescue_agent_notice t =
       (Config.string_of_agent_kind kind))
   | None ->
     None
+
+let string_of_top_level_policy_sync_state = function
+  | Policy_sync_clean -> "clean"
+  | Policy_sync_rotation_pending -> "rotation-pending"
+  | Policy_sync_marker_clear_pending -> "marker-clear-pending"
 
 let reraise_if_fatal_policy_exception exn =
   match exn with
@@ -156,6 +167,55 @@ let refresh_persistent_session_disk_state t =
 let refresh_top_level_disk_state t =
   refresh_disk_state ();
   refresh_persistent_session_disk_state t
+
+let session_converged_to_top_level_policy expected_agent
+    (session : Session_store.session) =
+  match session.session_override_kind, session.pending_agent_change with
+  | Some _, _
+  | _, Some { origin = Session_store.Session_override; _ } ->
+    true
+  | None, Some { origin = Session_store.Default_rotation; _ } ->
+    false
+  | None, None ->
+    Config.equal_agent_kind session.agent_kind expected_agent
+
+let top_level_policy_state_converged_for_agent t expected_agent =
+  Session_store.bindings t.sessions
+  |> List.for_all (fun (thread_id, (session : Session_store.session)) ->
+    not (is_persistent_channel t ~channel_id:thread_id)
+    || session_converged_to_top_level_policy expected_agent session)
+
+let rec top_level_policy_sync_state t =
+  let expected_agent = effective_top_level_agent t in
+  top_level_policy_sync_state_for_agent t expected_agent
+
+and top_level_policy_sync_state_for_agent t expected_agent =
+  if top_level_policy_state_converged_for_agent t expected_agent then
+    if policy_sync_pending t then
+      Policy_sync_marker_clear_pending
+    else
+      Policy_sync_clean
+  else
+    Policy_sync_rotation_pending
+
+let top_level_policy_sync_state_from_snapshot t disk =
+  let expected_agent = effective_top_level_agent_from_snapshot t.settings disk in
+  top_level_policy_sync_state_for_agent t expected_agent
+
+let note_policy_sync_clear_success t =
+  t.policy_sync_clear_last_warning <- None
+
+let should_log_policy_sync_clear_failure t err =
+  let state =
+    string_of_top_level_policy_sync_state (top_level_policy_sync_state t)
+  in
+  let warning = Some (state, err) in
+  if t.policy_sync_clear_last_warning = warning then
+    false
+  else begin
+    t.policy_sync_clear_last_warning <- warning;
+    true
+  end
 
 type persistent_rotation = {
   reset_count : int;
@@ -650,12 +710,18 @@ let align_persistent_sessions_to_agent
 
 let clear_policy_sync_pending t =
   if policy_sync_pending t then
-    Runtime_settings.set_policy_sync_pending t.settings false
+    match Runtime_settings.set_policy_sync_pending t.settings false with
+    | Ok () ->
+      note_policy_sync_clear_success t;
+      Ok ()
+    | Error _ as err ->
+      err
   else
     Ok ()
 
 let run_top_level_policy_change t ~current_channel_id
     ~default_agent ~rescue_agent ~new_agent ~summary ~policy_label =
+  t.policy_sync_clear_last_warning <- None;
   let policy_changed =
     not (Config.equal_agent_kind t.settings.default_agent default_agent)
     || not (Option.equal Config.equal_agent_kind
@@ -842,9 +908,10 @@ let reconcile_persisted_pending_agent_changes t =
     (match clear_policy_sync_pending t with
      | Ok () -> ()
      | Error err ->
-       Logs.warn (fun m ->
-         m "bot: failed to clear top-level policy sync marker after reconcile: %s"
-           err))
+       if should_log_policy_sync_clear_failure t err then
+         Logs.warn (fun m ->
+           m "bot: failed to clear top-level policy sync marker after reconcile: %s"
+             err))
   | Error err ->
     Logs.warn (fun m ->
       m "bot: failed to reconcile top-level default agent sessions: %s" err)
@@ -1743,7 +1810,8 @@ let handle_command t msg cmd =
           Printf.sprintf "Effective top-level agent: %s"
             (Config.string_of_agent_kind (effective_top_level_agent t));
           Printf.sprintf "Top-level policy sync: %s"
-            (if policy_sync_pending t then "pending" else "clean");
+            (string_of_top_level_policy_sync_state
+              (top_level_policy_sync_state t));
           Disk_health.status_summary ();
           Printf.sprintf "Sessions: %d (%d processing)"
             (Session_store.count t.sessions)
@@ -2103,9 +2171,10 @@ let sync_top_level_agent_policy t =
     (match clear_policy_sync_pending t with
      | Ok () -> ()
      | Error err ->
-       Logs.warn (fun m ->
-         m "bot: failed to clear top-level policy sync marker after runtime sync: %s"
-           err));
+       if should_log_policy_sync_clear_failure t err then
+         Logs.warn (fun m ->
+           m "bot: failed to clear top-level policy sync marker after runtime sync: %s"
+             err));
     Ok rotation
 
 let sync_top_level_agent_policy_best_effort t =
@@ -2290,6 +2359,7 @@ let create ~sw ~(env : Eio_unix.Stdenv.base) config =
                wrap_width = Agent_process.desktop_width;
                refreshing = false;
                output_lines = Agent_process.default_output_lines;
+               policy_sync_clear_last_warning = None;
                scroll_states = Hashtbl.create 64 } in
   reconcile_persisted_stop_requests bot;
   reconcile_persisted_pending_agent_changes bot;

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -175,7 +175,7 @@ let session_converged_to_top_level_policy expected_agent
   | _, Some { origin = Session_store.Session_override; _ } ->
     true
   | None, Some { origin = Session_store.Default_rotation; _ } ->
-    false
+    Config.equal_agent_kind session.agent_kind expected_agent
   | None, None ->
     Config.equal_agent_kind session.agent_kind expected_agent
 
@@ -205,10 +205,7 @@ let top_level_policy_sync_state_from_snapshot t disk =
 let note_policy_sync_clear_success t =
   t.policy_sync_clear_last_warning <- None
 
-let should_log_policy_sync_clear_failure t err =
-  let state =
-    string_of_top_level_policy_sync_state (top_level_policy_sync_state t)
-  in
+let should_log_policy_sync_clear_failure t ~state err =
   let warning = Some (state, err) in
   if t.policy_sync_clear_last_warning = warning then
     false
@@ -908,10 +905,13 @@ let reconcile_persisted_pending_agent_changes t =
     (match clear_policy_sync_pending t with
      | Ok () -> ()
      | Error err ->
-       if should_log_policy_sync_clear_failure t err then
+       let state =
+         string_of_top_level_policy_sync_state (top_level_policy_sync_state t)
+       in
+       if should_log_policy_sync_clear_failure t ~state err then
          Logs.warn (fun m ->
-           m "bot: failed to clear top-level policy sync marker after reconcile: %s"
-             err))
+           m "bot: failed to clear top-level policy sync marker after reconcile (state=%s): %s"
+             state err))
   | Error err ->
     Logs.warn (fun m ->
       m "bot: failed to reconcile top-level default agent sessions: %s" err)
@@ -2171,10 +2171,13 @@ let sync_top_level_agent_policy t =
     (match clear_policy_sync_pending t with
      | Ok () -> ()
      | Error err ->
-       if should_log_policy_sync_clear_failure t err then
+       let state =
+         string_of_top_level_policy_sync_state (top_level_policy_sync_state t)
+       in
+       if should_log_policy_sync_clear_failure t ~state err then
          Logs.warn (fun m ->
-           m "bot: failed to clear top-level policy sync marker after runtime sync: %s"
-             err));
+           m "bot: failed to clear top-level policy sync marker after runtime sync (state=%s): %s"
+             state err));
     Ok rotation
 
 let sync_top_level_agent_policy_best_effort t =

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -201,6 +201,9 @@ let handle_health (bot : Bot.t) =
      `String (Config.string_of_agent_kind effective_top_level_agent));
     ("top_level_policy_sync_pending",
      `Bool (Bot.policy_sync_pending bot));
+    ("top_level_policy_sync_state",
+     `String (Bot.string_of_top_level_policy_sync_state
+       (Bot.top_level_policy_sync_state_from_snapshot bot disk)));
     ("disk_rescue_active",
      `Bool (Bot.rescue_mode_active_from_snapshot bot.settings disk));
     ("sessions", `Int (Session_store.count bot.sessions));
@@ -656,6 +659,9 @@ let handle_default_agent (bot : Bot.t) params =
          (Bot.effective_top_level_agent_from_snapshot bot.settings disk)));
       ("top_level_policy_sync_pending",
        `Bool (Bot.policy_sync_pending bot));
+      ("top_level_policy_sync_state",
+       `String (Bot.string_of_top_level_policy_sync_state
+         (Bot.top_level_policy_sync_state_from_snapshot bot disk)));
       ("disk_rescue_active",
        `Bool (Bot.rescue_mode_active_from_snapshot bot.settings disk));
     ] @
@@ -667,13 +673,19 @@ let handle_default_agent (bot : Bot.t) params =
     (match Bot.set_default_agent bot kind with
      | Error err -> error_response err
      | Ok rotation ->
+       let disk = Disk_health.snapshot () in
        ok_response ([
          ("agent", `String (Config.string_of_agent_kind kind));
          ("effective_top_level_agent",
-          `String (Config.string_of_agent_kind (Bot.effective_top_level_agent bot)));
+          `String (Config.string_of_agent_kind
+            (Bot.effective_top_level_agent_from_snapshot bot.settings disk)));
          ("top_level_policy_sync_pending",
           `Bool (Bot.policy_sync_pending bot));
-         ("disk_rescue_active", `Bool (Bot.rescue_mode_active bot));
+         ("top_level_policy_sync_state",
+          `String (Bot.string_of_top_level_policy_sync_state
+            (Bot.top_level_policy_sync_state_from_snapshot bot disk)));
+         ("disk_rescue_active",
+          `Bool (Bot.rescue_mode_active_from_snapshot bot.settings disk));
          ("reset_count", `Int rotation.Bot.reset_count);
          ("busy_count", `Int rotation.Bot.busy_count);
        ] @
@@ -699,12 +711,18 @@ let handle_rescue_agent (bot : Bot.t) params =
   in
   match requested with
   | None ->
+    let disk = Disk_health.snapshot () in
     ok_response ([
       ("effective_top_level_agent",
-       `String (Config.string_of_agent_kind (Bot.effective_top_level_agent bot)));
+       `String (Config.string_of_agent_kind
+         (Bot.effective_top_level_agent_from_snapshot bot.settings disk)));
       ("top_level_policy_sync_pending",
        `Bool (Bot.policy_sync_pending bot));
-      ("disk_rescue_active", `Bool (Bot.rescue_mode_active bot));
+      ("top_level_policy_sync_state",
+       `String (Bot.string_of_top_level_policy_sync_state
+         (Bot.top_level_policy_sync_state_from_snapshot bot disk)));
+      ("disk_rescue_active",
+       `Bool (Bot.rescue_mode_active_from_snapshot bot.settings disk));
     ] @
     match bot.settings.rescue_agent with
     | Some kind ->
@@ -714,16 +732,22 @@ let handle_rescue_agent (bot : Bot.t) params =
     (match Bot.set_rescue_agent bot kind with
      | Error err -> error_response err
      | Ok rotation ->
+       let disk = Disk_health.snapshot () in
        ok_response [
          ("agent",
           match kind with
           | Some kind -> `String (Config.string_of_agent_kind kind)
           | None -> `Null);
          ("effective_top_level_agent",
-          `String (Config.string_of_agent_kind (Bot.effective_top_level_agent bot)));
+          `String (Config.string_of_agent_kind
+            (Bot.effective_top_level_agent_from_snapshot bot.settings disk)));
          ("top_level_policy_sync_pending",
           `Bool (Bot.policy_sync_pending bot));
-         ("disk_rescue_active", `Bool (Bot.rescue_mode_active bot));
+         ("top_level_policy_sync_state",
+          `String (Bot.string_of_top_level_policy_sync_state
+            (Bot.top_level_policy_sync_state_from_snapshot bot disk)));
+         ("disk_rescue_active",
+          `Bool (Bot.rescue_mode_active_from_snapshot bot.settings disk));
          ("reset_count", `Int rotation.Bot.reset_count);
          ("busy_count", `Int rotation.Bot.busy_count);
        ])

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -68,6 +68,7 @@ let with_test_bot f =
         wrap_width = Discord_agents.Agent_process.desktop_width;
         refreshing = false;
         output_lines = Discord_agents.Agent_process.default_output_lines;
+        policy_sync_clear_last_warning = None;
         scroll_states = Hashtbl.create 8;
       } in
       Fun.protect
@@ -75,6 +76,9 @@ let with_test_bot f =
         (fun () -> f bot))
 
 let kind_string = Discord_agents.Config.string_of_agent_kind
+let policy_sync_state_string bot =
+  Discord_agents.Bot.top_level_policy_sync_state bot
+  |> Discord_agents.Bot.string_of_top_level_policy_sync_state
 
 let set_disk_warning_mode () =
   Discord_agents.Disk_health.For_testing.set_probe_available_bytes
@@ -580,6 +584,110 @@ let test_best_effort_sync_observes_project_workdir_pressure () =
         Alcotest.(check bool) "fresh session id allocated"
           true (saved.session_id <> original_session_id)))
 
+let test_policy_sync_state_is_marker_clear_pending_after_converged_rotation () =
+  with_test_bot (fun bot ->
+    bot.settings.default_agent <- Discord_agents.Config.Codex;
+    bot.settings.policy_sync_pending <- true;
+    let session = make_session Discord_agents.Config.Codex in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    Alcotest.(check string) "policy sync state"
+      "marker-clear-pending" (policy_sync_state_string bot))
+
+let test_policy_sync_state_is_rotation_pending_for_deferred_default_rotation () =
+  with_test_bot (fun bot ->
+    bot.settings.default_agent <- Discord_agents.Config.Codex;
+    bot.settings.policy_sync_pending <- true;
+    let pending = Discord_agents.Session_store.{
+      kind = Discord_agents.Config.Codex;
+      origin = Default_rotation;
+    } in
+    let session =
+      make_session ~processing:true ~pending_agent_change:pending
+        Discord_agents.Config.Claude
+    in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    Alcotest.(check string) "policy sync state"
+      "rotation-pending" (policy_sync_state_string bot))
+
+let test_policy_sync_state_is_rotation_pending_after_marker_cleared () =
+  with_test_bot (fun bot ->
+    bot.settings.default_agent <- Discord_agents.Config.Codex;
+    let pending = Discord_agents.Session_store.{
+      kind = Discord_agents.Config.Codex;
+      origin = Default_rotation;
+    } in
+    let session =
+      make_session ~processing:true ~pending_agent_change:pending
+        Discord_agents.Config.Claude
+    in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    Alcotest.(check string) "policy sync state"
+      "rotation-pending" (policy_sync_state_string bot))
+
+let test_policy_sync_clear_warning_is_suppressed_for_repeat_state_and_error () =
+  with_test_bot (fun bot ->
+    bot.settings.default_agent <- Discord_agents.Config.Codex;
+    bot.settings.policy_sync_pending <- true;
+    let session = make_session Discord_agents.Config.Codex in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    Alcotest.(check bool) "first warning allowed"
+      true
+      (Discord_agents.Bot.should_log_policy_sync_clear_failure bot "disk full");
+    Alcotest.(check bool) "repeat warning suppressed"
+      false
+      (Discord_agents.Bot.should_log_policy_sync_clear_failure bot "disk full"))
+
+let test_policy_sync_clear_warning_logs_again_after_error_or_state_change () =
+  with_test_bot (fun bot ->
+    bot.settings.default_agent <- Discord_agents.Config.Codex;
+    bot.settings.policy_sync_pending <- true;
+    let converged = make_session Discord_agents.Config.Codex in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" converged;
+    ignore (Discord_agents.Bot.should_log_policy_sync_clear_failure bot "disk full");
+    Alcotest.(check bool) "different error re-logs"
+      true
+      (Discord_agents.Bot.should_log_policy_sync_clear_failure bot "io timeout");
+    let pending = Discord_agents.Session_store.{
+      kind = Discord_agents.Config.Codex;
+      origin = Default_rotation;
+    } in
+    let deferred =
+      make_session ~processing:true ~pending_agent_change:pending
+        Discord_agents.Config.Claude
+    in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" deferred;
+    Alcotest.(check string) "policy sync state changed"
+      "rotation-pending" (policy_sync_state_string bot);
+    Alcotest.(check bool) "state change re-logs"
+      true
+      (Discord_agents.Bot.should_log_policy_sync_clear_failure bot "io timeout"))
+
+let test_policy_sync_clear_success_rearms_warning () =
+  with_test_bot (fun bot ->
+    bot.settings.default_agent <- Discord_agents.Config.Codex;
+    bot.settings.policy_sync_pending <- true;
+    let session = make_session Discord_agents.Config.Codex in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    ignore (Discord_agents.Bot.should_log_policy_sync_clear_failure bot "disk full");
+    Discord_agents.Bot.note_policy_sync_clear_success bot;
+    Alcotest.(check bool) "warning re-armed after success"
+      true
+      (Discord_agents.Bot.should_log_policy_sync_clear_failure bot "disk full"))
+
+let test_policy_sync_state_ignores_nonpersistent_sessions () =
+  with_test_bot (fun bot ->
+    bot.settings.default_agent <- Discord_agents.Config.Codex;
+    bot.settings.policy_sync_pending <- true;
+    let control = make_session Discord_agents.Config.Codex in
+    let ephemeral =
+      make_session ~project_name:"thread" ~thread_id:"thread-1"
+        Discord_agents.Config.Claude
+    in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" control;
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"thread-1" ephemeral;
+    Alcotest.(check string) "policy sync state"
+      "marker-clear-pending" (policy_sync_state_string bot))
+
 let test_reconcile_applies_persisted_pending_default_rotation () =
   with_test_bot (fun bot ->
     bot.settings.default_agent <- Discord_agents.Config.Codex;
@@ -1000,6 +1108,20 @@ let () =
         test_finalize_pending_default_rotation_uses_current_policy_after_pressure_clears;
       Alcotest.test_case "default rotation rechecks active rescue policy" `Quick
         test_finalize_pending_default_rotation_uses_current_rescue_policy;
+      Alcotest.test_case "policy sync state marks converged uncleared marker as marker-clear-pending" `Quick
+        test_policy_sync_state_is_marker_clear_pending_after_converged_rotation;
+      Alcotest.test_case "policy sync state marks deferred default rotation as rotation-pending" `Quick
+        test_policy_sync_state_is_rotation_pending_for_deferred_default_rotation;
+      Alcotest.test_case "policy sync state stays rotation-pending after marker clears with busy rotation" `Quick
+        test_policy_sync_state_is_rotation_pending_after_marker_cleared;
+      Alcotest.test_case "policy sync clear warnings suppress repeated identical state+error pairs" `Quick
+        test_policy_sync_clear_warning_is_suppressed_for_repeat_state_and_error;
+      Alcotest.test_case "policy sync clear warnings re-log after error or state changes" `Quick
+        test_policy_sync_clear_warning_logs_again_after_error_or_state_change;
+      Alcotest.test_case "policy sync clear success re-arms warning logging" `Quick
+        test_policy_sync_clear_success_rearms_warning;
+      Alcotest.test_case "policy sync state ignores nonpersistent sessions" `Quick
+        test_policy_sync_state_ignores_nonpersistent_sessions;
       Alcotest.test_case "reconcile preserves idle session override" `Quick
         test_reconcile_preserves_idle_session_override;
       Alcotest.test_case "reconcile rotates idle session to default" `Quick

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -584,6 +584,14 @@ let test_best_effort_sync_observes_project_workdir_pressure () =
         Alcotest.(check bool) "fresh session id allocated"
           true (saved.session_id <> original_session_id)))
 
+let test_policy_sync_state_is_clean_when_converged_and_marker_cleared () =
+  with_test_bot (fun bot ->
+    bot.settings.default_agent <- Discord_agents.Config.Codex;
+    let session = make_session Discord_agents.Config.Codex in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    Alcotest.(check string) "policy sync state"
+      "clean" (policy_sync_state_string bot))
+
 let test_policy_sync_state_is_marker_clear_pending_after_converged_rotation () =
   with_test_bot (fun bot ->
     bot.settings.default_agent <- Discord_agents.Config.Codex;
@@ -609,6 +617,20 @@ let test_policy_sync_state_is_rotation_pending_for_deferred_default_rotation () 
     Alcotest.(check string) "policy sync state"
       "rotation-pending" (policy_sync_state_string bot))
 
+let test_policy_sync_state_treats_stale_default_rotation_as_converged () =
+  with_test_bot (fun bot ->
+    bot.settings.default_agent <- Discord_agents.Config.Codex;
+    let pending = Discord_agents.Session_store.{
+      kind = Discord_agents.Config.Gemini;
+      origin = Default_rotation;
+    } in
+    let session =
+      make_session ~pending_agent_change:pending Discord_agents.Config.Codex
+    in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    Alcotest.(check string) "policy sync state"
+      "clean" (policy_sync_state_string bot))
+
 let test_policy_sync_state_is_rotation_pending_after_marker_cleared () =
   with_test_bot (fun bot ->
     bot.settings.default_agent <- Discord_agents.Config.Codex;
@@ -624,6 +646,48 @@ let test_policy_sync_state_is_rotation_pending_after_marker_cleared () =
     Alcotest.(check string) "policy sync state"
       "rotation-pending" (policy_sync_state_string bot))
 
+let test_policy_sync_state_treats_session_override_as_converged () =
+  with_test_bot (fun bot ->
+    bot.settings.default_agent <- Discord_agents.Config.Codex;
+    bot.settings.policy_sync_pending <- true;
+    let session =
+      make_session
+        ~session_override_kind:(Some Discord_agents.Config.Gemini)
+        Discord_agents.Config.Gemini
+    in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    Alcotest.(check string) "policy sync state"
+      "marker-clear-pending" (policy_sync_state_string bot))
+
+let test_policy_sync_state_treats_pending_session_override_as_converged () =
+  with_test_bot (fun bot ->
+    bot.settings.default_agent <- Discord_agents.Config.Codex;
+    bot.settings.policy_sync_pending <- true;
+    let pending = Discord_agents.Session_store.{
+      kind = Discord_agents.Config.Gemini;
+      origin = Session_override;
+    } in
+    let session =
+      make_session ~pending_agent_change:pending Discord_agents.Config.Claude
+    in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    Alcotest.(check string) "policy sync state"
+      "marker-clear-pending" (policy_sync_state_string bot))
+
+let test_policy_sync_state_from_snapshot_uses_rescue_agent_under_pressure () =
+  with_test_bot (fun bot ->
+    bot.settings.rescue_agent <- Some Discord_agents.Config.Codex;
+    bot.settings.policy_sync_pending <- true;
+    set_disk_warning_mode ();
+    ignore (Discord_agents.Disk_health.preflight_state_mutation ());
+    let disk = Discord_agents.Disk_health.snapshot () in
+    let session = make_session Discord_agents.Config.Codex in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    Alcotest.(check string) "policy sync state from snapshot"
+      "marker-clear-pending"
+      (Discord_agents.Bot.top_level_policy_sync_state_from_snapshot bot disk
+       |> Discord_agents.Bot.string_of_top_level_policy_sync_state))
+
 let test_policy_sync_clear_warning_is_suppressed_for_repeat_state_and_error () =
   with_test_bot (fun bot ->
     bot.settings.default_agent <- Discord_agents.Config.Codex;
@@ -632,10 +696,12 @@ let test_policy_sync_clear_warning_is_suppressed_for_repeat_state_and_error () =
     Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
     Alcotest.(check bool) "first warning allowed"
       true
-      (Discord_agents.Bot.should_log_policy_sync_clear_failure bot "disk full");
+      (Discord_agents.Bot.should_log_policy_sync_clear_failure bot
+         ~state:(policy_sync_state_string bot) "disk full");
     Alcotest.(check bool) "repeat warning suppressed"
       false
-      (Discord_agents.Bot.should_log_policy_sync_clear_failure bot "disk full"))
+      (Discord_agents.Bot.should_log_policy_sync_clear_failure bot
+         ~state:(policy_sync_state_string bot) "disk full"))
 
 let test_policy_sync_clear_warning_logs_again_after_error_or_state_change () =
   with_test_bot (fun bot ->
@@ -643,10 +709,12 @@ let test_policy_sync_clear_warning_logs_again_after_error_or_state_change () =
     bot.settings.policy_sync_pending <- true;
     let converged = make_session Discord_agents.Config.Codex in
     Discord_agents.Session_store.add bot.sessions ~thread_id:"control" converged;
-    ignore (Discord_agents.Bot.should_log_policy_sync_clear_failure bot "disk full");
+    ignore (Discord_agents.Bot.should_log_policy_sync_clear_failure bot
+      ~state:(policy_sync_state_string bot) "disk full");
     Alcotest.(check bool) "different error re-logs"
       true
-      (Discord_agents.Bot.should_log_policy_sync_clear_failure bot "io timeout");
+      (Discord_agents.Bot.should_log_policy_sync_clear_failure bot
+         ~state:(policy_sync_state_string bot) "io timeout");
     let pending = Discord_agents.Session_store.{
       kind = Discord_agents.Config.Codex;
       origin = Default_rotation;
@@ -660,7 +728,8 @@ let test_policy_sync_clear_warning_logs_again_after_error_or_state_change () =
       "rotation-pending" (policy_sync_state_string bot);
     Alcotest.(check bool) "state change re-logs"
       true
-      (Discord_agents.Bot.should_log_policy_sync_clear_failure bot "io timeout"))
+      (Discord_agents.Bot.should_log_policy_sync_clear_failure bot
+         ~state:(policy_sync_state_string bot) "io timeout"))
 
 let test_policy_sync_clear_success_rearms_warning () =
   with_test_bot (fun bot ->
@@ -668,11 +737,13 @@ let test_policy_sync_clear_success_rearms_warning () =
     bot.settings.policy_sync_pending <- true;
     let session = make_session Discord_agents.Config.Codex in
     Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
-    ignore (Discord_agents.Bot.should_log_policy_sync_clear_failure bot "disk full");
+    ignore (Discord_agents.Bot.should_log_policy_sync_clear_failure bot
+      ~state:(policy_sync_state_string bot) "disk full");
     Discord_agents.Bot.note_policy_sync_clear_success bot;
     Alcotest.(check bool) "warning re-armed after success"
       true
-      (Discord_agents.Bot.should_log_policy_sync_clear_failure bot "disk full"))
+      (Discord_agents.Bot.should_log_policy_sync_clear_failure bot
+         ~state:(policy_sync_state_string bot) "disk full"))
 
 let test_policy_sync_state_ignores_nonpersistent_sessions () =
   with_test_bot (fun bot ->
@@ -1108,12 +1179,22 @@ let () =
         test_finalize_pending_default_rotation_uses_current_policy_after_pressure_clears;
       Alcotest.test_case "default rotation rechecks active rescue policy" `Quick
         test_finalize_pending_default_rotation_uses_current_rescue_policy;
+      Alcotest.test_case "policy sync state is clean when converged and marker cleared" `Quick
+        test_policy_sync_state_is_clean_when_converged_and_marker_cleared;
       Alcotest.test_case "policy sync state marks converged uncleared marker as marker-clear-pending" `Quick
         test_policy_sync_state_is_marker_clear_pending_after_converged_rotation;
       Alcotest.test_case "policy sync state marks deferred default rotation as rotation-pending" `Quick
         test_policy_sync_state_is_rotation_pending_for_deferred_default_rotation;
+      Alcotest.test_case "policy sync state treats stale default rotation as converged" `Quick
+        test_policy_sync_state_treats_stale_default_rotation_as_converged;
       Alcotest.test_case "policy sync state stays rotation-pending after marker clears with busy rotation" `Quick
         test_policy_sync_state_is_rotation_pending_after_marker_cleared;
+      Alcotest.test_case "policy sync state treats session override as converged" `Quick
+        test_policy_sync_state_treats_session_override_as_converged;
+      Alcotest.test_case "policy sync state treats pending session override as converged" `Quick
+        test_policy_sync_state_treats_pending_session_override_as_converged;
+      Alcotest.test_case "policy sync state from snapshot uses rescue agent under pressure" `Quick
+        test_policy_sync_state_from_snapshot_uses_rescue_agent_under_pressure;
       Alcotest.test_case "policy sync clear warnings suppress repeated identical state+error pairs" `Quick
         test_policy_sync_clear_warning_is_suppressed_for_repeat_state_and_error;
       Alcotest.test_case "policy sync clear warnings re-log after error or state changes" `Quick


### PR DESCRIPTION
## Summary
- add a live top-level policy sync state model that distinguishes `clean`, `rotation-pending`, and `marker-clear-pending`
- surface that richer state through `!status` and the control API using a single disk snapshot per response
- suppress repeated marker-clear warnings by `(state, error)` and expand regression coverage for overrides, stale pending rotations, rescue-agent snapshots, and warning re-arming

## Testing
- `nix develop --command dune build --build-dir _build_policysync6`
- `nix develop --command dune runtest --build-dir _build_policysync6`

## Follow-up
- control API field-contract coverage is tracked in #59