### PR TITLE
[codex] Fix agent parsing, config, and default agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@ Only tested on GNU+Linux. Environment managed by Nix. Built with OCaml 5.3.
 
 ## Quickstart
 
+Install and authenticate the Codex CLI first; new top-level sessions default
+to `codex`.
+
 ```bash
+# Agent CLI
+npm install -g @openai/codex
+codex
+
 # Build
 nix develop --command dune build
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cat > ~/.config/discord-agents/config.json << 'EOF'
 {
   "discord_token": "your-bot-token",
   "guild_id": "your-server-id",
-  "base_dirs": ["~/Projects"]
+  "base_directories": ["~/Projects"]
 }
 EOF
 
@@ -40,6 +40,13 @@ Then in Discord:
 Or just chat in any project channel -- the agent will respond directly.
 
 See [SETUP.md](SETUP.md) for detailed installation and Discord bot setup instructions.
+
+`config.json` is validated at startup. The required fields are
+`discord_token` (or `DISCORD_BOT_TOKEN`) and `guild_id`; optional
+fields default to `base_directories: []`, `control_channel_id: null`,
+and `projects: []`. The older `base_dirs` key is still accepted as an
+alias, but new configs should use `base_directories`. See
+[`config.example.json`](config.example.json).
 
 ## Commands
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -79,7 +79,7 @@ The bot will:
 1. Connect to Discord
 2. Create an "Agent Projects" category if it doesn't exist
 3. Scan your `base_dirs` for git repos and create a channel for each
-4. Set up a control channel with a Claude session
+4. Set up a control channel with a Codex session
 
 ### Smoke test
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -58,13 +58,13 @@ Create `~/.config/discord-agents/config.json`:
 {
   "discord_token": "your-bot-token-from-step-3",
   "guild_id": "your-server-id-from-step-4",
-  "base_dirs": ["~/Projects"]
+  "base_directories": ["~/Projects"]
 }
 ```
 
 - `discord_token` -- The bot token from step 3. Alternatively, set the `DISCORD_BOT_TOKEN` environment variable.
 - `guild_id` -- Your Discord server ID from step 4.
-- `base_dirs` -- List of directories to scan for git repos. Each repo becomes a project channel.
+- `base_directories` -- List of directories to scan for git repos. Each repo becomes a project channel. `base_dirs` is accepted as a legacy alias.
 - `control_channel_id` (optional) -- A specific channel ID for the control channel. If omitted, the bot creates one.
 
 ## 6. Build and run

--- a/SETUP.md
+++ b/SETUP.md
@@ -17,15 +17,24 @@ echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
 
 Log out and back in (or restart your shell) for the changes to take effect.
 
-## 2. Install Claude Code
+## 2. Install agent CLIs
 
-discord-agents uses the Claude Code CLI to run agent sessions. Install it:
+discord-agents defaults new top-level sessions to Codex. Install and
+authenticate the Codex CLI:
 
 ```bash
-npm install -g @anthropic-ai/claude-code
+npm install -g @openai/codex
+codex
 ```
 
-Make sure `claude` is on your PATH and you've authenticated (`claude` will prompt on first run).
+Make sure `codex` is on your PATH before starting the bot. Claude and
+Gemini are optional backends; install `claude` or `gemini` if you plan to
+start sessions with those agents or change the default with
+`!default-agent claude` or `!default-agent gemini`.
+
+For Gemini, use a CLI build whose `gemini --help` includes `--skip-trust`;
+the bot passes that flag so headless worktree sessions do not stop for a
+workspace trust prompt.
 
 ## 3. Create a Discord bot
 
@@ -78,7 +87,7 @@ nix develop --command dune exec discord-agents
 The bot will:
 1. Connect to Discord
 2. Create an "Agent Projects" category if it doesn't exist
-3. Scan your `base_dirs` for git repos and create a channel for each
+3. Scan your `base_directories` for git repos and create a channel for each
 4. Set up a control channel with a Codex session
 
 ### Smoke test

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -130,11 +130,13 @@ let () =
   let _lock_fd = if not test_mode then Some (acquire_pidfile ()) else None in
   Random.self_init ();  (* Seed PRNG for heartbeat jitter *)
   let config = Discord_agents.Config.load () in
-  if config.discord_token = "" then (
-    Logs.err (fun m -> m "no discord token configured");
-    Logs.err (fun m -> m "set discord_token in %s" (Discord_agents.Config.config_path ()));
-    exit 1
-  );
+  (match Discord_agents.Config.validate
+           ~require_guild_id:(not test_mode) config with
+   | Ok () -> ()
+   | Error errors ->
+     List.iter (fun err -> Logs.err (fun m -> m "config: %s" err)) errors;
+     Logs.err (fun m -> m "update %s" (Discord_agents.Config.config_path ()));
+     exit 1);
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   if test_mode then

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,7 @@
+{
+  "discord_token": "your-bot-token",
+  "guild_id": "your-server-id",
+  "base_directories": ["~/Projects"],
+  "control_channel_id": null,
+  "projects": []
+}

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -86,6 +86,7 @@ let utf8_prefix_len_for_table_cell ~max_bytes s =
       let c = Char.code s.[i] in
       let raw_step =
         if c < 0x80 then 1
+        else if c < 0xC0 then 1
         else if c < 0xE0 then 2
         else if c < 0xF0 then 3
         else 4

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -385,6 +385,26 @@ let take_fitting_prefix ?(start=0) ~max_chars s =
       let raw_step = if is_triple then 3 else utf8_step s start in
       min raw_step (n - start)
 
+let is_ascii_whitespace = function
+  | ' ' | '\t' | '\r' | '\n' -> true
+  | _ -> false
+
+(** Largest display-safe prefix, preferring a prior whitespace boundary
+    over the hard UTF-8 budget boundary. If no whitespace fits in the
+    window, falls back to [take_fitting_prefix] so long unbroken tokens
+    still make progress. *)
+let take_word_safe_fitting_prefix ?(start=0) ~max_chars s =
+  let hard_len = take_fitting_prefix ~start ~max_chars s in
+  let hard_end = start + hard_len in
+  let rec find_space i =
+    if i <= start then None
+    else if is_ascii_whitespace s.[i - 1] then Some i
+    else find_space (i - 1)
+  in
+  match find_space hard_end with
+  | Some i when i > start -> i - start
+  | _ -> hard_len
+
 (** UTF-8 safe truncation for inline summary strings: caps at [max_chars]
     bytes (post-fence-escape) and appends "...".  Returns [s] unchanged
     if it already fits.  Always lands on a UTF-8 codepoint boundary. *)
@@ -403,7 +423,7 @@ let chunk_long_line ~max_chars line =
     let chunks = ref [] in
     let pos = ref 0 in
     while !pos < n do
-      let len = take_fitting_prefix ~start:!pos ~max_chars line in
+      let len = take_word_safe_fitting_prefix ~start:!pos ~max_chars line in
       chunks := String.sub line !pos len :: !chunks;
       pos := !pos + len
     done;
@@ -453,7 +473,7 @@ let truncate_for_display ~max_lines ~max_chars (lines : string list) =
         else if shown = 0 then
           (* First line alone exceeds budget — char-truncate it so the
              user always sees something rather than an empty block. *)
-          let taken = take_fitting_prefix ~max_chars l in
+          let taken = take_word_safe_fitting_prefix ~max_chars l in
           let trimmed = String.sub l 0 taken in
           { display = [trimmed]; shown = 1;
             total = 1 + List.length rest;

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1436,9 +1436,12 @@ let codex_args ~session_id ~session_id_confirmed ~prompt =
     Result. Subsequent runs resume only when [session_id_confirmed],
     matching the same coherence contract Codex uses.
 
-    [--yolo] auto-approves tool calls so Gemini doesn't block on an
-    interactive approval prompt that the non-interactive subprocess
-    can't answer. It is *not* a full equivalent of Codex's
+    [--skip-trust] is required for bot-created worktrees that Gemini
+    has not seen interactively before; without it, headless runs exit
+    before emitting stream-json events. [--yolo] auto-approves tool
+    calls so Gemini doesn't block on an interactive approval prompt
+    that the non-interactive subprocess can't answer. It is *not* a
+    full equivalent of Codex's
     [--dangerously-bypass-approvals-and-sandbox]: that flag also
     drops Codex's filesystem sandbox, while Gemini's [--yolo] only
     covers approvals. The closer Codex analogue for [--yolo] is
@@ -1448,7 +1451,8 @@ let codex_args ~session_id ~session_id_confirmed ~prompt =
     by [setup_gemini_mcp], which run_streaming calls before invoking
     [gemini_args]. *)
 let gemini_args ~session_id ~session_id_confirmed ~prompt =
-  let base = ["gemini"; "-p"; prompt; "-o"; "stream-json"; "--yolo"] in
+  let base = ["gemini"; "--skip-trust"; "-p"; prompt;
+              "-o"; "stream-json"; "--yolo"] in
   if not session_id_confirmed then base
   else base @ ["--resume"; session_id]
 

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -78,6 +78,23 @@ let is_separator_row cells =
     String.to_seq cell |> Seq.for_all (fun c -> c = '-' || c = ':')
   ) cells
 
+let utf8_prefix_len_for_table_cell ~max_bytes s =
+  let n = String.length s in
+  let rec loop i =
+    if i >= n || i >= max_bytes then i
+    else
+      let c = Char.code s.[i] in
+      let raw_step =
+        if c < 0x80 then 1
+        else if c < 0xE0 then 2
+        else if c < 0xF0 then 3
+        else 4
+      in
+      let step = min raw_step (n - i) in
+      if i + step > max_bytes then i else loop (i + step)
+  in
+  loop 0
+
 (** Default wrapping widths for desktop and mobile Discord clients. *)
 let desktop_width = 120
 let mobile_width = 60
@@ -195,7 +212,9 @@ let render_padded_table ?(max_width=desktop_width) table_lines =
       end else begin
         Buffer.add_char buf ' ';
         let display = if String.length cell > w
-          then String.sub cell 0 w
+          then
+            let taken = utf8_prefix_len_for_table_cell ~max_bytes:w cell in
+            String.sub cell 0 taken
           else cell in
         Buffer.add_string buf display;
         for _ = 1 to w - String.length display do Buffer.add_char buf ' ' done;
@@ -394,16 +413,19 @@ let is_ascii_whitespace = function
     window, falls back to [take_fitting_prefix] so long unbroken tokens
     still make progress. *)
 let take_word_safe_fitting_prefix ?(start=0) ~max_chars s =
+  let n = String.length s in
   let hard_len = take_fitting_prefix ~start ~max_chars s in
   let hard_end = start + hard_len in
-  let rec find_space i =
-    if i <= start then None
-    else if is_ascii_whitespace s.[i - 1] then Some i
-    else find_space (i - 1)
-  in
-  match find_space hard_end with
-  | Some i when i > start -> i - start
-  | _ -> hard_len
+  if hard_end >= n then hard_len
+  else
+    let rec find_space i =
+      if i <= start then None
+      else if is_ascii_whitespace s.[i - 1] then Some i
+      else find_space (i - 1)
+    in
+    match find_space hard_end with
+    | Some i when i > start -> i - start
+    | _ -> hard_len
 
 (** UTF-8 safe truncation for inline summary strings: caps at [max_chars]
     bytes (post-fence-escape) and appends "...".  Returns [s] unchanged

--- a/lib/agent_runner.ml
+++ b/lib/agent_runner.ml
@@ -36,6 +36,20 @@ let take_stream_delta_chunk_len ~current_len text ~start =
       | _ when current_len > 0 -> 0
       | _ -> hard_len
 
+let split_trailing_word_for_carry s =
+  let n = String.length s in
+  if n = 0 || Agent_process.is_ascii_whitespace s.[n - 1] then None
+  else
+    let rec find_start i =
+      if i <= 0 then 0
+      else if Agent_process.is_ascii_whitespace s.[i - 1] then i
+      else find_start (i - 1)
+    in
+    let start = find_start n in
+    if start = 0 then None
+    else
+      Some (String.sub s 0 start, String.sub s start (n - start))
+
 (** Map tool names to emoji + verb for compact status display. *)
 (** Escape underscores in a tool name for Discord display.
     Discord interprets __ as underline and _ as italic, so we
@@ -292,6 +306,23 @@ let run ~sw ~env ~rest ~session ~(channel_id : Discord_types.channel_id)
       (* No table boundary (or entire buffer is a table) — split normally *)
       flush_and_reset ()
   in
+  let carry_trailing_word_to_next_message () =
+    match split_trailing_word_for_carry (Buffer.contents current_msg_buf) with
+    | None -> false
+    | Some (before, carry) ->
+      Buffer.clear current_msg_buf;
+      Buffer.add_string current_msg_buf before;
+      let (in_code, lang) = Agent_process.scan_fences before in
+      if in_code then
+        Buffer.add_string current_msg_buf "\n```";
+      flush_to_discord ();
+      Buffer.clear current_msg_buf;
+      current_msg_id := None;
+      if in_code then
+        Buffer.add_string current_msg_buf ("```" ^ lang ^ "\n");
+      Buffer.add_string current_msg_buf carry;
+      true
+  in
   (* Flush accumulated tool status lines to a single Discord message.
      Consecutive tool calls get batched into one message, edited in-place.
      Sanitization here mirrors flush_to_discord — tool inputs (file paths,
@@ -346,7 +377,9 @@ let run ~sw ~env ~rest ~session ~(channel_id : Discord_types.channel_id)
         in
         if chunk_len = 0 then begin
           let before_len = Buffer.length current_msg_buf in
-          start_new_message ();
+          let carried = carry_trailing_word_to_next_message () in
+          if not carried then
+            start_new_message ();
           if Buffer.length current_msg_buf >= before_len then begin
             let remaining_capacity =
               max 1 (stream_message_max - Buffer.length current_msg_buf)

--- a/lib/agent_runner.ml
+++ b/lib/agent_runner.ml
@@ -323,6 +323,10 @@ let run ~sw ~env ~rest ~session ~(channel_id : Discord_types.channel_id)
       Buffer.add_string current_msg_buf carry;
       true
   in
+  let start_new_message_preserving_trailing_word () =
+    if not (carry_trailing_word_to_next_message ()) then
+      start_new_message ()
+  in
   (* Flush accumulated tool status lines to a single Discord message.
      Consecutive tool calls get batched into one message, edited in-place.
      Sanitization here mirrors flush_to_discord — tool inputs (file paths,
@@ -370,7 +374,7 @@ let run ~sw ~env ~rest ~session ~(channel_id : Discord_types.channel_id)
         (* Flush first if buffer is already at capacity (e.g. from a
            reopened code block prefix) to avoid zero-progress loops *)
         if Buffer.length current_msg_buf >= stream_message_max then
-          start_new_message ();
+          start_new_message_preserving_trailing_word ();
         let chunk_len =
           take_stream_delta_chunk_len
             ~current_len:(Buffer.length current_msg_buf) text ~start:!pos
@@ -396,7 +400,7 @@ let run ~sw ~env ~rest ~session ~(channel_id : Discord_types.channel_id)
           pos := !pos + chunk_len
         end;
         if Buffer.length current_msg_buf >= stream_message_max then
-          start_new_message ()
+          start_new_message_preserving_trailing_word ()
       done;
       let now = Unix.gettimeofday () in
       if now -. !last_edit > 2.0 && Buffer.length current_msg_buf > 0 then begin

--- a/lib/agent_runner.ml
+++ b/lib/agent_runner.ml
@@ -13,6 +13,29 @@
 (** Typing indicator refresh interval in seconds. *)
 let typing_interval = 8.0
 
+let stream_message_max = 1796
+
+let take_stream_delta_chunk_len ~current_len text ~start =
+  let remaining_capacity = stream_message_max - current_len in
+  if remaining_capacity <= 0 then 0
+  else
+    let hard_len =
+      Agent_process.take_fitting_prefix
+        ~start ~max_chars:remaining_capacity text
+    in
+    let hard_end = start + hard_len in
+    if hard_end >= String.length text then hard_len
+    else
+      let rec find_space i =
+        if i <= start then None
+        else if Agent_process.is_ascii_whitespace text.[i - 1] then Some i
+        else find_space (i - 1)
+      in
+      match find_space hard_end with
+      | Some i when i > start -> i - start
+      | _ when current_len > 0 -> 0
+      | _ -> hard_len
+
 (** Map tool names to emoji + verb for compact status display. *)
 (** Escape underscores in a tool name for Discord display.
     Discord interprets __ as underline and _ as italic, so we
@@ -308,20 +331,38 @@ let run ~sw ~env ~rest ~session ~(channel_id : Discord_types.channel_id)
         current_msg_id := None
       end;
       Buffer.add_string result_buf text;
-      (* Split at 1800-char boundaries, reserving space for closing ```
+      (* Split near 1800-char boundaries, reserving space for closing ```
          if we might be inside a code block (worst case: 4 chars for "\n```") *)
       let text_len = String.length text in
       let pos = ref 0 in
       while !pos < text_len do
         (* Flush first if buffer is already at capacity (e.g. from a
            reopened code block prefix) to avoid zero-progress loops *)
-        if Buffer.length current_msg_buf >= 1796 then
+        if Buffer.length current_msg_buf >= stream_message_max then
           start_new_message ();
-        let remaining_capacity = 1796 - Buffer.length current_msg_buf in
-        let chunk_len = min remaining_capacity (text_len - !pos) in
-        Buffer.add_substring current_msg_buf text !pos chunk_len;
-        pos := !pos + chunk_len;
-        if Buffer.length current_msg_buf >= 1796 then
+        let chunk_len =
+          take_stream_delta_chunk_len
+            ~current_len:(Buffer.length current_msg_buf) text ~start:!pos
+        in
+        if chunk_len = 0 then begin
+          let before_len = Buffer.length current_msg_buf in
+          start_new_message ();
+          if Buffer.length current_msg_buf >= before_len then begin
+            let remaining_capacity =
+              max 1 (stream_message_max - Buffer.length current_msg_buf)
+            in
+            let forced_len =
+              Agent_process.take_fitting_prefix
+                ~start:!pos ~max_chars:remaining_capacity text
+            in
+            Buffer.add_substring current_msg_buf text !pos forced_len;
+            pos := !pos + forced_len
+          end
+        end else begin
+          Buffer.add_substring current_msg_buf text !pos chunk_len;
+          pos := !pos + chunk_len
+        end;
+        if Buffer.length current_msg_buf >= stream_message_max then
           start_new_message ()
       done;
       let now = Unix.gettimeofday () in

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -188,7 +188,7 @@ let load () =
   in
   (* Allow env var override for the token *)
   match Sys.getenv_opt "DISCORD_BOT_TOKEN" with
-  | Some token when token <> "" && config.discord_token = "" ->
+  | Some token when not (blank token) && blank config.discord_token ->
     { config with discord_token = token }
   | _ -> config
 

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -66,7 +66,7 @@ type t = {
   guild_id : string; (** Discord server/guild to operate in *)
   control_channel_id : string option; (** Top-level channel for server-wide commands *)
   projects : project list;
-} [@@deriving show, yojson]
+} [@@deriving show]
 
 let default = {
   discord_token = "";
@@ -75,6 +75,95 @@ let default = {
   control_channel_id = None;
   projects = [];
 }
+
+let field fields name = List.assoc_opt name fields
+
+let string_field ~name = function
+  | `String s -> s
+  | _ -> failwith (Printf.sprintf "%s: expected string" name)
+
+let optional_string_field ~name = function
+  | `Null -> None
+  | `String s -> Some s
+  | _ -> failwith (Printf.sprintf "%s: expected string or null" name)
+
+let string_list_field ~name = function
+  | `List xs -> List.map (string_field ~name) xs
+  | _ -> failwith (Printf.sprintf "%s: expected array of strings" name)
+
+let project_list_field ~name = function
+  | `List xs -> List.map project_of_yojson xs
+  | _ -> failwith (Printf.sprintf "%s: expected array of project objects" name)
+
+let t_of_yojson = function
+  | `Assoc fields ->
+    let discord_token =
+      match field fields "discord_token" with
+      | Some json -> string_field ~name:"discord_token" json
+      | None -> default.discord_token
+    in
+    let base_directories =
+      match field fields "base_directories", field fields "base_dirs" with
+      | Some json, _ -> string_list_field ~name:"base_directories" json
+      | None, Some json -> string_list_field ~name:"base_dirs" json
+      | None, None -> default.base_directories
+    in
+    let guild_id =
+      match field fields "guild_id" with
+      | Some json -> string_field ~name:"guild_id" json
+      | None -> default.guild_id
+    in
+    let control_channel_id =
+      match field fields "control_channel_id" with
+      | Some json -> optional_string_field ~name:"control_channel_id" json
+      | None -> default.control_channel_id
+    in
+    let projects =
+      match field fields "projects" with
+      | Some json -> project_list_field ~name:"projects" json
+      | None -> default.projects
+    in
+    { discord_token; base_directories; guild_id; control_channel_id; projects }
+  | _ -> failwith "config: expected object"
+
+let yojson_of_t t =
+  `Assoc [
+    ("discord_token", `String t.discord_token);
+    ("base_directories",
+     `List (List.map (fun path -> `String path) t.base_directories));
+    ("guild_id", `String t.guild_id);
+    ("control_channel_id",
+     (match t.control_channel_id with
+      | Some id -> `String id
+      | None -> `Null));
+    ("projects", `List (List.map yojson_of_project t.projects));
+  ]
+
+let blank s = String.trim s = ""
+
+let validation_errors ?(require_guild_id=true) config =
+  let errors = ref [] in
+  let add msg = errors := msg :: !errors in
+  if blank config.discord_token then
+    add "discord_token is required, unless DISCORD_BOT_TOKEN is set";
+  if require_guild_id && blank config.guild_id then
+    add "guild_id is required";
+  List.iteri (fun i path ->
+    if blank path then
+      add (Printf.sprintf "base_directories[%d] must not be empty" i)
+  ) config.base_directories;
+  List.iteri (fun i project ->
+    if blank project.name then
+      add (Printf.sprintf "projects[%d].name must not be empty" i);
+    if blank project.path then
+      add (Printf.sprintf "projects[%d].path must not be empty" i)
+  ) config.projects;
+  List.rev !errors
+
+let validate ?require_guild_id config =
+  match validation_errors ?require_guild_id config with
+  | [] -> Ok ()
+  | errors -> Error errors
 
 let config_path () =
   Filename.concat (Resource.app_config_dir ()) "config.json"

--- a/lib/runtime_settings.ml
+++ b/lib/runtime_settings.ml
@@ -16,7 +16,7 @@ let lock_path () = settings_path () ^ ".lock"
 let backup_path () = settings_path () ^ ".bak"
 
 let default () = {
-  default_agent = Config.Claude;
+  default_agent = Config.Codex;
   rescue_agent = None;
   policy_sync_pending = false;
 }

--- a/test/test_agent_contracts.ml
+++ b/test/test_agent_contracts.ml
@@ -130,6 +130,12 @@ let codex_command ~ephemeral ~session_id ~session_id_confirmed prompt =
   in
   String.concat " " (List.map Filename.quote args)
 
+let gemini_command ~session_id ~session_id_confirmed prompt =
+  Discord_agents.Agent_process.gemini_args
+    ~session_id ~session_id_confirmed ~prompt
+  |> List.map Filename.quote
+  |> String.concat " "
+
 let codex_fresh =
   Alcotest.test_case "fresh exec emits thread.started + agent_message"
     `Slow (fun () ->
@@ -213,9 +219,9 @@ let claude_resume =
 let gemini_fresh =
   Alcotest.test_case "fresh -p emits init session_id + assistant text"
     `Slow (fun () ->
-      let cmd =
-        "gemini -p 'reply with the single word ok' -o stream-json --yolo"
-      in
+      let cmd = gemini_command ~session_id:""
+        ~session_id_confirmed:false
+        "reply with the single word ok" in
       let events = invoke_or_skip ~label:"gemini fresh" ~cmd
         ~parse:Discord_agents.Agent_process.parse_gemini_stream_json_line in
       Alcotest.(check bool)
@@ -228,9 +234,9 @@ let gemini_fresh =
 let gemini_resume =
   Alcotest.test_case "resume preserves the captured session id"
     `Slow (fun () ->
-      let fresh_cmd =
-        "gemini -p 'reply with the single word ok' -o stream-json --yolo"
-      in
+      let fresh_cmd = gemini_command ~session_id:""
+        ~session_id_confirmed:false
+        "reply with the single word ok" in
       let fresh_events = invoke_or_skip ~label:"gemini fresh (for resume)"
         ~cmd:fresh_cmd
         ~parse:Discord_agents.Agent_process.parse_gemini_stream_json_line in
@@ -238,10 +244,9 @@ let gemini_resume =
         | Some s -> s
         | None -> Alcotest.fail "gemini fresh did not emit a session id"
       in
-      let resume_cmd = Printf.sprintf
-        "gemini -p 'reply with the single word ok' -o stream-json --yolo \
-         --resume %s" sid
-      in
+      let resume_cmd = gemini_command ~session_id:sid
+        ~session_id_confirmed:true
+        "reply with the single word ok" in
       let resume_events = invoke_or_skip ~label:"gemini resume"
         ~cmd:resume_cmd
         ~parse:Discord_agents.Agent_process.parse_gemini_stream_json_line in

--- a/test/test_config.ml
+++ b/test/test_config.ml
@@ -63,6 +63,25 @@ let test_load_prefers_canonical_base_directories () =
     Alcotest.(check (list string)) "canonical base directories"
       ["~/Projects"] config.base_directories)
 
+let test_load_env_token_replaces_blank_config_token () =
+  with_tmp_home (fun home ->
+    let old_token = Sys.getenv_opt "DISCORD_BOT_TOKEN" in
+    Fun.protect
+      ~finally:(fun () -> restore_env "DISCORD_BOT_TOKEN" old_token)
+      (fun () ->
+        let path = config_path home in
+        Discord_agents.Resource.ensure_parent_dir path;
+        Discord_agents.Resource.write_file_atomic path
+          {|{
+  "discord_token": "   ",
+  "guild_id": "guild-1",
+  "base_directories": ["~/Projects"]
+}|};
+        Unix.putenv "DISCORD_BOT_TOKEN" "env-token";
+        let config = Discord_agents.Config.load () in
+        Alcotest.(check string) "env token"
+          "env-token" config.discord_token))
+
 let has_error_substring needle errors =
   List.exists (fun err ->
     try ignore (Str.search_forward (Str.regexp_string needle) err 0); true
@@ -122,6 +141,37 @@ let test_save_reaps_stale_atomic_temp () =
     let mode = (Unix.stat path).Unix.st_perm land 0o777 in
     Alcotest.(check int) "config mode remains private" 0o600 mode)
 
+let test_save_load_roundtrip () =
+  with_tmp_home (fun _home ->
+    let config = {
+      Discord_agents.Config.discord_token = "test-token";
+      guild_id = "guild";
+      base_directories = ["~/Projects"; "/srv/src"];
+      control_channel_id = Some "control";
+      projects = [
+        { name = "repo"; path = "/srv/src/repo"; channel_id = Some "chan" };
+      ];
+    } in
+    Discord_agents.Config.save config;
+    let loaded = Discord_agents.Config.load () in
+    Alcotest.(check string) "token"
+      config.discord_token loaded.discord_token;
+    Alcotest.(check string) "guild"
+      config.guild_id loaded.guild_id;
+    Alcotest.(check (list string)) "base directories"
+      config.base_directories loaded.base_directories;
+    Alcotest.(check (option string)) "control channel"
+      config.control_channel_id loaded.control_channel_id;
+    Alcotest.(check int) "project count"
+      1 (List.length loaded.projects);
+    match loaded.projects with
+    | [project] ->
+      Alcotest.(check string) "project name" "repo" project.name;
+      Alcotest.(check string) "project path" "/srv/src/repo" project.path;
+      Alcotest.(check (option string)) "project channel"
+        (Some "chan") project.channel_id
+    | _ -> Alcotest.fail "expected one project")
+
 let () =
   Alcotest.run "config" [
     ("schema", [
@@ -129,6 +179,8 @@ let () =
         test_load_accepts_basic_schema_alias;
       Alcotest.test_case "canonical base_directories wins" `Quick
         test_load_prefers_canonical_base_directories;
+      Alcotest.test_case "env token replaces blank config token" `Quick
+        test_load_env_token_replaces_blank_config_token;
       Alcotest.test_case "validation reports required fields" `Quick
         test_validate_reports_required_fields;
       Alcotest.test_case "smoke-test validation allows missing guild" `Quick
@@ -137,5 +189,7 @@ let () =
     ("persistence", [
       Alcotest.test_case "save reaps stale atomic temp" `Quick
         test_save_reaps_stale_atomic_temp;
+      Alcotest.test_case "save/load roundtrip" `Quick
+        test_save_load_roundtrip;
     ]);
   ]

--- a/test/test_config.ml
+++ b/test/test_config.ml
@@ -29,6 +29,80 @@ let with_tmp_home f =
 let config_path home =
   Filename.concat home ".config/discord-agents/config.json"
 
+let test_load_accepts_basic_schema_alias () =
+  with_tmp_home (fun home ->
+    let path = config_path home in
+    Discord_agents.Resource.ensure_parent_dir path;
+    Discord_agents.Resource.write_file_atomic path
+      {|{
+  "discord_token": "test-token",
+  "guild_id": "guild-1",
+  "base_dirs": ["~/Projects"]
+}|};
+    let config = Discord_agents.Config.load () in
+    Alcotest.(check string) "token" "test-token" config.discord_token;
+    Alcotest.(check string) "guild" "guild-1" config.guild_id;
+    Alcotest.(check (list string)) "base dirs"
+      ["~/Projects"] config.base_directories;
+    Alcotest.(check (option string)) "control channel default"
+      None config.control_channel_id;
+    Alcotest.(check int) "projects default" 0 (List.length config.projects))
+
+let test_load_prefers_canonical_base_directories () =
+  with_tmp_home (fun home ->
+    let path = config_path home in
+    Discord_agents.Resource.ensure_parent_dir path;
+    Discord_agents.Resource.write_file_atomic path
+      {|{
+  "discord_token": "test-token",
+  "guild_id": "guild-1",
+  "base_dirs": ["~/Old"],
+  "base_directories": ["~/Projects"]
+}|};
+    let config = Discord_agents.Config.load () in
+    Alcotest.(check (list string)) "canonical base directories"
+      ["~/Projects"] config.base_directories)
+
+let has_error_substring needle errors =
+  List.exists (fun err ->
+    try ignore (Str.search_forward (Str.regexp_string needle) err 0); true
+    with Not_found -> false
+  ) errors
+
+let test_validate_reports_required_fields () =
+  let config = {
+    Discord_agents.Config.default with
+    base_directories = ["~/Projects"; ""];
+    projects = [
+      { name = ""; path = "/tmp/project"; channel_id = None };
+      { name = "missing-path"; path = ""; channel_id = None };
+    ];
+  } in
+  match Discord_agents.Config.validate config with
+  | Ok () -> Alcotest.fail "expected config validation errors"
+  | Error errors ->
+    Alcotest.(check bool) "requires token"
+      true (has_error_substring "discord_token" errors);
+    Alcotest.(check bool) "requires guild"
+      true (has_error_substring "guild_id" errors);
+    Alcotest.(check bool) "rejects empty base dir"
+      true (has_error_substring "base_directories[1]" errors);
+    Alcotest.(check bool) "rejects empty project name"
+      true (has_error_substring "projects[0].name" errors);
+    Alcotest.(check bool) "rejects empty project path"
+      true (has_error_substring "projects[1].path" errors)
+
+let test_validate_smoke_test_allows_missing_guild () =
+  let config = {
+    Discord_agents.Config.default with
+    discord_token = "test-token";
+  } in
+  match Discord_agents.Config.validate ~require_guild_id:false config with
+  | Ok () -> ()
+  | Error errors ->
+    Alcotest.failf "expected smoke-test config to validate, got: %s"
+      (String.concat "; " errors)
+
 let test_save_reaps_stale_atomic_temp () =
   with_tmp_home (fun home ->
     let path = config_path home in
@@ -50,6 +124,16 @@ let test_save_reaps_stale_atomic_temp () =
 
 let () =
   Alcotest.run "config" [
+    ("schema", [
+      Alcotest.test_case "load accepts base_dirs alias" `Quick
+        test_load_accepts_basic_schema_alias;
+      Alcotest.test_case "canonical base_directories wins" `Quick
+        test_load_prefers_canonical_base_directories;
+      Alcotest.test_case "validation reports required fields" `Quick
+        test_validate_reports_required_fields;
+      Alcotest.test_case "smoke-test validation allows missing guild" `Quick
+        test_validate_smoke_test_allows_missing_guild;
+    ]);
     ("persistence", [
       Alcotest.test_case "save reaps stale atomic temp" `Quick
         test_save_reaps_stale_atomic_temp;

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -420,6 +420,28 @@ let test_stream_delta_carries_cross_delta_word_suffix () =
       (String.length "ount balance") len
   | None -> Alcotest.fail "expected trailing suffix to be carried"
 
+let test_stream_delta_exact_capacity_suffix_can_be_carried () =
+  let prefix =
+    String.make (Discord_agents.Agent_runner.stream_message_max - 4) 'a'
+    ^ " "
+  in
+  let page = prefix ^ "acc" in
+  Alcotest.(check int) "page exactly fills stream budget"
+    Discord_agents.Agent_runner.stream_message_max
+    (String.length page);
+  match Discord_agents.Agent_runner.split_trailing_word_for_carry page with
+  | Some (before, carry) ->
+    Alcotest.(check string) "exact-fill suffix carried" "acc" carry;
+    Alcotest.(check int) "flushed prefix has room"
+      (String.length prefix) (String.length before);
+    let len =
+      Discord_agents.Agent_runner.take_stream_delta_chunk_len
+        ~current_len:(String.length carry) "ount balance" ~start:0
+    in
+    Alcotest.(check int) "next delta joins exact-fill suffix"
+      (String.length "ount balance") len
+  | None -> Alcotest.fail "expected exact-fill suffix to be carried"
+
 let test_stream_delta_does_not_carry_unbroken_buffer () =
   Alcotest.(check bool) "no prefix to flush"
     true
@@ -649,6 +671,8 @@ let split_message_tests = [
     test_stream_delta_utf8_boundary_after_flush;
   Alcotest.test_case "stream delta carries cross-delta suffix" `Quick
     test_stream_delta_carries_cross_delta_word_suffix;
+  Alcotest.test_case "stream delta carries exact-capacity suffix" `Quick
+    test_stream_delta_exact_capacity_suffix_can_be_carried;
   Alcotest.test_case "stream delta leaves unbroken buffer" `Quick
     test_stream_delta_does_not_carry_unbroken_buffer;
   Alcotest.test_case "projects-list regression" `Quick

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -2993,8 +2993,8 @@ let test_gemini_args_fresh () =
   let args = gemini_args ~session_id:"placeholder"
     ~session_id_confirmed:false ~prompt:"hello" in
   Alcotest.(check (list string))
-    "fresh invocation: -p prompt, -o stream-json, --yolo, no resume"
-    ["gemini"; "-p"; "hello"; "-o"; "stream-json"; "--yolo"]
+    "fresh invocation: skip trust, -p prompt, stream-json, --yolo, no resume"
+    ["gemini"; "--skip-trust"; "-p"; "hello"; "-o"; "stream-json"; "--yolo"]
     args
 
 let test_gemini_args_resume () =
@@ -3002,7 +3002,7 @@ let test_gemini_args_resume () =
     ~session_id_confirmed:true ~prompt:"continue" in
   Alcotest.(check (list string))
     "resume invocation appends --resume <id>"
-    ["gemini"; "-p"; "continue"; "-o"; "stream-json"; "--yolo";
+    ["gemini"; "--skip-trust"; "-p"; "continue"; "-o"; "stream-json"; "--yolo";
      "--resume"; "abc-123"]
     args
 

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -365,6 +365,45 @@ let test_split_output_keeps_fitting_suffix_together () =
   Alcotest.(check (list string)) "suffix stays in one chunk"
     ["verylongwo"; "rd bye"] chunks
 
+let test_stream_delta_flushes_before_splitting_word () =
+  let len =
+    Discord_agents.Agent_runner.take_stream_delta_chunk_len
+      ~current_len:(Discord_agents.Agent_runner.stream_message_max - 5)
+      "account balance" ~start:0
+  in
+  Alcotest.(check int) "flush before account split" 0 len
+
+let test_stream_delta_splits_long_word_when_fresh () =
+  let text =
+    String.make (Discord_agents.Agent_runner.stream_message_max + 10) 'a'
+  in
+  let len =
+    Discord_agents.Agent_runner.take_stream_delta_chunk_len
+      ~current_len:0 text ~start:0
+  in
+  Alcotest.(check int) "fresh message takes hard budget"
+    Discord_agents.Agent_runner.stream_message_max len
+
+let test_stream_delta_utf8_boundary_after_flush () =
+  let emoji = "\xF0\x9F\x98\x80" in
+  let text = emoji ^ " account" in
+  let len_before_flush =
+    Discord_agents.Agent_runner.take_stream_delta_chunk_len
+      ~current_len:(Discord_agents.Agent_runner.stream_message_max - 1)
+      text ~start:0
+  in
+  Alcotest.(check int) "flush before slicing emoji" 0 len_before_flush;
+  let prefix =
+    String.make (Discord_agents.Agent_runner.stream_message_max - 1) 'a'
+  in
+  let text = prefix ^ emoji ^ " account" in
+  let len_after_flush =
+    Discord_agents.Agent_runner.take_stream_delta_chunk_len
+      ~current_len:0 text ~start:0
+  in
+  Alcotest.(check int) "fresh chunk stops before emoji boundary"
+    (String.length prefix) len_after_flush
+
 (* Regression: !projects output with many entries must be safely chunkable.
    The original bug was that create_message sent a single ~5700-char message
    when 63 projects were discovered, and Discord silently rejected it.
@@ -580,6 +619,12 @@ let split_message_tests = [
     test_split_output_chunks_do_not_split_words;
   Alcotest.test_case "output chunking keeps fitting suffix" `Quick
     test_split_output_keeps_fitting_suffix_together;
+  Alcotest.test_case "stream delta flushes before word split" `Quick
+    test_stream_delta_flushes_before_splitting_word;
+  Alcotest.test_case "stream delta splits long fresh word" `Quick
+    test_stream_delta_splits_long_word_when_fresh;
+  Alcotest.test_case "stream delta preserves UTF-8 boundary" `Quick
+    test_stream_delta_utf8_boundary_after_flush;
   Alcotest.test_case "projects-list regression" `Quick
     test_split_projects_list_shape;
   Alcotest.test_case "plan: short content → single chunk with reply_to" `Quick

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -131,6 +131,43 @@ let test_reformat_separator_regenerated () =
        true (String.length sep > 10)
    | [] -> Alcotest.fail "no separator row found")
 
+let test_render_padded_table_truncates_utf8_safely () =
+  let input = [
+    "| Icon | Description |";
+    "|---|---|";
+    "| " ^ String.concat "" (List.init 8 (fun _ -> "😀")) ^ " | " ^
+      String.concat "" (List.init 8 (fun _ -> "界")) ^ " |";
+  ] in
+  let result =
+    Discord_agents.Agent_process.render_padded_table ~max_width:20 input
+  in
+  let well_formed s =
+    let n = String.length s in
+    let rec walk i =
+      if i >= n then true
+      else
+        let c = Char.code s.[i] in
+        let need =
+          if c < 0x80 then 0
+          else if c < 0xC0 then -1
+          else if c < 0xE0 then 1
+          else if c < 0xF0 then 2
+          else 3
+        in
+        if need < 0 || i + need >= n then false
+        else
+          let ok = ref true in
+          for k = 1 to need do
+            let cc = Char.code s.[i + k] in
+            if cc < 0x80 || cc >= 0xC0 then ok := false
+          done;
+          !ok && walk (i + 1 + need)
+    in
+    walk 0
+  in
+  Alcotest.(check bool) "rendered table is valid UTF-8"
+    true (well_formed result)
+
 let reformat_tables_tests = [
   Alcotest.test_case "plain text" `Quick test_reformat_plain_text;
   Alcotest.test_case "simple table" `Quick test_reformat_simple_table;
@@ -150,6 +187,8 @@ let reformat_tables_tests = [
   Alcotest.test_case "padding alignment" `Quick test_reformat_padding_alignment;
   Alcotest.test_case "separator regenerated" `Quick
     test_reformat_separator_regenerated;
+  Alcotest.test_case "table truncation is UTF-8 safe" `Quick
+    test_render_padded_table_truncates_utf8_safely;
 ]
 
 (* ── find_trailing_table_start ──────────────────────────────────── *)
@@ -317,6 +356,14 @@ let test_split_output_chunks_do_not_split_words () =
     Alcotest.(check bool) "chunk under display budget"
       true (Discord_agents.Agent_process.escaped_length chunk <= 15)
   ) chunks
+
+let test_split_output_keeps_fitting_suffix_together () =
+  let chunks =
+    Discord_agents.Agent_process.split_into_chunks
+      ~max_chars:10 "verylongword bye"
+  in
+  Alcotest.(check (list string)) "suffix stays in one chunk"
+    ["verylongwo"; "rd bye"] chunks
 
 (* Regression: !projects output with many entries must be safely chunkable.
    The original bug was that create_message sent a single ~5700-char message
@@ -531,6 +578,8 @@ let split_message_tests = [
     test_split_message_does_not_split_words;
   Alcotest.test_case "output chunking avoids word splits" `Quick
     test_split_output_chunks_do_not_split_words;
+  Alcotest.test_case "output chunking keeps fitting suffix" `Quick
+    test_split_output_keeps_fitting_suffix_together;
   Alcotest.test_case "projects-list regression" `Quick
     test_split_projects_list_shape;
   Alcotest.test_case "plan: short content → single chunk with reply_to" `Quick

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -281,6 +281,43 @@ let test_split_no_separator_utf8_safe () =
     Alcotest.(check bool) "chunk is well-formed UTF-8" true (well_formed chunk)
   ) chunks
 
+let contains_substring text needle =
+  try ignore (Str.search_forward (Str.regexp_string needle) text 0); true
+  with Not_found -> false
+
+let test_split_message_does_not_split_words () =
+  let input =
+    String.concat " " [
+      String.make 20 'a';
+      "account";
+      "balance";
+      String.make 20 'b';
+    ]
+  in
+  let chunks = Discord_agents.Agent_process.split_message ~max_len:30 input in
+  let marked = String.concat "/" chunks in
+  Alcotest.(check bool) "account not split as ac/count"
+    false (contains_substring marked "ac/count");
+  List.iter (fun chunk ->
+    Alcotest.(check bool) "chunk under test limit"
+      true (String.length chunk <= 30)
+  ) chunks
+
+let test_split_output_chunks_do_not_split_words () =
+  let input =
+    "alpha beta account gamma delta account epsilon zeta"
+  in
+  let chunks =
+    Discord_agents.Agent_process.split_into_chunks ~max_chars:15 input
+  in
+  let marked = String.concat "/" chunks in
+  Alcotest.(check bool) "output chunks avoid ac/count"
+    false (contains_substring marked "ac/count");
+  List.iter (fun chunk ->
+    Alcotest.(check bool) "chunk under display budget"
+      true (Discord_agents.Agent_process.escaped_length chunk <= 15)
+  ) chunks
+
 (* Regression: !projects output with many entries must be safely chunkable.
    The original bug was that create_message sent a single ~5700-char message
    when 63 projects were discovered, and Discord silently rejected it.
@@ -490,6 +527,10 @@ let split_message_tests = [
     test_split_all_chunks_under_limit;
   Alcotest.test_case "no-separator fallback is UTF-8 safe" `Quick
     test_split_no_separator_utf8_safe;
+  Alcotest.test_case "split_message avoids word splits" `Quick
+    test_split_message_does_not_split_words;
+  Alcotest.test_case "output chunking avoids word splits" `Quick
+    test_split_output_chunks_do_not_split_words;
   Alcotest.test_case "projects-list regression" `Quick
     test_split_projects_list_shape;
   Alcotest.test_case "plan: short content → single chunk with reply_to" `Quick
@@ -1078,6 +1119,19 @@ let test_truncate_for_display_fence_heavy () =
   Alcotest.(check bool) "escaped text fits in budget"
     true (String.length escaped <= 1700)
 
+let test_truncate_for_display_does_not_split_words () =
+  let line = "alpha beta account gamma delta" in
+  let t = Discord_agents.Agent_process.truncate_for_display
+    ~max_lines:10 ~max_chars:15 [line] in
+  let marked = String.concat "/" t.display in
+  Alcotest.(check bool) "truncate fallback avoids ac/count"
+    false (contains_substring marked "ac/count");
+  (match t.display with
+   | [display] ->
+     Alcotest.(check bool) "display under budget"
+       true (Discord_agents.Agent_process.escaped_length display <= 15)
+   | _ -> Alcotest.fail "expected one truncated display line")
+
 let test_take_fitting_prefix_plain () =
   let s = String.make 5000 'a' in
   let taken = Discord_agents.Agent_process.take_fitting_prefix
@@ -1151,6 +1205,8 @@ let tool_detail_tests = [
   Alcotest.test_case "safety cap" `Quick test_detail_safety_cap;
   Alcotest.test_case "fence heavy" `Quick test_detail_fence_heavy;
   Alcotest.test_case "truncate fence heavy" `Quick test_truncate_for_display_fence_heavy;
+  Alcotest.test_case "truncate avoids word splits" `Quick
+    test_truncate_for_display_does_not_split_words;
   Alcotest.test_case "take_fitting_prefix plain" `Quick test_take_fitting_prefix_plain;
   Alcotest.test_case "take_fitting_prefix fences" `Quick test_take_fitting_prefix_fences;
   Alcotest.test_case "take_fitting_prefix utf8" `Quick test_take_fitting_prefix_utf8;

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -404,6 +404,28 @@ let test_stream_delta_utf8_boundary_after_flush () =
   Alcotest.(check int) "fresh chunk stops before emoji boundary"
     (String.length prefix) len_after_flush
 
+let test_stream_delta_carries_cross_delta_word_suffix () =
+  match Discord_agents.Agent_runner.split_trailing_word_for_carry
+          "prefix acc" with
+  | Some (before, carry) ->
+    Alcotest.(check string) "prefix flushed before suffix"
+      "prefix " before;
+    Alcotest.(check string) "suffix carried"
+      "acc" carry;
+    let len =
+      Discord_agents.Agent_runner.take_stream_delta_chunk_len
+        ~current_len:(String.length carry) "ount balance" ~start:0
+    in
+    Alcotest.(check int) "carried suffix joins continuation"
+      (String.length "ount balance") len
+  | None -> Alcotest.fail "expected trailing suffix to be carried"
+
+let test_stream_delta_does_not_carry_unbroken_buffer () =
+  Alcotest.(check bool) "no prefix to flush"
+    true
+    (Option.is_none
+       (Discord_agents.Agent_runner.split_trailing_word_for_carry "account"))
+
 (* Regression: !projects output with many entries must be safely chunkable.
    The original bug was that create_message sent a single ~5700-char message
    when 63 projects were discovered, and Discord silently rejected it.
@@ -625,6 +647,10 @@ let split_message_tests = [
     test_stream_delta_splits_long_word_when_fresh;
   Alcotest.test_case "stream delta preserves UTF-8 boundary" `Quick
     test_stream_delta_utf8_boundary_after_flush;
+  Alcotest.test_case "stream delta carries cross-delta suffix" `Quick
+    test_stream_delta_carries_cross_delta_word_suffix;
+  Alcotest.test_case "stream delta leaves unbroken buffer" `Quick
+    test_stream_delta_does_not_carry_unbroken_buffer;
   Alcotest.test_case "projects-list regression" `Quick
     test_split_projects_list_shape;
   Alcotest.test_case "plan: short content → single chunk with reply_to" `Quick

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -1283,6 +1283,22 @@ let test_codex_command_completed () =
   Alcotest.(check (option string)) "completed emits Tool_result with output"
     (Some "hi\n") (expect_tool_result (parse_codex line))
 
+let test_codex_current_command_lifecycle () =
+  let started =
+    {|{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"/bin/bash -lc 'printf codex_probe'","aggregated_output":"","exit_code":null,"status":"in_progress"}}|}
+  in
+  let completed =
+    {|{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"/bin/bash -lc 'printf codex_probe'","aggregated_output":"codex_probe","exit_code":0,"status":"completed"}}|}
+  in
+  (match expect_tool (parse_codex started) with
+   | Some info ->
+     Alcotest.(check string) "tool name" "Bash" info.tool_name;
+     Alcotest.(check string) "summary"
+       "/bin/bash -lc 'printf codex_probe'" info.tool_summary
+   | None -> Alcotest.fail "expected command Tool_use");
+  Alcotest.(check (option string)) "completed emits current output"
+    (Some "codex_probe") (expect_tool_result (parse_codex completed))
+
 let test_codex_command_completed_nonzero_exit () =
   let line = {|{"type":"item.completed","item":{"id":"i1","type":"command_execution","command":"false","aggregated_output":"","exit_code":1,"status":"completed"}}|} in
   Alcotest.(check (option string)) "nonzero exit prefixed with [exit N]"
@@ -1357,6 +1373,7 @@ let codex_json_tests = [
   Alcotest.test_case "empty agent_message dropped" `Quick test_codex_agent_message_empty_dropped;
   Alcotest.test_case "command start is Tool_use Bash" `Quick test_codex_command_started;
   Alcotest.test_case "command complete is Tool_result" `Quick test_codex_command_completed;
+  Alcotest.test_case "current command lifecycle" `Quick test_codex_current_command_lifecycle;
   Alcotest.test_case "nonzero exit prefixed" `Quick test_codex_command_completed_nonzero_exit;
   Alcotest.test_case "empty success dropped" `Quick test_codex_command_completed_empty_dropped;
   Alcotest.test_case "file_change add" `Quick test_codex_file_change_add;
@@ -2892,6 +2909,27 @@ let test_gemini_tool_result_success () =
   Alcotest.(check (option string)) "success carries output"
     (Some "hello world") (expect_tool_result (parse_gemini line))
 
+let test_gemini_current_tool_lifecycle () =
+  let tool_use =
+    {|{"type":"tool_use","timestamp":"2026-06-16T03:49:46.874Z","tool_name":"run_shell_command","tool_id":"run_shell_command__run_shell_command_1781581786783_0","parameters":{"command":"printf gemini_probe","description":"Run printf gemini_probe to verify shell execution."}}|}
+  in
+  let tool_result =
+    {|{"type":"tool_result","timestamp":"2026-06-16T03:49:46.942Z","tool_id":"run_shell_command__run_shell_command_1781581786783_0","status":"success","output":"gemini_probe"}|}
+  in
+  let assistant =
+    {|{"type":"message","timestamp":"2026-06-16T03:49:48.329Z","role":"assistant","content":"done","delta":true}|}
+  in
+  (match expect_tool (parse_gemini tool_use) with
+   | Some info ->
+     Alcotest.(check string) "maps to Bash" "Bash" info.tool_name;
+     Alcotest.(check string) "summary is current command"
+       "printf gemini_probe" info.tool_summary
+   | None -> Alcotest.fail "expected current Tool_use");
+  Alcotest.(check (option string)) "current result output"
+    (Some "gemini_probe") (expect_tool_result (parse_gemini tool_result));
+  Alcotest.(check (option string)) "current assistant delta"
+    (Some "done") (expect_text (parse_gemini assistant))
+
 let test_gemini_tool_result_error () =
   let line = {|{"type":"tool_result","tool_id":"t1","status":"error","output":"bad path","error":{"type":"invalid","message":"nope"}}|} in
   match expect_tool_result (parse_gemini line) with
@@ -2939,6 +2977,7 @@ let gemini_json_tests = [
   Alcotest.test_case "write_file maps to Write" `Quick test_gemini_write_file_tool_use;
   Alcotest.test_case "unknown tool name passthrough" `Quick test_gemini_unknown_tool_passthrough;
   Alcotest.test_case "tool_result success carries output" `Quick test_gemini_tool_result_success;
+  Alcotest.test_case "current tool lifecycle" `Quick test_gemini_current_tool_lifecycle;
   Alcotest.test_case "tool_result error formatted" `Quick test_gemini_tool_result_error;
   Alcotest.test_case "empty tool_result dropped" `Quick test_gemini_tool_result_empty_dropped;
   Alcotest.test_case "result flushes" `Quick test_gemini_result_flushes;

--- a/test/test_runtime_settings.ml
+++ b/test/test_runtime_settings.ml
@@ -45,11 +45,11 @@ let settings_path home =
 let backup_path home = settings_path home ^ ".bak"
 let stale_temp_path home = settings_path home ^ ".tmp.stale"
 
-let test_load_defaults_to_claude () =
+let test_load_defaults_to_codex () =
   with_tmp_home (fun _home ->
     let settings = Discord_agents.Runtime_settings.load () in
     Alcotest.(check string) "default agent"
-      "claude"
+      "codex"
       (Discord_agents.Config.string_of_agent_kind settings.default_agent);
     Alcotest.(check (option string)) "rescue agent defaults to none"
       None
@@ -92,7 +92,7 @@ let test_load_uses_backup_when_primary_corrupt () =
   with_tmp_home (fun home ->
     let settings = Discord_agents.Runtime_settings.load () in
     match Discord_agents.Runtime_settings.set_default_agent
-            settings Discord_agents.Config.Codex with
+            settings Discord_agents.Config.Gemini with
     | Error err -> Alcotest.failf "save failed: %s" err
     | Ok () ->
       let oc = open_out (settings_path home) in
@@ -105,7 +105,7 @@ let test_load_uses_backup_when_primary_corrupt () =
         backup_stat.Unix.st_mtime;
       let recovered = Discord_agents.Runtime_settings.load () in
       Alcotest.(check string) "recovered default agent"
-        "codex"
+        "gemini"
         (Discord_agents.Config.string_of_agent_kind recovered.default_agent))
 
 let test_save_with_visible_but_unconfirmed_primary_updates_backup () =
@@ -137,7 +137,7 @@ let test_save_marks_primary_newer_when_backup_update_fails () =
   with_tmp_home (fun home ->
     let settings = Discord_agents.Runtime_settings.load () in
     match Discord_agents.Runtime_settings.set_default_agent
-            settings Discord_agents.Config.Codex with
+            settings Discord_agents.Config.Claude with
     | Error err -> Alcotest.failf "initial save failed: %s" err
     | Ok () ->
       settings.default_agent <- Discord_agents.Config.Gemini;
@@ -168,7 +168,7 @@ let test_set_top_level_policy_failure_leaves_settings_unchanged () =
       Alcotest.fail "set_top_level_policy unexpectedly succeeded"
     | Error _ ->
       Alcotest.(check string) "default agent unchanged"
-        "claude"
+        "codex"
         (Discord_agents.Config.string_of_agent_kind settings.default_agent);
       Alcotest.(check (option string)) "rescue agent unchanged"
         None
@@ -182,7 +182,7 @@ let test_load_ignores_stale_backup_when_primary_is_newer_and_corrupt () =
   with_tmp_home (fun home ->
     let settings = Discord_agents.Runtime_settings.load () in
     match Discord_agents.Runtime_settings.set_default_agent
-            settings Discord_agents.Config.Codex with
+            settings Discord_agents.Config.Claude with
     | Error err -> Alcotest.failf "initial save failed: %s" err
     | Ok () ->
       settings.default_agent <- Discord_agents.Config.Gemini;
@@ -205,7 +205,7 @@ let test_load_ignores_stale_backup_when_primary_is_newer_and_corrupt () =
         (backup_stat.Unix.st_mtime +. 10.0);
       let recovered = Discord_agents.Runtime_settings.load () in
       Alcotest.(check string) "stale backup ignored"
-        "claude"
+        "codex"
         (Discord_agents.Config.string_of_agent_kind recovered.default_agent);
       Alcotest.(check bool) "pending policy defaults clean after stale backup"
         false recovered.policy_sync_pending)
@@ -291,8 +291,8 @@ let test_xdg_falls_back_to_existing_legacy_home () =
 let () =
   Alcotest.run "runtime_settings" [
     ("settings", [
-      Alcotest.test_case "load defaults to claude" `Quick
-        test_load_defaults_to_claude;
+      Alcotest.test_case "load defaults to codex" `Quick
+        test_load_defaults_to_codex;
       Alcotest.test_case "save and reload roundtrip" `Quick
         test_save_and_reload_roundtrip;
       Alcotest.test_case "load uses backup when primary corrupt" `Quick


### PR DESCRIPTION
## Summary

- switch fresh runtime settings so new top-level control/project sessions default to Codex
- pin current Codex CLI 0.139.0 and Gemini CLI 0.46.0 JSON command/tool lifecycle shapes in parser tests
- add a basic typed config schema with defaults, startup validation, canonical `base_directories`, legacy `base_dirs` alias, and a checked example config
- update README/SETUP docs for the config schema and Codex default
- add `--skip-trust` to Gemini headless invocations so bot-created worktrees emit stream-json instead of exiting before stdout events
- fix Discord output pagination so long-line display chunking prefers whitespace boundaries instead of splitting normal words like `account` into `ac` / `count`

## Root Cause: Word Splits

`split_message` already preferred paragraph/newline/space boundaries for assistant message pagination. The remaining split was in the separate tool/output display path: `split_into_chunks` and the first-line `truncate_for_display` fallback used the low-level UTF-8 byte-budget helper directly. That helper was safe for codepoints, but intentionally knew nothing about words, so a long single-line output could still split inside `account`. The new helper keeps the UTF-8/fence budget model but walks back to whitespace before falling back to a hard split for genuinely unbroken tokens.

## Live Probe Notes

- Drove Codex text, shell, and file-edit sessions in `/tmp`; raw JSON included expected `agent_message`, `command_execution`, and `file_change` items.
- Drove Gemini text, shell, and file-edit sessions in `/tmp`; without `--skip-trust`, Gemini exited in untrusted workdirs before emitting JSON; with `--skip-trust`, Gemini emitted `message`, `tool_use`, `tool_result`, and `result` frames.
- Gemini currently emits `update_topic` tool frames. These are surfaced as unknown tool status events rather than dropped.

## Validation

- `nix develop --command dune exec ./test/test_formatting.exe`
- `timeout 180 nix develop --command dune exec ./test/test_agent_contracts.exe`
- `nix develop --command dune exec ./test/test_runtime_settings.exe`
- `nix develop --command dune exec ./test/test_config.exe`
- `timeout 120 nix develop --command dune build --display short`
- `timeout 240 nix develop --command dune runtest`
