### PR TITLE
refactor: encode active run checkpoints

### DIFF
--- a/lib/agent_checkpoint.ml
+++ b/lib/agent_checkpoint.ml
@@ -1,0 +1,66 @@
+type child_process_identity = {
+  pid : int;
+  start_ticks : int64;
+}
+
+type untracked
+type tracked
+
+type _ t =
+  | Untracked : {
+      message_id : Discord_types.message_id;
+    } -> untracked t
+  | Tracked : {
+      message_id : Discord_types.message_id;
+      child_process : child_process_identity;
+    } -> tracked t
+
+type any = Any : _ t -> any
+
+let child_process_identity ~pid ~start_ticks = { pid; start_ticks }
+
+let compare_child_process_identity a b =
+  match Int.compare a.pid b.pid with
+  | 0 -> Int64.compare a.start_ticks b.start_ticks
+  | n -> n
+
+let equal_child_process_identity a b =
+  Int.equal a.pid b.pid && Int64.equal a.start_ticks b.start_ticks
+
+let create ~message_id = Untracked { message_id }
+
+let track_child : untracked t -> child_process_identity -> tracked t =
+  fun checkpoint child_process ->
+    match checkpoint with
+    | Untracked { message_id } -> Tracked { message_id; child_process }
+
+let erase checkpoint = Any checkpoint
+
+let of_persisted ~message_id ~child_process =
+  match child_process with
+  | Some child_process ->
+    Any (Tracked { message_id; child_process })
+  | None ->
+    Any (Untracked { message_id })
+
+let message_id : type state. state t -> Discord_types.message_id = function
+  | Untracked { message_id } -> message_id
+  | Tracked { message_id; _ } -> message_id
+
+let message_id_any (Any checkpoint) = message_id checkpoint
+
+let child_process : tracked t -> child_process_identity = function
+  | Tracked { child_process; _ } -> child_process
+
+let child_process_any (Any checkpoint) =
+  match checkpoint with
+  | Untracked _ -> None
+  | Tracked { child_process; _ } -> Some child_process
+
+let equal_any a b =
+  String.equal (message_id_any a) (message_id_any b)
+  && Option.equal equal_child_process_identity
+       (child_process_any a)
+       (child_process_any b)
+
+let equal_any_option a b = Option.equal equal_any a b

--- a/lib/agent_checkpoint.mli
+++ b/lib/agent_checkpoint.mli
@@ -1,0 +1,42 @@
+(** Typed restart checkpoints for in-flight agent runs.
+
+    The persisted format allows an active run to exist before a child
+    process identity is captured, but cleanup operations require that
+    identity. The phantom state keeps those cases distinct at call sites:
+    callers create an untracked checkpoint first, and only [track_child]
+    can promote it to a tracked checkpoint.
+
+    Values recovered from disk are erased to [any] because persistence
+    loses the static phantom-state distinction. Callers that need
+    tracked-only operations must stay on the fresh [tracked t] path. *)
+
+type child_process_identity = private {
+  pid : int;
+  start_ticks : int64;
+}
+
+type untracked
+type tracked
+
+type _ t
+
+type any
+
+val child_process_identity : pid:int -> start_ticks:int64 -> child_process_identity
+val compare_child_process_identity :
+  child_process_identity -> child_process_identity -> int
+
+val create : message_id:Discord_types.message_id -> untracked t
+val track_child : untracked t -> child_process_identity -> tracked t
+val erase : _ t -> any
+val of_persisted :
+  message_id:Discord_types.message_id ->
+  child_process:child_process_identity option ->
+  any
+
+val message_id : _ t -> Discord_types.message_id
+val message_id_any : any -> Discord_types.message_id
+val child_process : tracked t -> child_process_identity
+val child_process_any : any -> child_process_identity option
+val equal_any : any -> any -> bool
+val equal_any_option : any option -> any option -> bool

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -377,7 +377,8 @@ let proc_stat_of_pid pid =
 let rec child_process_identity_of_pid ?(attempts=5) ?(sleep=Unix.sleepf) pid =
   match proc_stat_of_pid pid with
   | Proc_stat_found info ->
-    Some Session_store.{ pid; start_ticks = info.start_ticks }
+    Some (Agent_checkpoint.child_process_identity
+      ~pid ~start_ticks:info.start_ticks)
   | Proc_stat_missing
   | Proc_stat_unknown when attempts > 1 ->
     sleep 0.01;
@@ -420,8 +421,7 @@ let pid_ownership ?expected_start_ticks ?(tracked_child=false) pid =
 
 let active_child_process (session : Session_store.session) =
   match session.active_run with
-  | Some { child_process = Some child; _ } -> Some child
-  | Some { child_process = None; _ }
+  | Some active_run -> Agent_checkpoint.child_process_any active_run
   | None -> None
 
 let drop_queued_messages ?(mark_failed=true) ?(async_marking=false) t
@@ -509,15 +509,10 @@ let request_tracked_child_stop t ~reason ~pid ~expected_start_ticks =
           log_unknown_child_ownership (reason ^ " SIGKILL") pid));
   signalled
 
-let compare_child_process_identity
-    (a : Session_store.child_process_identity)
-    (b : Session_store.child_process_identity) =
-  match Int.compare a.pid b.pid with
-  | 0 -> Int64.compare a.start_ticks b.start_ticks
-  | n -> n
-
 let reap_tracked_child_processes_blocking t ~reason children =
-  let children = List.sort_uniq compare_child_process_identity children in
+  let children =
+    List.sort_uniq Agent_checkpoint.compare_child_process_identity children
+  in
   let signalled = Eio_unix.run_in_systhread (fun () ->
     List.filter (fun (child : Session_store.child_process_identity) ->
       match pid_ownership ~expected_start_ticks:child.start_ticks
@@ -1106,12 +1101,13 @@ let reconcile_interrupted_active_runs
   let children =
     interrupted
     |> List.filter_map (fun (_session, (active_run : Session_store.active_run)) ->
-      active_run.child_process)
+      Agent_checkpoint.child_process_any active_run)
   in
   if children <> [] then
     reap_children t children;
   List.iter (fun ((session : Session_store.session), active_run) ->
-    mark_failed t session ~message_id:active_run.Session_store.message_id;
+    mark_failed t session
+      ~message_id:(Agent_checkpoint.message_id_any active_run);
     if forget_active_run t session ~context:"startup" then
       Logs.info (fun m ->
         m "bot: reconciled interrupted active run for %s"
@@ -1207,7 +1203,7 @@ let child_processes_for_restart t =
        | None -> Eio_unix.run_in_systhread (fun () ->
            child_process_identity_of_pid pid))
     | None -> None)
-  |> List.sort_uniq compare_child_process_identity
+  |> List.sort_uniq Agent_checkpoint.compare_child_process_identity
 
 (** Trigger a graceful restart: drain → reap → build → spawn.
     Callable from command handler or signal handler.
@@ -2351,16 +2347,14 @@ let rec process_session_message_with_hooks hooks t session
     (msg : Discord_types.message) channel_info =
   let child_pid = ref None in
   let checkpoint_failure = ref None in
-  let active_run = Session_store.{
-    message_id = msg.id;
-    child_process = None;
-  } in
+  let active_run = Agent_checkpoint.create ~message_id:msg.id in
   Fun.protect ~finally:(fun () ->
     Option.iter (unregister_child_pid t session) !child_pid
   ) (fun () ->
     let channel_id = msg.channel_id in
     let message_id = msg.id in
-    match hooks.set_active_run t.sessions session (Some active_run) with
+    match hooks.set_active_run t.sessions session
+            (Some (Agent_checkpoint.erase active_run)) with
     | Error err ->
       Logs.warn (fun m ->
         m "bot: failed to persist active run checkpoint for %s: %s"
@@ -2393,15 +2387,21 @@ let rec process_session_message_with_hooks hooks t session
         register_child_pid t session pid;
         (match hooks.capture_child_process pid with
          | Some child_process ->
+           let tracked_run =
+             Agent_checkpoint.track_child active_run child_process
+           in
+           (* Read through the tracked witness so failure cleanup uses
+              the same promoted state we attempted to persist. *)
+           let tracked_child = Agent_checkpoint.child_process tracked_run in
            (match hooks.set_active_run t.sessions session
-                    (Some { active_run with child_process = Some child_process }) with
+                    (Some (Agent_checkpoint.erase tracked_run)) with
             | Ok () -> ()
             | Error err ->
               checkpoint_failure := Some err;
               ignore (request_tracked_child_stop t
                 ~reason:"checkpoint failure"
                 ~pid
-                ~expected_start_ticks:(Some child_process.start_ticks));
+                ~expected_start_ticks:(Some tracked_child.start_ticks));
               Logs.warn (fun m ->
                 m "bot: failed to persist child identity for %s: %s"
                   session.thread_id err))

--- a/lib/discord_agents.ml
+++ b/lib/discord_agents.ml
@@ -11,6 +11,7 @@ module Agent_runner = Agent_runner
 module Discord_types = Discord_types
 module Discord_rest = Discord_rest
 module Discord_gateway = Discord_gateway
+module Agent_checkpoint = Agent_checkpoint
 module Session_store = Session_store
 module Channel_manager = Channel_manager
 module Command = Command

--- a/lib/session_store.ml
+++ b/lib/session_store.ml
@@ -20,15 +20,8 @@ type pending_agent_change = {
   origin : pending_agent_origin;
 }
 
-type child_process_identity = {
-  pid : int;
-  start_ticks : int64;
-}
-
-type active_run = {
-  message_id : Discord_types.message_id;
-  child_process : child_process_identity option;
-}
+type child_process_identity = Agent_checkpoint.child_process_identity
+type active_run = Agent_checkpoint.any
 
 let string_of_pending_agent_origin = function
   | Default_rotation -> "default_rotation"
@@ -126,8 +119,9 @@ let sessions_to_json sessions =
          | None -> [])
       @ (match s.active_run with
          | Some active_run ->
-           [("active_message_id", `String active_run.message_id)]
-           @ (match active_run.child_process with
+           [("active_message_id",
+             `String (Agent_checkpoint.message_id_any active_run))]
+           @ (match Agent_checkpoint.child_process_any active_run with
               | Some child ->
                 [("active_child_pid", `Int child.pid);
                  ("active_child_start_ticks", json_of_int64 child.start_ticks)]
@@ -180,10 +174,11 @@ let sessions_of_json json =
         let child_process =
           match j |> member "active_child_pid",
                 int64_of_json (j |> member "active_child_start_ticks") with
-          | `Int pid, Some start_ticks -> Some { pid; start_ticks }
+          | `Int pid, Some start_ticks ->
+            Some (Agent_checkpoint.child_process_identity ~pid ~start_ticks)
           | _ -> None
         in
-        Some { message_id; child_process }
+        Some (Agent_checkpoint.of_persisted ~message_id ~child_process)
       | _ -> None
     in
     let session = {
@@ -507,7 +502,7 @@ let set_stop_requested t session stop_requested =
 
 let set_active_run t session active_run =
   let prior = session.active_run in
-  if prior = active_run then
+  if Agent_checkpoint.equal_any_option prior active_run then
     Ok ()
   else begin
     session.active_run <- active_run;

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -1,5 +1,7 @@
 (** Behavioral tests for default-agent and session-agent session transitions. *)
 
+module Agent_checkpoint = Discord_agents__Agent_checkpoint
+
 let rec rm_rf path =
   match Unix.lstat path with
   | exception Unix.Unix_error (ENOENT, _, _) -> ()
@@ -1199,10 +1201,10 @@ let test_reconcile_interrupted_active_runs_clears_checkpoint () =
   with_test_bot (fun bot ->
     let session = make_session Discord_agents.Config.Claude in
     Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
-    let active_run = Some Discord_agents.Session_store.{
-      message_id = "message-1";
-      child_process = None;
-    } in
+    let active_run =
+      Some (Agent_checkpoint.erase
+        (Agent_checkpoint.create ~message_id:"message-1"))
+    in
     (match Discord_agents.Session_store.set_active_run bot.sessions session active_run with
      | Ok () -> ()
      | Error err -> Alcotest.failf "set_active_run failed: %s" err);
@@ -1219,18 +1221,23 @@ let test_reconcile_interrupted_active_runs_clears_checkpoint () =
 
 let test_reconcile_interrupted_active_runs_reaps_children_in_one_batch () =
   with_test_bot (fun bot ->
-    let child pid start_ticks = Discord_agents.Session_store.{
-      pid;
-      start_ticks;
-    } in
+    let child pid start_ticks =
+      Agent_checkpoint.child_process_identity ~pid ~start_ticks
+    in
     let add_active thread_id pid start_ticks =
       let session = make_session ~thread_id Discord_agents.Config.Claude in
       Discord_agents.Session_store.add bot.sessions ~thread_id session;
+      let checkpoint =
+        Agent_checkpoint.create
+          ~message_id:("message-" ^ thread_id)
+      in
+      let active_run =
+        Agent_checkpoint.track_child checkpoint
+          (child pid start_ticks)
+        |> Agent_checkpoint.erase
+      in
       match Discord_agents.Session_store.set_active_run bot.sessions session
-              (Some Discord_agents.Session_store.{
-                message_id = "message-" ^ thread_id;
-                child_process = Some (child pid start_ticks);
-              }) with
+              (Some active_run) with
       | Ok () -> ()
       | Error err -> Alcotest.failf "set_active_run failed: %s" err
     in
@@ -1249,10 +1256,10 @@ let test_persist_completed_run_rolls_back_active_run_on_save_failure () =
     let session = make_session Discord_agents.Config.Claude in
     session.initial_prompt <- Some "preface";
     session.message_count <- 7;
-    let active_run = Some Discord_agents.Session_store.{
-      message_id = "message-1";
-      child_process = None;
-    } in
+    let active_run =
+      Some (Agent_checkpoint.erase
+        (Agent_checkpoint.create ~message_id:"message-1"))
+    in
     session.active_run <- active_run;
     let failing_save _store = failwith "disk full" in
     match Discord_agents.Bot.persist_completed_run ~save:failing_save bot session ~had_initial_prompt:true with
@@ -1262,7 +1269,8 @@ let test_persist_completed_run_rolls_back_active_run_on_save_failure () =
       Alcotest.(check (option string)) "initial_prompt rolled back"
         (Some "preface") session.initial_prompt;
       Alcotest.(check bool) "active run restored"
-        true (session.active_run = active_run))
+        true (Agent_checkpoint.equal_any_option
+          session.active_run active_run))
 
 let eyes_emoji = "\xF0\x9F\x91\x80"
 let x_emoji = "\xE2\x9D\x8C"
@@ -1457,10 +1465,12 @@ let test_stop_busy_session_signals_tracked_child () =
         | None -> Alcotest.fail "expected live child identity"
         | Some child ->
           session.child_pid <- Some pid;
-          session.active_run <- Some Discord_agents.Session_store.{
-            message_id = "message-1";
-            child_process = Some child;
-          };
+          let checkpoint =
+            Agent_checkpoint.create ~message_id:"message-1"
+          in
+          session.active_run <- Some (
+            Agent_checkpoint.track_child checkpoint child
+            |> Agent_checkpoint.erase);
           match Discord_agents.Bot.stop_session bot ~thread_id:"control" with
           | Discord_agents.Bot.Session_stopping stop ->
             Alcotest.(check bool) "had running process" true stop.had_running_process;

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -1,6 +1,6 @@
 (** Behavioral tests for default-agent and session-agent session transitions. *)
 
-module Agent_checkpoint = Discord_agents__Agent_checkpoint
+module Agent_checkpoint = Discord_agents.Agent_checkpoint
 
 let rec rm_rf path =
   match Unix.lstat path with

--- a/test/test_session_store.ml
+++ b/test/test_session_store.ml
@@ -1,3 +1,5 @@
+module Agent_checkpoint = Discord_agents__Agent_checkpoint
+
 let rec rm_rf path =
   match Unix.lstat path with
   | exception Unix.Unix_error (ENOENT, _, _) -> ()
@@ -34,6 +36,14 @@ let sessions_path home =
 
 let backup_path home = sessions_path home ^ ".bak"
 
+let write_primary_sessions home content =
+  let path = sessions_path home in
+  Discord_agents.Resource.ensure_parent_dir path;
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () -> output_string oc content)
+
 let make_session () =
   Discord_agents.Session_store.make_session
     ~project_name:"control"
@@ -53,14 +63,48 @@ let find_control_session store =
 let expect_active_run session ~message_id ~pid ~start_ticks =
   match session.Discord_agents.Session_store.active_run with
   | Some active_run ->
-    Alcotest.(check string) "active message id" message_id active_run.message_id;
-    (match active_run.child_process with
+    Alcotest.(check string) "active message id" message_id
+      (Agent_checkpoint.message_id_any active_run);
+    (match Agent_checkpoint.child_process_any active_run with
      | Some child ->
        Alcotest.(check int) "child pid" pid child.pid;
        Alcotest.(check int64) "child start ticks" start_ticks child.start_ticks
      | None -> Alcotest.fail "expected persisted child process identity")
   | None ->
     Alcotest.fail "expected persisted active run"
+
+let expect_active_run_without_child session ~message_id =
+  match session.Discord_agents.Session_store.active_run with
+  | Some active_run ->
+    Alcotest.(check string) "active message id" message_id
+      (Agent_checkpoint.message_id_any active_run);
+    Alcotest.(check bool) "no child identity"
+      true
+      (Option.is_none
+         (Agent_checkpoint.child_process_any active_run))
+  | None ->
+    Alcotest.fail "expected persisted active run"
+
+let test_agent_checkpoint_tracks_child_by_construction () =
+  let open Agent_checkpoint in
+  let checkpoint = create ~message_id:"message-1" in
+  Alcotest.(check string) "untracked message id"
+    "message-1" (message_id checkpoint);
+  Alcotest.(check bool) "untracked has no child"
+    true (Option.is_none (child_process_any (erase checkpoint)));
+  let child = child_process_identity ~pid:1234 ~start_ticks:5678L in
+  let tracked = track_child checkpoint child in
+  let tracked_child = child_process tracked in
+  Alcotest.(check int) "tracked child pid" 1234 tracked_child.pid;
+  Alcotest.(check int64) "tracked child start ticks"
+    5678L tracked_child.start_ticks;
+  (match child_process_any (erase tracked) with
+   | Some erased_child ->
+     Alcotest.(check int) "erased child pid" 1234 erased_child.pid;
+     Alcotest.(check int64) "erased child start ticks"
+       5678L erased_child.start_ticks
+   | None ->
+     Alcotest.fail "expected erased tracked checkpoint to expose child")
 
 let test_save_updates_backup () =
   with_tmp_home (fun home ->
@@ -168,6 +212,51 @@ let test_save_marks_primary_newer_when_backup_update_fails () =
     Alcotest.(check bool) "primary stamped newer than stale backup"
       true (primary_stat.Unix.st_mtime > backup_stat.Unix.st_mtime))
 
+let test_persisted_active_run_without_child_loads () =
+  with_tmp_home (fun home ->
+    (* This is the real crash window after the active-run checkpoint
+       is saved and before the child process identity is captured. *)
+    write_primary_sessions home {|
+[
+  {
+    "project_name": "control",
+    "working_dir": "/tmp/project",
+    "agent_kind": "claude",
+    "session_id": "session-1",
+    "thread_id": "control",
+    "message_count": 0,
+    "active_message_id": "message-legacy"
+  }
+]
+|};
+    let store = Discord_agents.Session_store.create () in
+    let recovered = find_control_session store in
+    expect_active_run_without_child recovered ~message_id:"message-legacy")
+
+let test_persisted_active_run_with_child_loads () =
+  with_tmp_home (fun home ->
+    write_primary_sessions home {|
+[
+  {
+    "project_name": "control",
+    "working_dir": "/tmp/project",
+    "agent_kind": "claude",
+    "session_id": "session-1",
+    "thread_id": "control",
+    "message_count": 0,
+    "active_message_id": "message-legacy",
+    "active_child_pid": 4242,
+    "active_child_start_ticks": "123456789"
+  }
+]
+|};
+    let store = Discord_agents.Session_store.create () in
+    let recovered = find_control_session store in
+    expect_active_run recovered
+      ~message_id:"message-legacy"
+      ~pid:4242
+      ~start_ticks:123456789L)
+
 let test_load_ignores_stale_backup_when_primary_is_newer_and_corrupt () =
   with_tmp_home (fun home ->
     let store = Discord_agents.Session_store.create () in
@@ -200,10 +289,17 @@ let test_active_run_roundtrips_through_backup () =
     let store = Discord_agents.Session_store.create () in
     let session = make_session () in
     Discord_agents.Session_store.add store ~thread_id:"control" session;
-    let active_run = Some Discord_agents.Session_store.{
-      message_id = "message-42";
-      child_process = Some { pid = 4242; start_ticks = 123456789L };
-    } in
+    let child =
+      Agent_checkpoint.child_process_identity
+        ~pid:4242 ~start_ticks:123456789L
+    in
+    let active_run =
+      let checkpoint =
+        Agent_checkpoint.create ~message_id:"message-42"
+      in
+      Some (Agent_checkpoint.erase
+        (Agent_checkpoint.track_child checkpoint child))
+    in
     (match Discord_agents.Session_store.set_active_run store session active_run with
      | Ok () -> ()
      | Error err -> Alcotest.failf "set_active_run failed: %s" err);
@@ -246,6 +342,8 @@ let test_save_refuses_read_only_preflight () =
 let () =
   Alcotest.run "session_store" [
     ("persistence", [
+      Alcotest.test_case "agent checkpoint tracks child by construction" `Quick
+        test_agent_checkpoint_tracks_child_by_construction;
       Alcotest.test_case "save updates backup" `Quick
         test_save_updates_backup;
       Alcotest.test_case "load uses backup when primary corrupt" `Quick
@@ -258,6 +356,10 @@ let () =
         test_save_with_visible_but_unconfirmed_primary_updates_backup;
       Alcotest.test_case "failed backup leaves primary newer" `Quick
         test_save_marks_primary_newer_when_backup_update_fails;
+      Alcotest.test_case "persisted active run without child loads" `Quick
+        test_persisted_active_run_without_child_loads;
+      Alcotest.test_case "persisted active run with child loads" `Quick
+        test_persisted_active_run_with_child_loads;
       Alcotest.test_case "load ignores stale backup when primary is newer and corrupt" `Quick
         test_load_ignores_stale_backup_when_primary_is_newer_and_corrupt;
       Alcotest.test_case "active run roundtrips through backup" `Quick

--- a/test/test_session_store.ml
+++ b/test/test_session_store.ml
@@ -1,4 +1,4 @@
-module Agent_checkpoint = Discord_agents__Agent_checkpoint
+module Agent_checkpoint = Discord_agents.Agent_checkpoint
 
 let rec rm_rf path =
   match Unix.lstat path with


### PR DESCRIPTION
## Summary
- Add an internal typed `Agent_checkpoint` state machine for active-run restart checkpoints, separating untracked and tracked states before persistence erases them.
- Update session persistence, restart reconciliation, and child reaping paths to use checkpoint accessors and field-wise equality instead of open records/polymorphic equality.
- Keep the raw checkpoint module out of the public `Discord_agents` facade and add persisted active-run fixtures for checkpoints with and without child process identity.

## Verification
- `nix develop --command dune build`
- `git diff --check`
- `python3 -m py_compile scripts/mcp-server.py`
- `nix develop --command dune exec ./test/test_session_store.exe`
- `nix develop --command dune exec ./test/test_bot_defaults.exe`
- `nix develop --command dune runtest` passes local/unit suites and fails only in live Gemini `agent_contracts` because the configured Gemini CLI model returns `ModelNotFoundError` / 404.

## Council Review
- `$council-review` run to fixpoint across Claude and Codex.
- Gemini review unavailable: Gemini CLI currently fails with `ModelNotFoundError` / 404 for the configured model.
- Final Claude and Codex passes reported no blocking findings.
