### PR TITLE
fix: close REST sockets after each request

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -117,6 +117,7 @@ let run_test ~sw ~env config test_channel =
 
 let () =
   setup_logging ();
+  Discord_agents.Runtime_limits.bump_nofile ();
   let args = Array.to_list Sys.argv |> List.tl in
   let test_mode = List.mem "--test" args in
   let test_channel =

--- a/lib/discord_agents.ml
+++ b/lib/discord_agents.ml
@@ -4,6 +4,7 @@ module Resource = Resource
 module Disk_health = Disk_health
 module Config = Config
 module Runtime_settings = Runtime_settings
+module Runtime_limits = Runtime_limits
 module Project = Project
 module Agent_process = Agent_process
 module Agent_runner = Agent_runner

--- a/lib/discord_rest.ml
+++ b/lib/discord_rest.ml
@@ -18,18 +18,17 @@ type backoff_source =
 type t = {
   token : string;
   call : http_call;
-  sw : Eio.Switch.t;
   clock : Eio.Time.Mono.ty Eio.Resource.t;
   rest_state : health_state;
+  api_base : string;
 }
 
 and http_call =
-  sw:Eio.Switch.t ->
   headers:Http.Header.t ->
   ?body:Cohttp_eio.Body.t ->
   Http.Method.t ->
   Uri.t ->
-  Http.Response.t * Cohttp_eio.Body.t
+  Http.Response.t * string * bool
 
 and health_state = {
   mutable last_error : string option;
@@ -471,7 +470,32 @@ let response_clears_rest_health code =
 let response_marks_rest_failure code =
   code >= 400 && code < 500 && code <> 404 && code <> 429
 
-let create ~sw ~(env : Eio_unix.Stdenv.base) ~token =
+(** Read entire body from a cohttp-eio response source.
+    Capped at 10MB to prevent OOM from unexpected large responses. *)
+let max_body_size = 10 * 1024 * 1024
+
+let read_body_with_truncation (body : Cohttp_eio.Body.t) =
+  let buf = Buffer.create 4096 in
+  let chunk = Cstruct.create 4096 in
+  let truncated = ref false in
+  let rec loop () =
+    match Eio.Flow.single_read body chunk with
+    | n ->
+      if not !truncated then begin
+        Buffer.add_string buf (Cstruct.to_string ~off:0 ~len:n chunk);
+        if Buffer.length buf > max_body_size then
+          truncated := true
+      end;
+      (* Always drain to EOF so the connection stays clean for reuse. *)
+      loop ()
+    | exception End_of_file -> (Buffer.contents buf, !truncated)
+  in
+  loop ()
+
+let read_body body =
+  fst (read_body_with_truncation body)
+
+let create_with_api_base ~api_base ~sw:_ ~(env : Eio_unix.Stdenv.base) ~token =
   Random.self_init ();
   Mirage_crypto_rng_unix.use_default ();
   let authenticator =
@@ -494,11 +518,18 @@ let create ~sw ~(env : Eio_unix.Stdenv.base) ~token =
   let net = Eio.Stdenv.net env in
   let client = Cohttp_eio.Client.make ~https:(Some https) net in
   let clock = Eio.Stdenv.mono_clock env in
-  let call ~sw ~headers ?body meth uri =
-    Cohttp_eio.Client.call client ~sw ~headers ?body meth uri
+  let call ~headers ?body meth uri =
+    Eio.Switch.run @@ fun request_sw ->
+    let (resp, resp_body) =
+      Cohttp_eio.Client.call client ~sw:request_sw ~headers ?body meth uri
+    in
+    let (body_str, truncated) = read_body_with_truncation resp_body in
+    (resp, body_str, truncated)
   in
-  { token; call; sw; clock;
-    rest_state = create_health_state (); }
+  { token; call; clock; rest_state = create_health_state (); api_base; }
+
+let create ~sw ~env ~token =
+  create_with_api_base ~api_base ~sw ~env ~token
 
 let make_headers t =
   Http.Header.of_list [
@@ -506,31 +537,6 @@ let make_headers t =
     ("Content-Type", "application/json");
     ("User-Agent", "DiscordBot (discord-agents/0.1.0, OCaml)");
   ]
-
-(** Read entire body from a cohttp-eio response source.
-    Capped at 10MB to prevent OOM from unexpected large responses. *)
-let max_body_size = 10 * 1024 * 1024
-
-let read_body_with_truncation (body : Cohttp_eio.Body.t) =
-  let buf = Buffer.create 4096 in
-  let chunk = Cstruct.create 4096 in
-  let truncated = ref false in
-  let rec loop () =
-    match Eio.Flow.single_read body chunk with
-    | n ->
-      if not !truncated then begin
-        Buffer.add_string buf (Cstruct.to_string ~off:0 ~len:n chunk);
-        if Buffer.length buf > max_body_size then
-          truncated := true
-      end;
-      (* Always drain to EOF so the connection stays clean for reuse *)
-      loop ()
-    | exception End_of_file -> (Buffer.contents buf, !truncated)
-  in
-  loop ()
-
-let read_body body =
-  fst (read_body_with_truncation body)
 
 (** Truncate a byte string near [max_len] for log output. Preserves
     UTF-8 validity without verifying it: if the input is valid UTF-8,
@@ -598,7 +604,7 @@ let decode_json_body body_str =
     debug level (expected for typing/reactions on deleted channels); other
     errors log at warn. *)
 let request ?(retry_mode = No_retry) t ~meth ~path ?body () =
-  let uri = Uri.of_string (api_base ^ path) in
+  let uri = Uri.of_string (t.api_base ^ path) in
   let host = Uri.host uri |> Option.value ~default:"discord.com" in
   let retry_limit = match retry_mode with
     | No_retry -> 1
@@ -609,7 +615,10 @@ let request ?(retry_mode = No_retry) t ~meth ~path ?body () =
   let meth_str = Http.Method.to_string meth in
   let do_call () =
     let cohttp_body = Option.map Cohttp_eio.Body.of_string body_str in
-    t.call ~sw:t.sw ~headers ?body:cohttp_body meth uri
+    let (resp, body_str, _truncated) =
+      t.call ~headers ?body:cohttp_body meth uri
+    in
+    (resp, body_str)
   in
   let log_non_2xx code body =
     let body = truncate_for_log body in
@@ -661,11 +670,10 @@ let request ?(retry_mode = No_retry) t ~meth ~path ?body () =
   let rec loop attempt rate_limit_retries =
     wait_for_transport_backoff t;
     try
-      let (resp, resp_body) = do_call () in
+      let (resp, body_str) = do_call () in
       let status = Http.Response.status resp in
       let code = Http.Status.to_int status in
       let headers = Http.Response.headers resp in
-      let body_str = read_body resp_body in
       if code = 429 && rate_limit_retries < max_rate_limit_retries then begin
         note_transport_response t;
         let retry_after =
@@ -980,11 +988,15 @@ let download_url t ~url () =
   let rec loop attempt =
     try
       let (resp, body) =
-        t.call ~sw:t.sw ~headers `GET uri in
+        let (resp, body_str, truncated) =
+          t.call ~headers `GET uri
+        in
+        (resp, (body_str, truncated))
+      in
       let status = Http.Response.status resp in
       let code = Http.Status.to_int status in
       let resp_headers = Http.Response.headers resp in
-      let (body_str, truncated) = read_body_with_truncation body in
+      let (body_str, truncated) = body in
       if truncated then
         Error (Printf.sprintf "download_url %s: response exceeded %d bytes"
           url max_body_size)

--- a/lib/dune
+++ b/lib/dune
@@ -4,7 +4,7 @@
  (libraries eio_main cohttp-eio tls-eio ca-certs mirage-crypto-rng.unix base64 yojson logs fmt uri)
  (foreign_stubs
   (language c)
-  (names disk_space_stubs))
+  (names disk_space_stubs rlimit_stubs))
  (preprocess
   (pps ppx_yojson_conv ppx_deriving.show ppx_deriving.eq)))
 

--- a/lib/rlimit_stubs.c
+++ b/lib/rlimit_stubs.c
@@ -1,0 +1,62 @@
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/resource.h>
+
+static int64_t rlim_to_int64(rlim_t value) {
+  if (value == RLIM_INFINITY) {
+    return INT64_MAX;
+  }
+  if (sizeof(rlim_t) > sizeof(int64_t) && value > (rlim_t)INT64_MAX) {
+    return INT64_MAX;
+  }
+  return (int64_t)value;
+}
+
+static rlim_t int64_to_rlim(int64_t value) {
+  if (value < 0) {
+    caml_invalid_argument("nofile limit must be non-negative");
+  }
+  if ((uint64_t)value > (uint64_t)RLIM_INFINITY) {
+    return RLIM_INFINITY;
+  }
+  return (rlim_t)value;
+}
+
+CAMLprim value discord_agents_get_nofile_limit(value unit) {
+  CAMLparam1(unit);
+  CAMLlocal3(result, soft, hard);
+  struct rlimit limit;
+
+  if (getrlimit(RLIMIT_NOFILE, &limit) != 0) {
+    caml_failwith(strerror(errno));
+  }
+
+  soft = caml_copy_int64(rlim_to_int64(limit.rlim_cur));
+  hard = caml_copy_int64(rlim_to_int64(limit.rlim_max));
+  result = caml_alloc_tuple(2);
+  Store_field(result, 0, soft);
+  Store_field(result, 1, hard);
+  CAMLreturn(result);
+}
+
+CAMLprim value discord_agents_set_nofile_soft_limit(value soft_v) {
+  CAMLparam1(soft_v);
+  struct rlimit limit;
+
+  if (getrlimit(RLIMIT_NOFILE, &limit) != 0) {
+    caml_failwith(strerror(errno));
+  }
+
+  limit.rlim_cur = int64_to_rlim(Int64_val(soft_v));
+  if (setrlimit(RLIMIT_NOFILE, &limit) != 0) {
+    caml_failwith(strerror(errno));
+  }
+
+  CAMLreturn(Val_unit);
+}

--- a/lib/runtime_limits.ml
+++ b/lib/runtime_limits.ml
@@ -1,0 +1,44 @@
+(** Process resource limit hardening for long-running daemon mode. *)
+
+type nofile_limit = {
+  soft : int64;
+  hard : int64;
+}
+
+let desired_nofile_soft_limit = 65_536L
+
+external get_nofile_limit_raw : unit -> int64 * int64 =
+  "discord_agents_get_nofile_limit"
+
+external set_nofile_soft_limit_raw : int64 -> unit =
+  "discord_agents_set_nofile_soft_limit"
+
+let get_nofile_limit () =
+  let soft, hard = get_nofile_limit_raw () in
+  { soft; hard }
+
+let nofile_target ~desired { soft; hard } =
+  if soft >= desired then
+    None
+  else
+    let target = min desired hard in
+    if target > soft then Some target else None
+
+let bump_nofile ?(desired=desired_nofile_soft_limit) () =
+  try
+    let before = get_nofile_limit () in
+    match nofile_target ~desired before with
+    | None ->
+      Logs.info (fun m ->
+        m "runtime_limits: nofile soft limit already %Ld (hard %Ld)"
+          before.soft before.hard)
+    | Some target ->
+      set_nofile_soft_limit_raw target;
+      let after = get_nofile_limit () in
+      Logs.info (fun m ->
+        m "runtime_limits: raised nofile soft limit from %Ld to %Ld (hard %Ld)"
+          before.soft after.soft after.hard)
+  with exn ->
+    Logs.warn (fun m ->
+      m "runtime_limits: failed to raise nofile soft limit: %s"
+        (Printexc.to_string exn))

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,6 @@
 (tests
  (names test_formatting test_project test_agent_contracts test_discord_rest test_gateway
-  test_runtime_settings test_bot_defaults test_session_store test_disk_health test_config)
+  test_runtime_settings test_bot_defaults test_session_store test_disk_health test_config
+  test_runtime_limits)
  (libraries discord_agents alcotest str unix yojson eio.mock eio_main cohttp-eio
   uri mirage-crypto-rng.unix))

--- a/test/test_discord_rest.ml
+++ b/test/test_discord_rest.ml
@@ -10,18 +10,18 @@ let ensure_rng () =
 
 let response ?(headers = Http.Header.of_list []) code body =
   (Http.Response.make ~status:(Http.Status.of_int code) ~headers (),
-   Cohttp_eio.Body.of_string body)
+   body,
+   false)
 
 let with_fake_rest call f =
   ensure_rng ();
   Eio_main.run @@ fun env ->
-  Eio.Switch.run @@ fun sw ->
   let t : Rest.t = {
     token = "test-token";
     call;
-    sw;
     clock = Eio.Stdenv.mono_clock env;
     rest_state = Rest.create_health_state ();
+    api_base = Rest.api_base;
   } in
   f t
 
@@ -406,7 +406,7 @@ let test_read_body_reports_truncation () =
 
 let test_create_message_reuses_nonce_across_5xx_retry () =
   let attempts = ref [] in
-  let call ~sw:_ ~headers:_ ?body meth uri =
+  let call ~headers:_ ?body meth uri =
     attempts := (meth, Uri.path uri, body_json body) :: !attempts;
     match List.length !attempts with
     | 1 ->
@@ -437,7 +437,7 @@ let test_create_message_reuses_nonce_across_5xx_retry () =
 
 let test_create_channel_does_not_retry_5xx () =
   let attempts = ref 0 in
-  let call ~sw:_ ~headers:_ ?body:_ _meth _uri =
+  let call ~headers:_ ?body:_ _meth _uri =
     incr attempts;
     response 500 {|{"message":"server unavailable"}|}
   in
@@ -448,7 +448,7 @@ let test_create_channel_does_not_retry_5xx () =
     Alcotest.(check int) "single non-idempotent attempt" 1 !attempts
 
 let test_401_marks_rest_health_without_transport_backoff () =
-  let call ~sw:_ ~headers:_ ?body:_ _meth _uri =
+  let call ~headers:_ ?body:_ _meth _uri =
     response 401 {|{"message":"bad auth"}|}
   in
   with_fake_rest call @@ fun t ->
@@ -464,6 +464,69 @@ let test_401_marks_rest_health_without_transport_backoff () =
       1 (Rest.consecutive_rest_failures t);
     Alcotest.(check int) "transport failure not recorded"
       0 (Rest.consecutive_transport_failures t)
+
+let count_open_fds () =
+  if Sys.file_exists "/proc/self/fd" then
+    Some (Array.length (Sys.readdir "/proc/self/fd"))
+  else
+    None
+
+let local_server_addr socket =
+  match Eio.Net.listening_addr socket with
+  | `Tcp (_addr, port) -> Printf.sprintf "http://127.0.0.1:%d" port
+  | `Unix path -> Alcotest.failf "unexpected Unix listening socket %s" path
+
+let run_local_json_server env sw f =
+  let net = Eio.Stdenv.net env in
+  let addr = `Tcp (Eio.Net.Ipaddr.V4.loopback, 0) in
+  let socket = Eio.Net.listen ~sw ~backlog:64 ~reuse_addr:true net addr in
+  let stop, stop_resolver = Eio.Promise.create () in
+  let server =
+    Cohttp_eio.Server.make
+      ~callback:(fun _conn _request _body response ->
+        Cohttp_eio.Server.respond
+          ~headers:(Http.Header.of_list [("connection", "close")])
+          ~status:`OK
+          ~body:(Cohttp_eio.Body.of_string "{}")
+          () response)
+      ()
+  in
+  Eio.Fiber.fork ~sw (fun () ->
+    Cohttp_eio.Server.run ~stop ~on_error:raise socket server);
+  Fun.protect
+    ~finally:(fun () -> Eio.Promise.resolve stop_resolver ())
+    (fun () -> f (local_server_addr socket))
+
+let test_requests_close_response_sockets () =
+  match count_open_fds () with
+  | None ->
+    Alcotest.skip ()
+  | Some _ ->
+    Eio_main.run @@ fun env ->
+    Eio.Switch.run @@ fun sw ->
+    run_local_json_server env sw @@ fun api_base ->
+    let rest =
+      Discord_agents.Discord_rest.create_with_api_base
+        ~api_base ~sw ~env ~token:"test-token"
+    in
+    let before =
+      match count_open_fds () with
+      | Some count -> count
+      | None -> Alcotest.fail "lost /proc/self/fd during test"
+    in
+    for _i = 1 to 64 do
+      match Discord_agents.Discord_rest.request rest ~meth:`GET ~path:"/ok" () with
+      | Ok _ -> ()
+      | Error err -> Alcotest.failf "REST request failed: %s" err
+    done;
+    Eio.Time.sleep (Eio.Stdenv.clock env) 0.1;
+    let after =
+      match count_open_fds () with
+      | Some count -> count
+      | None -> Alcotest.fail "lost /proc/self/fd during test"
+    in
+    Alcotest.(check bool) "fd count remains bounded"
+      true (after <= before + 8)
 
 let () =
   Alcotest.run "discord_rest" [
@@ -514,5 +577,7 @@ let () =
         test_create_channel_does_not_retry_5xx;
       Alcotest.test_case "401 marks rest health without transport backoff" `Quick
         test_401_marks_rest_health_without_transport_backoff;
+      Alcotest.test_case "requests close response sockets" `Quick
+        test_requests_close_response_sockets;
     ]);
   ]

--- a/test/test_runtime_limits.ml
+++ b/test/test_runtime_limits.ml
@@ -1,0 +1,40 @@
+let limit soft hard =
+  Discord_agents.Runtime_limits.{ soft; hard }
+
+let test_nofile_target_raises_to_desired () =
+  Alcotest.(check (option int64)) "target"
+    (Some 65_536L)
+    (Discord_agents.Runtime_limits.nofile_target
+       ~desired:65_536L (limit 1_024L 1_048_576L))
+
+let test_nofile_target_caps_at_hard_limit () =
+  Alcotest.(check (option int64)) "target"
+    (Some 4_096L)
+    (Discord_agents.Runtime_limits.nofile_target
+       ~desired:65_536L (limit 1_024L 4_096L))
+
+let test_nofile_target_does_not_lower_existing_soft_limit () =
+  Alcotest.(check (option int64)) "target"
+    None
+    (Discord_agents.Runtime_limits.nofile_target
+       ~desired:65_536L (limit 131_072L 1_048_576L))
+
+let test_nofile_target_noop_when_hard_not_above_soft () =
+  Alcotest.(check (option int64)) "target"
+    None
+    (Discord_agents.Runtime_limits.nofile_target
+       ~desired:65_536L (limit 1_024L 512L))
+
+let () =
+  Alcotest.run "runtime_limits" [
+    ("nofile", [
+      Alcotest.test_case "raises to desired" `Quick
+        test_nofile_target_raises_to_desired;
+      Alcotest.test_case "caps at hard limit" `Quick
+        test_nofile_target_caps_at_hard_limit;
+      Alcotest.test_case "does not lower existing soft limit" `Quick
+        test_nofile_target_does_not_lower_existing_soft_limit;
+      Alcotest.test_case "noop when hard not above soft" `Quick
+        test_nofile_target_noop_when_hard_not_above_soft;
+    ]);
+  ]


### PR DESCRIPTION
## Summary
- Bound each Discord REST attempt to a short-lived Eio switch so HTTP sockets close after the response body is drained.
- Add a local fd-regression test that repeatedly calls a local REST endpoint and asserts descriptor usage stays bounded.
- Raise the daemon startup `nofile` soft limit toward 65536, capped by the OS hard limit.

## Tests
- `nix develop --command dune exec ./test/test_runtime_limits.exe`
- `nix develop --command dune exec ./test/test_discord_rest.exe`
- `nix develop --command dune runtest`