### PR TITLE
fix: harden post-stack restart paths

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -150,7 +150,7 @@ let () =
     in
     let run_control_api_supervised () =
       let clock = Eio.Stdenv.clock env in
-      let rec loop () =
+      let rec loop retry_delay =
         if bot.gateway.shutdown then
           ()
         else
@@ -165,8 +165,8 @@ let () =
             bot.control_api_restarts <- bot.control_api_restarts + 1;
             bot.last_control_api_error <- Some err;
             Logs.warn (fun m -> m "bot: %s" err);
-            Eio.Time.sleep clock 1.0;
-            loop ()
+            Eio.Time.sleep clock retry_delay;
+            loop (Discord_agents.Bot.supervisor_next_backoff_s retry_delay)
           | Error _exn when bot.gateway.shutdown -> ()
           | Error exn ->
             Discord_agents.Bot.reraise_if_fatal_policy_exception exn;
@@ -175,10 +175,10 @@ let () =
             bot.last_control_api_error <- Some err;
             Logs.warn (fun m ->
               m "bot: control_api supervisor restarting after error: %s" err);
-            Eio.Time.sleep clock 1.0;
-            loop ()
+            Eio.Time.sleep clock retry_delay;
+            loop (Discord_agents.Bot.supervisor_next_backoff_s retry_delay)
       in
-      loop ()
+      loop Discord_agents.Bot.supervisor_initial_backoff_s
     in
     (* Shutdown via pipe: signal handler writes a byte, fiber reads it.
        No Eio I/O in the signal handler — just a raw Unix write. *)

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1201,15 +1201,35 @@ let write_file_safely ~path contents =
          m "agent_process: failed to write %s: %s"
            path (Printexc.to_string exn)))
 
-let read_file_opt path =
+type read_file_result =
+  | File_missing
+  | File_contents of string
+  | File_read_error of exn
+
+let read_file_result path =
   try
-    let ic = open_in path in
-    Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
-      let n = in_channel_length ic in
-      let s = Bytes.create n in
-      really_input ic s 0 n;
-      Some (Bytes.to_string s))
-  with _ -> None
+    if not (Sys.file_exists path) then
+      File_missing
+    else
+      let ic = open_in path in
+      Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
+        let n = in_channel_length ic in
+        let s = Bytes.create n in
+        really_input ic s 0 n;
+        File_contents (Bytes.to_string s))
+  with exn ->
+    if Sys.file_exists path then File_read_error exn else File_missing
+
+let read_file_opt path =
+  match read_file_result path with
+  | File_contents contents -> Some contents
+  | File_missing
+  | File_read_error _ -> None
+
+let log_file_read_failure ~path exn =
+  Logs.warn (fun m ->
+    m "agent_process: failed to read %s; leaving it unchanged: %s"
+      path (Printexc.to_string exn))
 
 let contains_substring text needle =
   let nlen = String.length needle in
@@ -1304,6 +1324,17 @@ let exclude_already_lists_gemini text =
     let trimmed = String.trim line in
     trimmed = ".gemini/" || trimmed = ".gemini")
 
+let merge_gemini_exclude existing =
+  match existing with
+  | Some text when exclude_already_lists_gemini text -> text
+  | existing ->
+    let text = Option.value existing ~default:"" in
+    let prefix =
+      if text = "" || String.ends_with ~suffix:"\n" text then text
+      else text ^ "\n"
+    in
+    prefix ^ ".gemini/\n"
+
 (** Gemini: drop our entry into [.gemini/settings.json] (merging into
     any pre-existing user config) and ensure [.gemini/] is in the
     repo's [info/exclude]. Both writes are idempotent — re-running
@@ -1320,24 +1351,24 @@ let setup_gemini_mcp ~working_dir =
      if not (Sys.file_exists gemini_dir) then Unix.mkdir gemini_dir 0o755
    with _ -> ());
   let settings_path = Filename.concat gemini_dir "settings.json" in
-  let merged = merge_gemini_settings (read_file_opt settings_path) in
-  write_file_safely ~path:settings_path merged;
+  (match read_file_result settings_path with
+   | File_read_error exn -> log_file_read_failure ~path:settings_path exn
+   | File_missing ->
+     write_file_safely ~path:settings_path
+       (merge_gemini_settings None)
+   | File_contents existing ->
+     write_file_safely ~path:settings_path
+       (merge_gemini_settings (Some existing)));
   match resolve_git_info_exclude ~working_dir with
   | None -> ()
   | Some exclude_path ->
-    match read_file_opt exclude_path with
-    | Some existing when exclude_already_lists_gemini existing -> ()
-    | _ ->
-      try
-        (* exclude_path may live in a directory git hasn't materialized
-           (e.g. a fresh worktree's info/). Create it if missing. *)
-        let info_dir = Filename.dirname exclude_path in
-        (try if not (Sys.file_exists info_dir) then Unix.mkdir info_dir 0o755
-         with _ -> ());
-        let oc = open_out_gen [Open_append; Open_creat] 0o644 exclude_path in
-        Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
-          output_string oc "\n.gemini/\n")
-      with _ -> ()
+    match read_file_result exclude_path with
+    | File_read_error exn -> log_file_read_failure ~path:exclude_path exn
+    | File_contents existing when exclude_already_lists_gemini existing -> ()
+    | File_contents existing ->
+      write_file_safely ~path:exclude_path (merge_gemini_exclude (Some existing))
+    | File_missing ->
+      write_file_safely ~path:exclude_path (merge_gemini_exclude None)
 
 (** Escape a string for embedding inside a TOML double-quoted string.
     Beyond backslash and double-quote (the cases we actually hit with
@@ -1421,6 +1452,31 @@ let gemini_args ~session_id ~session_id_confirmed ~prompt =
   if not session_id_confirmed then base
   else base @ ["--resume"; session_id]
 
+let executable_in_path name =
+  if Filename.is_implicit name then
+    Sys.getenv_opt "PATH"
+    |> Option.value ~default:""
+    |> String.split_on_char ':'
+    |> List.filter_map (fun dir ->
+      let dir = if dir = "" then "." else dir in
+      let path = Filename.concat dir name in
+      if Sys.file_exists path && not (Sys.is_directory path) then Some path
+      else None)
+    |> List.find_opt (fun path ->
+      try Unix.access path [Unix.X_OK]; true
+      with Unix.Unix_error _ -> false)
+  else if Sys.file_exists name && not (Sys.is_directory name) then
+    (try Unix.access name [Unix.X_OK]; Some name with Unix.Unix_error _ -> None)
+  else
+    None
+
+let setsid_command () =
+  match executable_in_path "setsid" with
+  | Some path -> path
+  | None ->
+    failwith
+      "agent_process: required command `setsid` was not found in PATH; install util-linux or start discord-agents with setsid available"
+
 (** Compose the per-turn prompt sent to a non-Claude agent, prepending
     the session's system prompt on the first turn so MCP-aware agents
     know what tools they have. Claude takes [--append-system-prompt]
@@ -1457,6 +1513,9 @@ let run_streaming ~sw ~env ~working_dir ~kind ~session_id ~message_count
      [--append-system-prompt] flag instead. *)
   let prompt = compose_session_prompt
     ~agent_kind:kind ~system_prompt ~message_count ~user_prompt:prompt in
+  let close_noerr flow =
+    try Eio.Resource.close flow with _ -> ()
+  in
   let args = match kind with
     | Config.Claude ->
       let base = claude_args ~session_id ~message_count ~prompt in
@@ -1470,50 +1529,68 @@ let run_streaming ~sw ~env ~working_dir ~kind ~session_id ~message_count
       setup_gemini_mcp ~working_dir;
       gemini_args ~session_id ~session_id_confirmed ~prompt
   in
-  let args = ["setsid"; "--wait"] @ args in
+  let args = [setsid_command (); "--wait"] @ args in
   let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
-  let stderr_r, stderr_w = Eio.Process.pipe ~sw mgr in
-  let proc = Eio.Process.spawn ~sw mgr ~cwd
-    ~stdout:stdout_w ~stderr:stderr_w args in
-  (match on_pid with Some f -> f (Eio.Process.pid proc) | None -> ());
-  (* Close write ends so reads get EOF when process exits *)
-  Eio.Resource.close stdout_w;
-  Eio.Resource.close stderr_w;
-  (* Read stdout and stderr concurrently to avoid deadlock.
-     If the child fills the stderr pipe buffer (~64KB) before stdout
-     hits EOF, the child blocks on write and stdout never closes. *)
-  let stderr_buf = Buffer.create 1024 in
-  Eio.Fiber.both
-    (fun () ->
-      (* Drain stderr in parallel *)
+  try
+    let stderr_r, stderr_w = Eio.Process.pipe ~sw mgr in
+    try
+      let proc = Eio.Process.spawn ~sw mgr ~cwd
+        ~stdout:stdout_w ~stderr:stderr_w args in
+      (* Close write ends so reads get EOF when process exits. Do this before
+         callbacks so callback failures cannot strand pipe writers on [sw]. *)
+      Eio.Resource.close stdout_w;
+      Eio.Resource.close stderr_w;
       (try
-        let sr = Eio.Buf_read.of_flow ~max_size:(64 * 1024) stderr_r in
-        Buffer.add_string stderr_buf (Eio.Buf_read.take_all sr)
-      with End_of_file -> ());
-      Eio.Resource.close stderr_r)
-    (fun () ->
-      (* Read stdout line by line and parse events *)
-      let reader = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) stdout_r in
-      (try
-        while true do
-          let line = Eio.Buf_read.line reader in
-          if String.length line > 0 then begin
-            let events = match kind with
-              | Config.Claude -> parse_stream_json_line line
-              | Config.Codex -> parse_codex_json_line line
-              | Config.Gemini -> parse_gemini_stream_json_line line
-            in
-            List.iter on_event events
-          end
-        done
-      with End_of_file -> ());
-      Eio.Resource.close stdout_r);
-  let stderr_text = Buffer.contents stderr_buf in
-  (* Wait for process to finish *)
-  let status = Eio.Process.await proc in
-  match status with
-  | `Exited 0 -> Ok ()
-  | `Exited code ->
-    Error (Printf.sprintf "agent exited with code %d: %s" code stderr_text)
-  | `Signaled sig_ ->
-    Error (Printf.sprintf "agent killed by signal %d" sig_)
+         (match on_pid with Some f -> f (Eio.Process.pid proc) | None -> ())
+       with exn ->
+         close_noerr stdout_r;
+         close_noerr stderr_r;
+         raise exn);
+      (* Read stdout and stderr concurrently to avoid deadlock.
+         If the child fills the stderr pipe buffer (~64KB) before stdout
+         hits EOF, the child blocks on write and stdout never closes. *)
+      let stderr_buf = Buffer.create 1024 in
+      Eio.Fiber.both
+        (fun () ->
+          (* Drain stderr in parallel *)
+          (try
+             let sr = Eio.Buf_read.of_flow ~max_size:(64 * 1024) stderr_r in
+             Buffer.add_string stderr_buf (Eio.Buf_read.take_all sr)
+           with End_of_file -> ());
+          Eio.Resource.close stderr_r)
+        (fun () ->
+          (* Read stdout line by line and parse events *)
+          let reader = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) stdout_r in
+          (try
+             while true do
+               let line = Eio.Buf_read.line reader in
+               if String.length line > 0 then begin
+                 let events = match kind with
+                   | Config.Claude -> parse_stream_json_line line
+                   | Config.Codex -> parse_codex_json_line line
+                   | Config.Gemini -> parse_gemini_stream_json_line line
+                 in
+                 List.iter on_event events
+               end
+             done
+           with End_of_file -> ());
+          Eio.Resource.close stdout_r);
+      let stderr_text = Buffer.contents stderr_buf in
+      (* Wait for process to finish *)
+      let status = Eio.Process.await proc in
+      match status with
+      | `Exited 0 -> Ok ()
+      | `Exited code ->
+        Error (Printf.sprintf "agent exited with code %d: %s" code stderr_text)
+      | `Signaled sig_ ->
+        Error (Printf.sprintf "agent killed by signal %d" sig_)
+    with exn ->
+      close_noerr stdout_r;
+      close_noerr stdout_w;
+      close_noerr stderr_r;
+      close_noerr stderr_w;
+      raise exn
+  with exn ->
+    close_noerr stdout_r;
+    close_noerr stdout_w;
+    raise exn

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -68,6 +68,7 @@ type t = {
   mutable refreshing : bool;
   mutable output_lines : int;
   mutable policy_sync_clear_last_warning : (string * string) option;
+  mutable last_top_level_disk_refresh_at : float;
   mutable gateway_supervisor_restarts : int;
   mutable control_api_restarts : int;
   mutable last_gateway_supervisor_error : string option;
@@ -162,15 +163,36 @@ let is_persistent_session t ~thread_id (session : Session_store.session) =
 let refresh_session_disk_state (session : Session_store.session) =
   ignore (Disk_health.preflight_write session.working_dir)
 
-let refresh_persistent_session_disk_state t =
+let persistent_session_working_dirs t =
   Session_store.bindings t.sessions
-  |> List.iter (fun (thread_id, (session : Session_store.session)) ->
+  |> List.filter_map (fun (thread_id, (session : Session_store.session)) ->
     if is_persistent_session t ~thread_id session then
-      refresh_session_disk_state session)
+      Some session.working_dir
+    else
+      None)
+  |> List.sort_uniq String.compare
 
-let refresh_top_level_disk_state t =
-  refresh_disk_state ();
-  refresh_persistent_session_disk_state t
+let refresh_persistent_session_disk_state t =
+  persistent_session_working_dirs t
+  |> List.iter (fun working_dir ->
+    ignore (Disk_health.preflight_write working_dir))
+
+let min_top_level_disk_refresh_interval_s = 5.0
+
+let refresh_top_level_disk_state ?(force=false) t =
+  let now = Unix.gettimeofday () in
+  if force
+     || now -. t.last_top_level_disk_refresh_at
+        >= min_top_level_disk_refresh_interval_s
+  then begin
+    let persistent_session_dirs = persistent_session_working_dirs t in
+    t.last_top_level_disk_refresh_at <- now;
+    Eio_unix.run_in_systhread (fun () ->
+      refresh_disk_state ();
+      List.iter
+        (fun working_dir -> ignore (Disk_health.preflight_write working_dir))
+        persistent_session_dirs)
+  end
 
 let session_converged_to_top_level_policy expected_agent
     (session : Session_store.session) =
@@ -948,7 +970,7 @@ let run_top_level_policy_change t ~current_channel_id
          Ok rotation)
 
 let set_default_agent t ?(current_channel_id=None) kind =
-  refresh_top_level_disk_state t;
+  refresh_top_level_disk_state ~force:true t;
   let simulated_settings : Runtime_settings.t = {
     t.settings with default_agent = kind;
   } in
@@ -962,7 +984,7 @@ let set_default_agent t ?(current_channel_id=None) kind =
     ~policy_label:"default-agent"
 
 let set_rescue_agent t ?(current_channel_id=None) kind =
-  refresh_top_level_disk_state t;
+  refresh_top_level_disk_state ~force:true t;
   let simulated_settings : Runtime_settings.t = {
     t.settings with rescue_agent = kind;
   } in
@@ -1068,22 +1090,33 @@ let mark_active_run_failed t (session : Session_store.session)
   ignore (Discord_rest.create_reaction t.rest
     ~channel_id:session.thread_id ~message_id ~emoji:"\xE2\x9D\x8C" ())
 
-let reconcile_interrupted_active_runs ?(mark_failed=mark_active_run_failed) t =
-  Session_store.bindings t.sessions
-  |> List.iter (fun (_thread_id, (session : Session_store.session)) ->
-    match session.active_run with
-    | None -> ()
-    | Some active_run ->
-      (match active_run.child_process with
-       | Some child ->
-         ignore (reap_tracked_child_processes_blocking t
-           ~reason:"startup cleanup" [child])
-       | None -> ());
-      mark_failed t session ~message_id:active_run.message_id;
-      if forget_active_run t session ~context:"startup" then
-        Logs.info (fun m ->
-          m "bot: reconciled interrupted active run for %s"
-            session.thread_id))
+let reconcile_interrupted_active_runs
+    ?(mark_failed=mark_active_run_failed)
+    ?(reap_children=(fun t children ->
+      ignore (reap_tracked_child_processes_blocking t
+        ~reason:"startup cleanup" children)))
+    t =
+  let interrupted =
+    Session_store.bindings t.sessions
+    |> List.filter_map (fun (_thread_id, (session : Session_store.session)) ->
+      match session.active_run with
+      | None -> None
+      | Some active_run -> Some (session, active_run))
+  in
+  let children =
+    interrupted
+    |> List.filter_map (fun (_session, (active_run : Session_store.active_run)) ->
+      active_run.child_process)
+  in
+  if children <> [] then
+    reap_children t children;
+  List.iter (fun ((session : Session_store.session), active_run) ->
+    mark_failed t session ~message_id:active_run.Session_store.message_id;
+    if forget_active_run t session ~context:"startup" then
+      Logs.info (fun m ->
+        m "bot: reconciled interrupted active run for %s"
+          session.thread_id))
+    interrupted
 
 let persist_completed_run ?(save=Session_store.save) t
     (session : Session_store.session) ~had_initial_prompt =
@@ -1138,7 +1171,7 @@ let reconcile_persisted_stop_requests t =
             session.thread_id err))
 
 let reconcile_persisted_pending_agent_changes t =
-  refresh_top_level_disk_state t;
+  refresh_top_level_disk_state ~force:true t;
   Session_store.bindings t.sessions
   |> List.iter (fun (_thread_id, (session : Session_store.session)) ->
     match session.pending_agent_change with
@@ -1213,9 +1246,10 @@ let trigger_restart t ~notify =
         in
         wait ()
       end;
-      (* Clear any remaining queued messages and notify users *)
+      (* Clear any remaining queued messages without spawning best-effort REST
+         reaction updates while the process is trying to shed load. *)
       List.iter (fun (_tid, (s : Session_store.session)) ->
-        ignore (drop_queued_messages t s ~reason:"restart")
+        ignore (drop_queued_messages ~mark_failed:false t s ~reason:"restart")
       ) (Session_store.bindings t.sessions);
       (* Phase 2: Reap child processes. *)
       let children = child_processes_for_restart t in
@@ -2344,6 +2378,16 @@ let rec process_session_message_with_hooks hooks t session
       let author_name = msg.author.username in
       let (channel_name, channel_type) =
         resolve_channel_context t ~channel_id ~session ?channel_info () in
+      let expected_start_ticks_for_pid pid =
+        match active_child_process session with
+        | Some child when child.pid = pid -> Some child.start_ticks
+        | Some _
+        | None -> None
+      in
+      let stop_child_after_checkpoint_failure ~reason pid =
+        ignore (request_tracked_child_stop t ~reason ~pid
+          ~expected_start_ticks:(expected_start_ticks_for_pid pid))
+      in
       let on_pid pid =
         child_pid := Some pid;
         register_child_pid t session pid;
@@ -2362,8 +2406,12 @@ let rec process_session_message_with_hooks hooks t session
                 m "bot: failed to persist child identity for %s: %s"
                   session.thread_id err))
          | None ->
+           let err = "could not capture child process identity" in
+           checkpoint_failure := Some err;
+           stop_child_after_checkpoint_failure
+             ~reason:"checkpoint identity capture failure" pid;
            Logs.warn (fun m ->
-             m "bot: could not capture child identity for %s; restart cleanup is degraded for this run"
+             m "bot: could not capture child identity for %s; aborting run because restart cleanup would be unsafe"
                session.thread_id));
         if session.stop_requested then
           ignore (request_session_process_stop t session);
@@ -2422,9 +2470,15 @@ let rec process_session_message_with_hooks hooks t session
           hooks.set_session_id t.sessions session
             ~session_id:sid
         with exn ->
+          let err = Printexc.to_string exn in
+          checkpoint_failure := Some err;
+          Option.iter
+            (stop_child_after_checkpoint_failure
+               ~reason:"checkpoint session id failure")
+            !child_pid;
           Logs.warn (fun m ->
             m "bot: failed to persist session id for %s: %s"
-              session.thread_id (Printexc.to_string exn))
+              session.thread_id err)
       in
       let result =
         try
@@ -2761,6 +2815,7 @@ let create ~sw ~(env : Eio_unix.Stdenv.base) config =
                refreshing = false;
                output_lines = Agent_process.default_output_lines;
                policy_sync_clear_last_warning = None;
+               last_top_level_disk_refresh_at = 0.0;
                gateway_supervisor_restarts = 0;
                control_api_restarts = 0;
                last_gateway_supervisor_error = None;
@@ -2836,9 +2891,15 @@ let exn_with_backtrace exn =
   else
     Printf.sprintf "%s\n%s" (Printexc.to_string exn) bt
 
+let supervisor_initial_backoff_s = 1.0
+let supervisor_max_backoff_s = 60.0
+
+let supervisor_next_backoff_s delay =
+  min supervisor_max_backoff_s (max supervisor_initial_backoff_s (delay *. 2.0))
+
 let supervise_bot_component t ~label ~note_restart run_once =
   let clock = Eio.Stdenv.clock t.env in
-  let rec loop () =
+  let rec loop retry_delay =
     if t.gateway.shutdown then
       ()
     else
@@ -2851,18 +2912,18 @@ let supervise_bot_component t ~label ~note_restart run_once =
         let err = Printf.sprintf "%s loop exited without shutdown" label in
         note_restart err;
         Logs.warn (fun m -> m "bot: %s" err);
-        Eio.Time.sleep clock 1.0;
-        loop ()
+        Eio.Time.sleep clock retry_delay;
+        loop (supervisor_next_backoff_s retry_delay)
       | Error _exn when t.gateway.shutdown -> ()
       | Error exn ->
         reraise_if_fatal_policy_exception exn;
         let err = exn_with_backtrace exn in
         note_restart err;
         Logs.warn (fun m -> m "bot: %s supervisor restarting after error: %s" label err);
-        Eio.Time.sleep clock 1.0;
-        loop ()
+        Eio.Time.sleep clock retry_delay;
+        loop (supervisor_next_backoff_s retry_delay)
   in
-  loop ()
+  loop supervisor_initial_backoff_s
 
 let run_gateway_supervised ~(env : Eio_unix.Stdenv.base) t =
   supervise_bot_component t ~label:"gateway" ~note_restart:(fun err ->

--- a/lib/disk_space_stubs.c
+++ b/lib/disk_space_stubs.c
@@ -1,21 +1,35 @@
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/memory.h>
+#include <caml/threads.h>
 #include <caml/mlvalues.h>
 
 #include <errno.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/statvfs.h>
 
 CAMLprim value discord_agents_available_bytes(value path_v)
 {
   CAMLparam1(path_v);
+  CAMLlocal1(result);
   struct statvfs st;
-  const char *path = String_val(path_v);
+  char *path = strdup(String_val(path_v));
+  if (path == NULL) {
+    caml_failwith("out of memory");
+  }
 
-  if (statvfs(path, &st) != 0) {
-    caml_failwith(strerror(errno));
+  int rc;
+  int saved_errno;
+  caml_enter_blocking_section();
+  rc = statvfs(path, &st);
+  saved_errno = errno;
+  caml_leave_blocking_section();
+  free(path);
+
+  if (rc != 0) {
+    caml_failwith(strerror(saved_errno));
   }
 
   unsigned __int128 bytes =
@@ -24,5 +38,6 @@ CAMLprim value discord_agents_available_bytes(value path_v)
     bytes = (unsigned __int128) INT64_MAX;
   }
 
-  CAMLreturn(caml_copy_int64((int64_t) bytes));
+  result = caml_copy_int64((int64_t) bytes);
+  CAMLreturn(result);
 }

--- a/lib/resource.ml
+++ b/lib/resource.ml
@@ -186,17 +186,45 @@ let write_file_atomic ?(fsync_parent=fsync_dir) path content =
       (try Sys.remove tmp with _ -> ());
     raise exn
 
+let in_process_flock_table_mu = Mutex.create ()
+let in_process_flock_table : (string, Mutex.t) Hashtbl.t = Hashtbl.create 16
+
+let in_process_flock_mutex lock_path =
+  Mutex.lock in_process_flock_table_mu;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock in_process_flock_table_mu)
+    (fun () ->
+       match Hashtbl.find_opt in_process_flock_table lock_path with
+       | Some mu -> mu
+       | None ->
+         let mu = Mutex.create () in
+         Hashtbl.add in_process_flock_table lock_path mu;
+         mu)
+
 (** Execute f while holding an exclusive flock on lock_path.
-    Used for cross-process synchronization (bot + MCP server). *)
+    Used for cross-process synchronization (bot + MCP server).
+
+    POSIX record locks are per-process, so the OS lock alone does not
+    serialize two fibers in this bot process. The in-process mutex closes
+    that gap, while [lockf] still coordinates with the MCP helper process.
+    Callers must keep [f] synchronous: doing Eio I/O while holding this
+    stdlib mutex can deadlock the scheduler if another fiber contends on
+    the same lock path. The table is intentionally never pruned; current
+    callers use a bounded set of config/session lock paths. *)
 let with_flock lock_path f =
-  ensure_parent_dir lock_path;
-  let fd = Unix.openfile lock_path [Unix.O_WRONLY; Unix.O_CREAT] 0o600 in
+  let in_process_mu = in_process_flock_mutex lock_path in
+  Mutex.lock in_process_mu;
   Fun.protect ~finally:(fun () ->
-    (try Unix.lockf fd Unix.F_ULOCK 0 with _ -> ());
-    Unix.close fd
+    Mutex.unlock in_process_mu
   ) (fun () ->
-    Unix.lockf fd Unix.F_LOCK 0;
-    f ())
+    ensure_parent_dir lock_path;
+    let fd = Unix.openfile lock_path [Unix.O_WRONLY; Unix.O_CREAT] 0o600 in
+    Fun.protect ~finally:(fun () ->
+      (try Unix.lockf fd Unix.F_ULOCK 0 with _ -> ());
+      Unix.close fd
+    ) (fun () ->
+      Unix.lockf fd Unix.F_LOCK 0;
+      f ()))
 
 (** Generate a random hex string of the given byte length using mirage-crypto-rng. *)
 let random_hex n =

--- a/test/test_agent_contracts.ml
+++ b/test/test_agent_contracts.ml
@@ -14,8 +14,8 @@
       a missing gemini shouldn't fail tests for someone who only uses
       codex. The skip notice is printed at suite start so it stays
       visible.
-    - Detected auth failure — that's a user config issue, not a
-      contract drift in the binary.
+    - Detected auth/quota failure — that's a user config/capacity
+      issue, not a contract drift in the binary.
 
     Tests FAIL (not skip) on anything else: non-zero exit with a
     non-auth-looking error, missing event fields, schema drift.
@@ -47,14 +47,16 @@ let contains_substring text needle =
     true
   with Not_found -> false
 
-(** Heuristic union of auth-failure messages across the three
+(** Heuristic union of auth/quota-failure messages across the three
     binaries. Any match short-circuits to a clean skip — auth is
-    user config, not a contract drift. *)
+    user config and quota is external capacity, not a contract drift. *)
 let auth_failure_indicators = [
   "unauthenticated"; "Unauthorized"; "Not authorized";
   "API key"; "api_key"; "401"; "403";
   "log in"; "Please log in"; "login required";
   "Please run"; "authenticate"; "credentials"; "OAuth";
+  "429"; "QUOTA_EXHAUSTED"; "TerminalQuotaError";
+  "exhausted your capacity";
 ]
 
 let looks_like_auth_failure text =

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -69,6 +69,7 @@ let with_test_bot f =
         refreshing = false;
         output_lines = Discord_agents.Agent_process.default_output_lines;
         policy_sync_clear_last_warning = None;
+        last_top_level_disk_refresh_at = 0.0;
         gateway_supervisor_restarts = 0;
         control_api_restarts = 0;
         last_gateway_supervisor_error = None;
@@ -1216,6 +1217,33 @@ let test_reconcile_interrupted_active_runs_clears_checkpoint () =
         true (Option.is_none saved.active_run)
     | None -> Alcotest.fail "expected reloaded session")
 
+let test_reconcile_interrupted_active_runs_reaps_children_in_one_batch () =
+  with_test_bot (fun bot ->
+    let child pid start_ticks = Discord_agents.Session_store.{
+      pid;
+      start_ticks;
+    } in
+    let add_active thread_id pid start_ticks =
+      let session = make_session ~thread_id Discord_agents.Config.Claude in
+      Discord_agents.Session_store.add bot.sessions ~thread_id session;
+      match Discord_agents.Session_store.set_active_run bot.sessions session
+              (Some Discord_agents.Session_store.{
+                message_id = "message-" ^ thread_id;
+                child_process = Some (child pid start_ticks);
+              }) with
+      | Ok () -> ()
+      | Error err -> Alcotest.failf "set_active_run failed: %s" err
+    in
+    add_active "control-1" 101 1001L;
+    add_active "control-2" 202 2002L;
+    let batches = ref [] in
+    Discord_agents.Bot.reconcile_interrupted_active_runs
+      ~mark_failed:(fun _t _session ~message_id:_ -> ())
+      ~reap_children:(fun _t children -> batches := children :: !batches)
+      bot;
+    Alcotest.(check (list int)) "one reap batch with both children"
+      [2] (List.map List.length (List.rev !batches)))
+
 let test_persist_completed_run_rolls_back_active_run_on_save_failure () =
   with_test_bot (fun bot ->
     let session = make_session Discord_agents.Config.Claude in
@@ -1237,7 +1265,6 @@ let test_persist_completed_run_rolls_back_active_run_on_save_failure () =
         true (session.active_run = active_run))
 
 let eyes_emoji = "\xF0\x9F\x91\x80"
-let check_emoji = "\xE2\x9C\x85"
 let x_emoji = "\xE2\x9D\x8C"
 
 type process_effect =
@@ -1262,8 +1289,12 @@ let process_effect_equal a b =
 
 let process_effect = Alcotest.testable process_effect_pp process_effect_equal
 
-let record_process_hooks ?capture_child_process ?run_agent ?persist_completed_run effects =
+let record_process_hooks ?set_session_id ?capture_child_process ?run_agent
+    ?persist_completed_run effects =
   let base = Discord_agents.Bot.default_process_message_hooks in
+  let set_session_id =
+    Option.value set_session_id ~default:base.set_session_id
+  in
   let capture_child_process =
     Option.value capture_child_process ~default:base.capture_child_process
   in
@@ -1274,6 +1305,7 @@ let record_process_hooks ?capture_child_process ?run_agent ?persist_completed_ru
     Option.value persist_completed_run ~default:base.persist_completed_run
   in
   { base with
+    set_session_id;
     capture_child_process;
     run_agent;
     persist_completed_run;
@@ -1288,7 +1320,10 @@ let record_process_hooks ?capture_child_process ?run_agent ?persist_completed_ru
          effects := Message_sent content :: !effects);
   }
 
-let test_process_session_message_keeps_success_when_child_identity_is_missing () =
+let checkpoint_failure_message =
+  "Run aborted because the bot could not persist or confirm restart state for the spawned agent process. The agent may have exited before it could be tracked, or the bot may have hit a storage error. Try again; if it keeps happening, check bot logs and disk health."
+
+let test_process_session_message_aborts_when_child_identity_is_missing () =
   with_test_bot (fun bot ->
     let session = make_session Discord_agents.Config.Claude in
     Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
@@ -1307,7 +1342,8 @@ let test_process_session_message_keeps_success_when_child_identity_is_missing ()
     Alcotest.(check (list process_effect)) "effects"
       [ Reaction_added eyes_emoji;
         Reaction_removed eyes_emoji;
-        Reaction_added check_emoji ]
+        Reaction_added x_emoji;
+        Message_sent checkpoint_failure_message ]
       (List.rev !effects);
     Alcotest.(check bool) "active run cleared in memory"
       true (Option.is_none session.active_run);
@@ -1319,6 +1355,36 @@ let test_process_session_message_keeps_success_when_child_identity_is_missing ()
       Alcotest.(check bool) "active run cleared on disk"
         true (Option.is_none saved.active_run)
     | None -> Alcotest.fail "expected reloaded session")
+
+let test_process_session_message_aborts_on_session_id_persist_failure () =
+  with_test_bot (fun bot ->
+    let session = make_session Discord_agents.Config.Codex in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    let effects = ref [] in
+    let hooks = record_process_hooks effects
+      ~set_session_id:(fun _sessions _session ~session_id:_ ->
+        failwith "disk full")
+      ~run_agent:(fun ~sw:_ ~env:_ ~rest:_ ~session:_ ~channel_id:_ ~prompt:_
+                     ~attachments:_ ~author_name:_ ~channel_name:_ ~channel_type:_
+                     ~wrap_width:_ ~output_lines:_ ~on_scroll_content:_
+                     ~on_pid:_ ~on_session_id () ->
+        on_session_id "real-codex-session-id";
+        Ok ())
+    in
+    Discord_agents.Bot.process_session_message_with_hooks hooks bot session
+      (make_message "hello") None;
+    Alcotest.(check (list process_effect)) "effects"
+      [ Reaction_added eyes_emoji;
+        Reaction_removed eyes_emoji;
+        Reaction_added x_emoji;
+        Message_sent checkpoint_failure_message ]
+      (List.rev !effects);
+    Alcotest.(check string) "placeholder session id preserved"
+      "session-1" session.session_id;
+    Alcotest.(check bool) "session id remains unconfirmed"
+      false session.session_id_confirmed;
+    Alcotest.(check bool) "active run cleared in memory"
+      true (Option.is_none session.active_run))
 
 let test_process_session_message_keeps_run_replayable_on_completion_persist_failure () =
   with_test_bot (fun bot ->
@@ -1506,10 +1572,14 @@ let () =
         test_proc_stat_info_of_line_parses_start_ticks;
       Alcotest.test_case "startup reconcile clears interrupted active run checkpoint" `Quick
         test_reconcile_interrupted_active_runs_clears_checkpoint;
+      Alcotest.test_case "startup reconcile reaps interrupted children in one batch" `Quick
+        test_reconcile_interrupted_active_runs_reaps_children_in_one_batch;
       Alcotest.test_case "completed run rollback restores active checkpoint" `Quick
         test_persist_completed_run_rolls_back_active_run_on_save_failure;
-      Alcotest.test_case "process message succeeds when child identity is unavailable" `Quick
-        test_process_session_message_keeps_success_when_child_identity_is_missing;
+      Alcotest.test_case "process message aborts when child identity is unavailable" `Quick
+        test_process_session_message_aborts_when_child_identity_is_missing;
+      Alcotest.test_case "process message aborts on session id persist failure" `Quick
+        test_process_session_message_aborts_on_session_id_persist_failure;
       Alcotest.test_case "process message keeps run replayable on completion persist failure" `Quick
         test_process_session_message_keeps_run_replayable_on_completion_persist_failure;
       Alcotest.test_case "reap tracked process-group leader" `Quick

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -2446,6 +2446,25 @@ let test_setup_gemini_mcp_preserves_user_settings () =
     Alcotest.(check bool) "theme key preserved"
       true (List.mem_assoc "theme" (json |> to_assoc)))
 
+let test_setup_gemini_mcp_fails_closed_on_read_errors () =
+  with_temp_dir (fun dir ->
+    let rc = Sys.command (Printf.sprintf
+      "git init -q -b main %s 2>&1 >/dev/null"
+      (Filename.quote dir)) in
+    Alcotest.(check int) "git init succeeded" 0 rc;
+    let gemini_dir = Filename.concat dir ".gemini" in
+    Unix.mkdir gemini_dir 0o755;
+    let settings_path = Filename.concat gemini_dir "settings.json" in
+    Unix.mkdir settings_path 0o755;
+    let exclude_path = Filename.concat dir ".git/info/exclude" in
+    Sys.remove exclude_path;
+    Unix.mkdir exclude_path 0o755;
+    Discord_agents.Agent_process.setup_gemini_mcp ~working_dir:dir;
+    Alcotest.(check bool) "settings path left untouched"
+      true (Sys.is_directory settings_path);
+    Alcotest.(check bool) "exclude path left untouched"
+      true (Sys.is_directory exclude_path))
+
 let setup_gemini_mcp_e2e_tests = [
   Alcotest.test_case "writes settings in a regular repo" `Quick
     test_setup_gemini_mcp_writes_settings_in_regular_repo;
@@ -2453,6 +2472,8 @@ let setup_gemini_mcp_e2e_tests = [
     test_setup_gemini_mcp_idempotent;
   Alcotest.test_case "preserves user's prior .gemini/settings.json" `Quick
     test_setup_gemini_mcp_preserves_user_settings;
+  Alcotest.test_case "fails closed on config read errors" `Quick
+    test_setup_gemini_mcp_fails_closed_on_read_errors;
 ]
 
 (* ── single_line + format_session_listing newline safety ─────────── *)
@@ -2547,6 +2568,24 @@ let test_exclude_already_lists_gemini_false_positives () =
   Alcotest.(check bool) "empty file"
     false (already "")
 
+let test_merge_gemini_exclude_appends_preserving_existing_content () =
+  let merge = Discord_agents.Agent_process.merge_gemini_exclude in
+  Alcotest.(check string) "empty exclude"
+    ".gemini/\n" (merge None);
+  Alcotest.(check string) "adds newline before appended pattern"
+    "*.tmp\n.gemini/\n" (merge (Some "*.tmp"));
+  Alcotest.(check string) "preserves trailing newline"
+    "*.tmp\n.gemini/\n" (merge (Some "*.tmp\n"))
+
+let test_merge_gemini_exclude_is_idempotent () =
+  let merge = Discord_agents.Agent_process.merge_gemini_exclude in
+  let existing = "*.tmp\n.gemini/\nbuild/\n" in
+  Alcotest.(check string) "already listed unchanged"
+    existing (merge (Some existing));
+  let commented = "# .gemini/ is only documentation\n" in
+  Alcotest.(check string) "comment is not treated as active exclude"
+    (commented ^ ".gemini/\n") (merge (Some commented))
+
 let test_merge_gemini_settings_non_object_falls_back () =
   (* Parseable JSON that isn't an object — list, scalar — would
      round-trip unchanged under naive logic, dropping our MCP entry. *)
@@ -2580,6 +2619,10 @@ let resume_helpers_tests = [
     test_exclude_already_lists_gemini_positive;
   Alcotest.test_case "exclude check rejects comment/negated/subpath" `Quick
     test_exclude_already_lists_gemini_false_positives;
+  Alcotest.test_case "merge_gemini_exclude appends preserving content" `Quick
+    test_merge_gemini_exclude_appends_preserving_existing_content;
+  Alcotest.test_case "merge_gemini_exclude is idempotent" `Quick
+    test_merge_gemini_exclude_is_idempotent;
   Alcotest.test_case "single_line strips \\n \\r \\t" `Quick
     test_single_line_strips_newlines;
   Alcotest.test_case "single_line passthrough" `Quick


### PR DESCRIPTION
## Summary
- hard-fail unsafe agent checkpoint gaps instead of allowing degraded restart cleanup
- close agent subprocess pipes on spawn/callback failures, preflight `setsid`, and make Gemini MCP config writes fail closed
- batch startup reaping, reduce restart-time REST work, debounce disk probes with path snapshots, and add supervisor backoff
- protect same-process file locks and move `statvfs` off the OCaml runtime lock

## Review
- Ran council review on the follow-up diff via Claude/Codex/Gemini. Gemini was unavailable due `QUOTA_EXHAUSTED`; Claude/Codex findings were addressed in this PR.

## Tests
- `nix develop --command dune exec ./test/test_formatting.exe`
- `nix develop --command dune exec ./test/test_bot_defaults.exe`
- `nix develop --command dune runtest` (Gemini live contract tests skipped due quota exhaustion)
- `nix develop --command dune build`
- `git diff --check`
- `python3 -m py_compile scripts/mcp-server.py`
