### PR TITLE
[codex] Add thread interrupt commands

### DIFF
--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -668,6 +668,37 @@ let stop_session t ~thread_id =
         }
       | Error err -> Session_stop_failed err
 
+let reply_stop_outcome reply = function
+  | Session_not_found ->
+    reply "Session not found."
+  | Session_stopped { project_name; dropped_count } ->
+    let dropped_text =
+      if dropped_count = 0 then ""
+      else Printf.sprintf " Dropped %d queued message%s."
+        dropped_count (if dropped_count = 1 then "" else "s")
+    in
+    reply (Printf.sprintf "Stopped session for **%s**.%s"
+      project_name dropped_text)
+  | Session_stopping { project_name; had_running_process; dropped_count } ->
+    let process_text =
+      if had_running_process then
+        " Terminating the active agent process."
+      else
+        " The active session will stop as soon as its current turn or agent startup finishes."
+    in
+    let dropped_text =
+      if dropped_count = 0 then ""
+      else Printf.sprintf " Dropped %d queued message%s."
+        dropped_count (if dropped_count = 1 then "" else "s")
+    in
+    reply (Printf.sprintf
+      "Stopping session for **%s**.%s%s"
+      project_name process_text dropped_text)
+  | Session_already_stopping { project_name } ->
+    reply (Printf.sprintf "Session for **%s** is already stopping." project_name)
+  | Session_stop_failed err ->
+    reply (Printf.sprintf "Failed to stop session: %s" err)
+
 (** Find a usable working directory for a project. *)
 let working_dir_of_project (p : Project.t) =
   if p.is_bare then
@@ -1747,36 +1778,9 @@ let handle_command t msg cmd =
              reply (Printf.sprintf "Failed to persist resumed session: %s"
                (Printexc.to_string exn)))))
   | Command.Stop_session { thread_id } ->
-    (match stop_session t ~thread_id with
-     | Session_not_found ->
-       reply "Session not found."
-    | Session_stopped { project_name; dropped_count } ->
-      let dropped_text =
-        if dropped_count = 0 then ""
-        else Printf.sprintf " Dropped %d queued message%s."
-          dropped_count (if dropped_count = 1 then "" else "s")
-      in
-      reply (Printf.sprintf "Stopped session for **%s**.%s"
-        project_name dropped_text)
-     | Session_stopping { project_name; had_running_process; dropped_count } ->
-      let process_text =
-        if had_running_process then
-          " Terminating the active agent process."
-        else
-          " The active session will stop as soon as its current turn or agent startup finishes."
-       in
-       let dropped_text =
-         if dropped_count = 0 then ""
-         else Printf.sprintf " Dropped %d queued message%s."
-           dropped_count (if dropped_count = 1 then "" else "s")
-       in
-       reply (Printf.sprintf
-         "Stopping session for **%s**.%s%s"
-         project_name process_text dropped_text)
-     | Session_already_stopping { project_name } ->
-       reply (Printf.sprintf "Session for **%s** is already stopping." project_name)
-     | Session_stop_failed err ->
-       reply (Printf.sprintf "Failed to stop session: %s" err))
+    reply_stop_outcome reply (stop_session t ~thread_id)
+  | Command.Interrupt_session ->
+    reply_stop_outcome reply (stop_session t ~thread_id:channel_id)
   | Command.Default_agent None ->
     refresh_disk_state ();
     let base = Printf.sprintf "Default agent: `%s`."
@@ -2123,6 +2127,7 @@ let handle_command t msg cmd =
       "`!session-agent [agent]` / `!session_agent [agent]` — show or set the current channel session agent";
       "`!resume [agent] <session_id>` — resume a session (no agent = try the current effective top-level agent first)";
       "`!stop <thread_id>` — stop a session";
+      "`!esc` / `!int` / `!interrupt` — interrupt this thread's current turn";
       "`!rename [thread_id] <name>` — rename a thread";
       "`!status` — bot status and running processes";
       "`!refresh` — re-scan for new projects";

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -2127,7 +2127,7 @@ let handle_command t msg cmd =
       "`!session-agent [agent]` / `!session_agent [agent]` — show or set the current channel session agent";
       "`!resume [agent] <session_id>` — resume a session (no agent = try the current effective top-level agent first)";
       "`!stop <thread_id>` — stop a session";
-      "`!esc` / `!int` / `!interrupt` — interrupt this thread's current turn";
+      "`!esc` / `!int` / `!interrupt` — stop this thread's active session";
       "`!rename [thread_id] <name>` — rename a thread";
       "`!status` — bot status and running processes";
       "`!refresh` — re-scan for new projects";

--- a/lib/command.ml
+++ b/lib/command.ml
@@ -13,6 +13,7 @@ type t =
   (** [kind = None] means use the current effective top-level agent. *)
   | Resume_session of { session_id : string; kind : Config.agent_kind option }
   | Stop_session of { thread_id : string }
+  | Interrupt_session
   | Cleanup_channels
   | Default_agent of Config.agent_kind option
   | Rescue_agent of Config.agent_kind option option
@@ -80,6 +81,7 @@ let parse content =
      | Ok k -> Session_agent (Some k)
      | Error _ -> Unknown content)
   | ["stop"; thread_id] -> Stop_session { thread_id }
+  | ["esc"] | ["int"] | ["interrupt"] -> Interrupt_session
   | ["cleanup-channels"] | ["cleanup"] -> Cleanup_channels
   | "rename" :: rest when rest <> [] ->
     (* !rename <name> — rename current thread

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,6 @@
 (tests
  (names test_formatting test_project test_agent_contracts test_discord_rest test_gateway
-  test_runtime_settings test_bot_defaults test_session_store test_disk_health test_config
-  test_runtime_limits)
+ test_runtime_settings test_bot_defaults test_session_store test_disk_health test_config
+  test_runtime_limits test_stream_interrupt)
  (libraries discord_agents alcotest str unix yojson eio.mock eio_main cohttp-eio
   uri mirage-crypto-rng.unix))

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -677,6 +677,7 @@ let cmd_testable =
         Printf.sprintf "Resume_session(%s,%s)"
           (Discord_agents.Config.string_of_agent_kind k) session_id
       | Stop_session { thread_id } -> "Stop_session(" ^ thread_id ^ ")"
+      | Interrupt_session -> "Interrupt_session"
       | Cleanup_channels -> "Cleanup_channels"
       | Default_agent None -> "Default_agent"
       | Default_agent (Some k) ->
@@ -932,6 +933,19 @@ let test_parse_session_agent_invalid_kind () =
     Alcotest.(check pass) "invalid session agent is Unknown" () ()
   | _ -> Alcotest.fail "expected Unknown for invalid session agent kind"
 
+let test_parse_interrupt_aliases () =
+  List.iter (fun raw ->
+    Alcotest.(check cmd_testable) raw
+      Discord_agents.Command.Interrupt_session
+      (Discord_agents.Command.parse raw))
+    ["!esc"; "!int"; "!interrupt"]
+
+let test_parse_interrupt_rejects_args () =
+  match Discord_agents.Command.parse "!interrupt now" with
+  | Discord_agents.Command.Unknown _ ->
+    Alcotest.(check pass) "interrupt with args is Unknown" () ()
+  | _ -> Alcotest.fail "expected Unknown for interrupt args"
+
 let command_tests = [
   Alcotest.test_case "desktop" `Quick test_parse_desktop;
   Alcotest.test_case "mobile" `Quick test_parse_mobile;
@@ -970,6 +984,8 @@ let command_tests = [
   Alcotest.test_case "session-agent set" `Quick test_parse_session_agent_set;
   Alcotest.test_case "session_agent alias" `Quick test_parse_session_agent_underscore_alias;
   Alcotest.test_case "session-agent invalid kind" `Quick test_parse_session_agent_invalid_kind;
+  Alcotest.test_case "interrupt aliases" `Quick test_parse_interrupt_aliases;
+  Alcotest.test_case "interrupt rejects args" `Quick test_parse_interrupt_rejects_args;
 ]
 
 (* ── tool detail formatting ────────────────────────────────────── *)

--- a/test/test_stream_interrupt.ml
+++ b/test/test_stream_interrupt.ml
@@ -3,8 +3,9 @@
     These fixtures are captured line shapes from the three agent stream
     modes. The simulated interrupt happens after complete JSONL records
     have been emitted and while the next record is only partially written.
-    Production reads line-oriented JSON, so the incomplete tail must not be
-    handed to a line parser; already parsed events must remain intact. *)
+    Production reads line-oriented JSON; at EOF, Eio.Buf_read.line can return
+    the final unterminated line, so the partial tail is handed to the parser
+    and must degrade to Other without disturbing already parsed events. *)
 
 type expected = {
   text : string;
@@ -12,18 +13,8 @@ type expected = {
   tool_name : string option;
 }
 
-let parse_complete_jsonl ~parse chunk =
-  let len = String.length chunk in
-  let lines = String.split_on_char '\n' chunk in
-  let complete_lines =
-    if len > 0 && chunk.[len - 1] <> '\n' then
-      match List.rev lines with
-      | _partial :: rev_complete -> List.rev rev_complete
-      | [] -> []
-    else
-      lines
-  in
-  complete_lines
+let parse_jsonl_until_eof ~parse chunk =
+  String.split_on_char '\n' chunk
   |> List.filter (fun line -> line <> "")
   |> List.concat_map parse
 
@@ -44,17 +35,17 @@ let has_tool expected =
       tool_name = expected
     | _ -> false)
 
-let no_raw_tail tail =
-  List.for_all (function
-    | Discord_agents.Agent_process.Other raw -> raw <> tail
-    | _ -> true)
+let has_raw_tail tail =
+  List.exists (function
+    | Discord_agents.Agent_process.Other raw -> raw = tail
+    | _ -> false)
 
 let assert_interrupt_preserves_complete_events
     ~name ~parse ~complete_lines ~truncated_tail expected =
   let stream =
     String.concat "\n" complete_lines ^ "\n" ^ truncated_tail
   in
-  let events = parse_complete_jsonl ~parse stream in
+  let events = parse_jsonl_until_eof ~parse stream in
   Alcotest.(check bool) (name ^ " text survives interrupt")
     true (has_text expected.text events);
   (match expected.session_id with
@@ -67,8 +58,8 @@ let assert_interrupt_preserves_complete_events
      Alcotest.(check bool) (name ^ " tool event survives interrupt")
        true (has_tool tool_name events)
    | None -> ());
-  Alcotest.(check bool) (name ^ " truncated tail is not parsed")
-    true (no_raw_tail truncated_tail events)
+  Alcotest.(check bool) (name ^ " truncated tail degrades to Other")
+    true (has_raw_tail truncated_tail events)
 
 let test_claude_interrupt_preserves_events () =
   assert_interrupt_preserves_complete_events

--- a/test/test_stream_interrupt.ml
+++ b/test/test_stream_interrupt.ml
@@ -1,0 +1,122 @@
+(** Deterministic JSONL interrupt tests.
+
+    These fixtures are captured line shapes from the three agent stream
+    modes. The simulated interrupt happens after complete JSONL records
+    have been emitted and while the next record is only partially written.
+    Production reads line-oriented JSON, so the incomplete tail must not be
+    handed to a line parser; already parsed events must remain intact. *)
+
+type expected = {
+  text : string;
+  session_id : string option;
+  tool_name : string option;
+}
+
+let parse_complete_jsonl ~parse chunk =
+  let len = String.length chunk in
+  let lines = String.split_on_char '\n' chunk in
+  let complete_lines =
+    if len > 0 && chunk.[len - 1] <> '\n' then
+      match List.rev lines with
+      | _partial :: rev_complete -> List.rev rev_complete
+      | [] -> []
+    else
+      lines
+  in
+  complete_lines
+  |> List.filter (fun line -> line <> "")
+  |> List.concat_map parse
+
+let has_text expected =
+  List.exists (function
+    | Discord_agents.Agent_process.Text_delta text -> text = expected
+    | _ -> false)
+
+let has_session_id expected =
+  List.exists (function
+    | Discord_agents.Agent_process.Result { session_id = Some sid; _ } ->
+      sid = expected
+    | _ -> false)
+
+let has_tool expected =
+  List.exists (function
+    | Discord_agents.Agent_process.Tool_use { tool_name; _ } ->
+      tool_name = expected
+    | _ -> false)
+
+let no_raw_tail tail =
+  List.for_all (function
+    | Discord_agents.Agent_process.Other raw -> raw <> tail
+    | _ -> true)
+
+let assert_interrupt_preserves_complete_events
+    ~name ~parse ~complete_lines ~truncated_tail expected =
+  let stream =
+    String.concat "\n" complete_lines ^ "\n" ^ truncated_tail
+  in
+  let events = parse_complete_jsonl ~parse stream in
+  Alcotest.(check bool) (name ^ " text survives interrupt")
+    true (has_text expected.text events);
+  (match expected.session_id with
+   | Some sid ->
+     Alcotest.(check bool) (name ^ " session id survives interrupt")
+       true (has_session_id sid events)
+   | None -> ());
+  (match expected.tool_name with
+   | Some tool_name ->
+     Alcotest.(check bool) (name ^ " tool event survives interrupt")
+       true (has_tool tool_name events)
+   | None -> ());
+  Alcotest.(check bool) (name ^ " truncated tail is not parsed")
+    true (no_raw_tail truncated_tail events)
+
+let test_claude_interrupt_preserves_events () =
+  assert_interrupt_preserves_complete_events
+    ~name:"claude"
+    ~parse:Discord_agents.Agent_process.parse_stream_json_line
+    ~complete_lines:[
+      {|{"type":"assistant","message":{"content":[{"type":"text","text":"planning complete\n"}]}}|};
+      {|{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_01A","name":"Bash","input":{"command":"sleep 30","description":"simulate long work"}}]}}|};
+    ]
+    ~truncated_tail:{|{"type":"assistant","message":{"content":[{"type":"text","text":"partial|}
+    { text = "planning complete\n"; session_id = None; tool_name = Some "Bash" }
+
+let test_codex_interrupt_preserves_events () =
+  assert_interrupt_preserves_complete_events
+    ~name:"codex"
+    ~parse:Discord_agents.Agent_process.parse_codex_json_line
+    ~complete_lines:[
+      {|{"type":"thread.started","thread_id":"codex-thread-123"}|};
+      {|{"type":"item.completed","item":{"id":"msg_0","type":"agent_message","text":"ready before interrupt"}}|};
+      {|{"type":"item.started","item":{"id":"cmd_0","type":"command_execution","command":"sleep 30","status":"in_progress"}}|};
+    ]
+    ~truncated_tail:{|{"type":"item.completed","item":{"id":"cmd_0","type":"command_execution","aggregated_output":"|}
+    { text = "ready before interrupt\n\n";
+      session_id = Some "codex-thread-123";
+      tool_name = Some "Bash" }
+
+let test_gemini_interrupt_preserves_events () =
+  assert_interrupt_preserves_complete_events
+    ~name:"gemini"
+    ~parse:Discord_agents.Agent_process.parse_gemini_stream_json_line
+    ~complete_lines:[
+      {|{"type":"init","session_id":"gemini-session-123","model":"gemini-2.5-pro"}|};
+      {|{"type":"message","role":"assistant","content":"ready before interrupt","delta":true}|};
+      {|{"type":"tool_use","tool_name":"run_shell_command","parameters":{"command":"sleep 30","description":"simulate long work"}}|};
+    ]
+    ~truncated_tail:{|{"type":"tool_result","status":"success","output":"|}
+    { text = "ready before interrupt";
+      session_id = Some "gemini-session-123";
+      tool_name = Some "Bash" }
+
+let () =
+  Alcotest.run "stream_interrupt" [
+    "jsonl truncation", [
+      Alcotest.test_case "claude complete events survive partial tail" `Quick
+        test_claude_interrupt_preserves_events;
+      Alcotest.test_case "codex complete events survive partial tail" `Quick
+        test_codex_interrupt_preserves_events;
+      Alcotest.test_case "gemini complete events survive partial tail" `Quick
+        test_gemini_interrupt_preserves_events;
+    ];
+  ]


### PR DESCRIPTION
## Summary

- Add no-argument `!esc`, `!int`, and `!interrupt` commands that target the current Discord channel/thread.
- Route those aliases through the existing `stop_session` path so stop_requested persistence and tracked process termination stay centralized.
- Add deterministic JSONL truncation tests for Claude, Codex, and Gemini parser behavior under a simulated mid-stream interrupt.

## Validation

- `nix develop --command dune runtest`

Note: existing live agent contract tests skipped Gemini via their existing skip path; Claude and Codex live contract checks passed.