### PR TITLE
Add inter-agent message MCP tool

### DIFF
--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -2889,22 +2889,51 @@ type inter_agent_message_outcome =
       message_id : Discord_types.message_id;
       remaining_hops : int;
     }
+  | Inter_agent_message_posted_not_routed of {
+      thread_id : Discord_types.channel_id;
+      message_id : Discord_types.message_id;
+      remaining_hops : int;
+    }
   | Inter_agent_message_rejected of string
 
-let describe_inter_agent_source t source_thread_id =
+type inter_agent_message_hooks = {
+  post_inter_agent_message :
+    Discord_rest.t ->
+    channel_id:Discord_types.channel_id ->
+    content:string ->
+    (Discord_types.message, string) result;
+  route_inter_agent_message :
+    t ->
+    Discord_types.message ->
+    unit;
+}
+
+let valid_discord_snowflake s =
+  let len = String.length s in
+  len > 0
+  && len <= 32
+  && String.for_all (fun c -> c >= '0' && c <= '9') s
+
+let claimed_source_label t source_thread_id =
   match source_thread_id with
   | None -> "another agent"
   | Some tid ->
     match Session_store.find_opt t.sessions ~thread_id:tid with
     | Some session ->
-      Printf.sprintf "%s in <#%s>"
+      Printf.sprintf "another agent (claimed source: %s in <#%s>)"
         (Config.string_of_agent_kind session.agent_kind) tid
-    | None -> Printf.sprintf "thread <#%s>" tid
+    | None -> Printf.sprintf "another agent (claimed source: <#%s>)" tid
 
 let prepare_inter_agent_message ?source_thread_id ?remaining_hops message =
   let message = String.trim message in
   if message = "" then
     Error "message must not be empty"
+  else if
+    (match source_thread_id with
+     | Some tid -> not (valid_discord_snowflake tid)
+     | None -> false)
+  then
+    Error "source_thread_id must be a Discord snowflake"
   else if Command.is_command message then
     Error "inter-agent messages cannot start with ! commands"
   else if String.length message > max_inter_agent_message_bytes then
@@ -2923,11 +2952,10 @@ let prepare_inter_agent_message ?source_thread_id ?remaining_hops message =
       let delivered_remaining_hops = requested_hops - 1 in
       let origin =
         Option.value source_thread_id ~default:"unknown"
-        |> Resource.single_line
       in
       let visible_content =
         Printf.sprintf
-          "[inter-agent message; origin=%s; remaining_hops=%d]\n\n%s"
+          "[inter-agent message; claimed_source=%s; remaining_hops=%d]\n\n%s"
           origin delivered_remaining_hops message
       in
       Ok { visible_content; delivered_remaining_hops }
@@ -2959,13 +2987,20 @@ let handle_thread_message t msg ?channel_info () =
           process_session_message t session msg channel_info))
     end
 
-let send_inter_agent_message t ?source_thread_id ?remaining_hops ~thread_id
-    ~message () =
+let default_inter_agent_message_hooks = {
+  post_inter_agent_message =
+    (fun rest ~channel_id ~content ->
+       Discord_rest.create_message rest ~channel_id ~content ());
+  route_inter_agent_message =
+    (fun t msg -> handle_thread_message t msg ());
+}
+
+let send_inter_agent_message_with_hooks hooks t ?source_thread_id
+    ?remaining_hops ~thread_id ~message () =
   if t.draining then
     Inter_agent_message_rejected "Bot is restarting; try again shortly."
-  else if source_thread_id = Some thread_id then
-    Inter_agent_message_rejected
-      "source_thread_id and thread_id must be different"
+  else if not (valid_discord_snowflake thread_id) then
+    Inter_agent_message_rejected "thread_id must be a Discord snowflake"
   else
     match Session_store.find_opt t.sessions ~thread_id with
     | None -> Inter_agent_message_rejected "Target session not found."
@@ -2973,32 +3008,45 @@ let send_inter_agent_message t ?source_thread_id ?remaining_hops ~thread_id
       (match prepare_inter_agent_message ?source_thread_id ?remaining_hops message with
        | Error err -> Inter_agent_message_rejected err
        | Ok prepared ->
-         let source_label = describe_inter_agent_source t source_thread_id in
+         let source_label = claimed_source_label t source_thread_id in
          let content =
            Printf.sprintf "**Message from %s**\n%s"
              source_label prepared.visible_content
          in
-         match Discord_rest.create_message t.rest ~channel_id:thread_id
-                 ~content () with
+         match hooks.post_inter_agent_message t.rest ~channel_id:thread_id
+                 ~content with
          | Error err ->
            Inter_agent_message_rejected
              (Printf.sprintf "Failed to post message: %s" err)
          | Ok posted_msg ->
-           let routed_msg = {
-             posted_msg with
-             content;
-             author = {
-               id = "inter-agent";
-               username = "inter-agent";
-               bot = Some false;
-             };
-           } in
-           handle_thread_message t routed_msg ();
-           Inter_agent_message_sent {
-             thread_id;
-             message_id = posted_msg.id;
-             remaining_hops = prepared.delivered_remaining_hops;
-           })
+           (match Session_store.find_opt t.sessions ~thread_id with
+            | None ->
+              Inter_agent_message_posted_not_routed {
+                thread_id;
+                message_id = posted_msg.id;
+                remaining_hops = prepared.delivered_remaining_hops;
+              }
+            | Some _ ->
+              let routed_msg = {
+                posted_msg with
+                content;
+                author = {
+                  id = "inter-agent";
+                  username = "inter-agent";
+                  bot = Some false;
+                };
+              } in
+              hooks.route_inter_agent_message t routed_msg;
+              Inter_agent_message_sent {
+                thread_id;
+                message_id = posted_msg.id;
+                remaining_hops = prepared.delivered_remaining_hops;
+              }))
+
+let send_inter_agent_message t ?source_thread_id ?remaining_hops ~thread_id
+    ~message () =
+  send_inter_agent_message_with_hooks default_inter_agent_message_hooks t
+    ?source_thread_id ?remaining_hops ~thread_id ~message ()
 
 (** Fork an agent run on a fresh session whose [processing] flag is
     already locked by the caller. Used by

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -3001,9 +3001,14 @@ let send_inter_agent_message_with_hooks hooks t ?source_thread_id
     Inter_agent_message_rejected "Bot is restarting; try again shortly."
   else if not (valid_discord_snowflake thread_id) then
     Inter_agent_message_rejected "thread_id must be a Discord snowflake"
+  else if source_thread_id = Some thread_id then
+    Inter_agent_message_rejected
+      "source_thread_id and thread_id must be different"
   else
     match Session_store.find_opt t.sessions ~thread_id with
     | None -> Inter_agent_message_rejected "Target session not found."
+    | Some session when session.stop_requested ->
+      Inter_agent_message_rejected "Target session is stopping."
     | Some _ ->
       (match prepare_inter_agent_message ?source_thread_id ?remaining_hops message with
        | Error err -> Inter_agent_message_rejected err

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -3025,7 +3025,7 @@ let send_inter_agent_message_with_hooks hooks t ?source_thread_id
              (Printf.sprintf "Failed to post message: %s" err)
          | Ok posted_msg ->
            (match Session_store.find_opt t.sessions ~thread_id with
-            | None ->
+            | None | Some { stop_requested = true; _ } ->
               Inter_agent_message_posted_not_routed {
                 thread_id;
                 message_id = posted_msg.id;

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -738,6 +738,7 @@ You have MCP tools available:
 - import_project: Clone a GitHub repository into the project registry and create its Discord project channel
 - list_projects: List all discovered projects
 - list_sessions: List active bot sessions
+- send_message: Send a visible user-style message to another active session thread
 - stop_session: Stop an active bot session by Discord thread ID
 - list_claude_sessions: Find recent Claude Code sessions to resume
 - list_codex_sessions: Find recent Codex CLI sessions to resume
@@ -779,6 +780,7 @@ You have MCP tools available:
 - import_project: Clone a GitHub repository into the project registry and create its Discord project channel
 - list_projects: List all discovered projects
 - list_sessions: List active bot sessions
+- send_message: Send a visible user-style message to another active session thread
 - stop_session: Stop an active bot session by Discord thread ID
 - list_claude_sessions: Find recent Claude Code sessions to resume
 - list_codex_sessions: Find recent Codex CLI sessions to resume
@@ -2872,6 +2874,64 @@ let process_session_message t session
   process_session_message_with_hooks default_process_message_hooks
     t session msg channel_info
 
+let max_inter_agent_message_bytes = 1600
+let max_inter_agent_hops = 5
+let default_inter_agent_hops = 3
+
+type prepared_inter_agent_message = {
+  visible_content : string;
+  delivered_remaining_hops : int;
+}
+
+type inter_agent_message_outcome =
+  | Inter_agent_message_sent of {
+      thread_id : Discord_types.channel_id;
+      message_id : Discord_types.message_id;
+      remaining_hops : int;
+    }
+  | Inter_agent_message_rejected of string
+
+let describe_inter_agent_source t source_thread_id =
+  match source_thread_id with
+  | None -> "another agent"
+  | Some tid ->
+    match Session_store.find_opt t.sessions ~thread_id:tid with
+    | Some session ->
+      Printf.sprintf "%s in <#%s>"
+        (Config.string_of_agent_kind session.agent_kind) tid
+    | None -> Printf.sprintf "thread <#%s>" tid
+
+let prepare_inter_agent_message ?source_thread_id ?remaining_hops message =
+  let message = String.trim message in
+  if message = "" then
+    Error "message must not be empty"
+  else if Command.is_command message then
+    Error "inter-agent messages cannot start with ! commands"
+  else if String.length message > max_inter_agent_message_bytes then
+    Error (Printf.sprintf
+      "message is too long (%d bytes max)" max_inter_agent_message_bytes)
+  else
+    let requested_hops =
+      Option.value remaining_hops ~default:default_inter_agent_hops
+    in
+    if requested_hops <= 0 then
+      Error "inter-agent hop limit exhausted"
+    else if requested_hops > max_inter_agent_hops then
+      Error (Printf.sprintf
+        "remaining_hops must be between 1 and %d" max_inter_agent_hops)
+    else
+      let delivered_remaining_hops = requested_hops - 1 in
+      let origin =
+        Option.value source_thread_id ~default:"unknown"
+        |> Resource.single_line
+      in
+      let visible_content =
+        Printf.sprintf
+          "[inter-agent message; origin=%s; remaining_hops=%d]\n\n%s"
+          origin delivered_remaining_hops message
+      in
+      Ok { visible_content; delivered_remaining_hops }
+
 let handle_thread_message t msg ?channel_info () =
   if t.draining then
     ignore (Discord_rest.create_message t.rest
@@ -2898,6 +2958,47 @@ let handle_thread_message t msg ?channel_info () =
         ) (fun () ->
           process_session_message t session msg channel_info))
     end
+
+let send_inter_agent_message t ?source_thread_id ?remaining_hops ~thread_id
+    ~message () =
+  if t.draining then
+    Inter_agent_message_rejected "Bot is restarting; try again shortly."
+  else if source_thread_id = Some thread_id then
+    Inter_agent_message_rejected
+      "source_thread_id and thread_id must be different"
+  else
+    match Session_store.find_opt t.sessions ~thread_id with
+    | None -> Inter_agent_message_rejected "Target session not found."
+    | Some _ ->
+      (match prepare_inter_agent_message ?source_thread_id ?remaining_hops message with
+       | Error err -> Inter_agent_message_rejected err
+       | Ok prepared ->
+         let source_label = describe_inter_agent_source t source_thread_id in
+         let content =
+           Printf.sprintf "**Message from %s**\n%s"
+             source_label prepared.visible_content
+         in
+         match Discord_rest.create_message t.rest ~channel_id:thread_id
+                 ~content () with
+         | Error err ->
+           Inter_agent_message_rejected
+             (Printf.sprintf "Failed to post message: %s" err)
+         | Ok posted_msg ->
+           let routed_msg = {
+             posted_msg with
+             content;
+             author = {
+               id = "inter-agent";
+               username = "inter-agent";
+               bot = Some false;
+             };
+           } in
+           handle_thread_message t routed_msg ();
+           Inter_agent_message_sent {
+             thread_id;
+             message_id = posted_msg.id;
+             remaining_hops = prepared.delivered_remaining_hops;
+           })
 
 (** Fork an agent run on a fresh session whose [processing] flag is
     already locked by the caller. Used by

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -1173,6 +1173,45 @@ let handle_stop_session (bot : Bot.t) params =
   | Bot.Session_stop_failed err ->
     error_response (Printf.sprintf "Failed to stop session: %s" err)
 
+let handle_send_message (bot : Bot.t) params =
+  let open Yojson.Safe.Util in
+  let params = match params with Some p -> p | None ->
+    failwith "missing params" in
+  let thread_id = params |> member "thread_id" |> to_string in
+  let message = params |> member "message" |> to_string in
+  let source_thread_id =
+    match params |> member "source_thread_id" |> to_string_option with
+    | Some s when String.trim s <> "" -> Some (String.trim s)
+    | _ -> None
+  in
+  let remaining_hops =
+    let raw = params |> member "remaining_hops" in
+    match raw with
+    | `Null -> Ok None
+    | `Int n -> Ok (Some n)
+    | `Intlit s | `String s ->
+      (match int_of_string_opt s with
+       | Some n -> Ok (Some n)
+       | None -> Error "remaining_hops must be an integer")
+    | _ -> Error "remaining_hops must be an integer"
+  in
+  match remaining_hops with
+  | Error err -> error_response err
+  | Ok remaining_hops ->
+  match Bot.send_inter_agent_message bot ?source_thread_id ?remaining_hops
+          ~thread_id ~message () with
+  | Bot.Inter_agent_message_sent sent ->
+    ok_response [
+      ("thread_id", `String sent.thread_id);
+      ("message_id", `String sent.message_id);
+      ("remaining_hops", `Int sent.remaining_hops);
+      ("message", `String (Printf.sprintf
+        "Sent message to <#%s>. remaining_hops=%d"
+        sent.thread_id sent.remaining_hops));
+    ]
+  | Bot.Inter_agent_message_rejected err ->
+    error_response err
+
 let handle_restart (bot : Bot.t) =
   Bot.trigger_restart bot ~notify:(fun msg ->
     Logs.info (fun m -> m "control_api restart: %s" msg));
@@ -1220,6 +1259,7 @@ let dispatch (bot : Bot.t) method_ params =
     | "start_session" -> handle_start_session bot params
     | "resume_session" -> handle_resume_session bot params
     | "stop_session" -> handle_stop_session bot params
+    | "send_message" -> handle_send_message bot params
     | "default_agent" -> handle_default_agent bot params
     | "rescue_agent" -> handle_rescue_agent bot params
     | "get_agent_config" -> handle_get_agent_config bot params

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -1202,11 +1202,22 @@ let handle_send_message (bot : Bot.t) params =
           ~thread_id ~message () with
   | Bot.Inter_agent_message_sent sent ->
     ok_response [
+      ("state", `String "sent");
       ("thread_id", `String sent.thread_id);
       ("message_id", `String sent.message_id);
       ("remaining_hops", `Int sent.remaining_hops);
       ("message", `String (Printf.sprintf
         "Sent message to <#%s>. remaining_hops=%d"
+        sent.thread_id sent.remaining_hops));
+    ]
+  | Bot.Inter_agent_message_posted_not_routed sent ->
+    ok_response [
+      ("state", `String "posted_not_routed");
+      ("thread_id", `String sent.thread_id);
+      ("message_id", `String sent.message_id);
+      ("remaining_hops", `Int sent.remaining_hops);
+      ("message", `String (Printf.sprintf
+        "Posted message to <#%s>, but the target session disappeared before routing. remaining_hops=%d"
         sent.thread_id sent.remaining_hops));
     ]
   | Bot.Inter_agent_message_rejected err ->

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -166,7 +166,7 @@ TOOLS = [
                 },
                 "source_thread_id": {
                     "type": "string",
-                    "description": "Optional Discord thread ID of the sending session, if known. Used for the visible origin marker and self-send rejection."
+                    "description": "Optional claimed Discord thread ID of the sending session, if known. This is displayed as an untrusted claimed source until caller context is wired in."
                 },
                 "remaining_hops": {
                     "type": "integer",
@@ -469,6 +469,9 @@ def handle_tool_call(name, arguments):
             return result["error"]
         tid = result.get("thread_id", "")
         hops = result.get("remaining_hops", 0)
+        state = result.get("state", "sent")
+        if state == "posted_not_routed":
+            return f"Posted message to <#{tid}>, but the target session disappeared before routing. remaining_hops={hops}."
         return f"Sent message to <#{tid}>. remaining_hops={hops}."
 
     elif name == "stop_session":

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -161,7 +161,7 @@ TOOLS = [
                 },
                 "message": {
                     "type": "string",
-                    "description": "Plain message text to send. Must not start with ! and must fit in one Discord message.",
+                    "description": "Plain message text to send. Must not start with ! and must fit in one Discord message. The bot enforces a 1600-byte cap, so non-ASCII text may allow fewer characters.",
                     "maxLength": 1600
                 },
                 "source_thread_id": {

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -150,6 +150,36 @@ TOOLS = [
         }
     },
     {
+        "name": "send_message",
+        "description": "Send a visible user-style message to another active session thread, then route it through the same handler as a Discord user message. Use list_sessions to find thread IDs. The message is queued if the target session is busy. Do not send command-looking messages. If replying to an inter-agent message, pass its remaining_hops value so loops terminate.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "thread_id": {
+                    "type": "string",
+                    "description": "Discord thread ID of the destination active session"
+                },
+                "message": {
+                    "type": "string",
+                    "description": "Plain message text to send. Must not start with ! and must fit in one Discord message.",
+                    "maxLength": 1600
+                },
+                "source_thread_id": {
+                    "type": "string",
+                    "description": "Optional Discord thread ID of the sending session, if known. Used for the visible origin marker and self-send rejection."
+                },
+                "remaining_hops": {
+                    "type": "integer",
+                    "description": "Loop guard. Defaults to 3 for a new chain. If replying to an inter-agent message, pass the remaining_hops value shown in that message.",
+                    "minimum": 1,
+                    "maximum": 5,
+                    "default": 3
+                }
+            },
+            "required": ["thread_id", "message"]
+        }
+    },
+    {
         "name": "stop_session",
         "description": "Stop an active bot session by Discord thread ID. Idle sessions stop immediately; busy sessions terminate the active agent run and then clean up the session.",
         "inputSchema": {
@@ -432,6 +462,14 @@ def handle_tool_call(name, arguments):
         lines = [f"- **{s['project_name']}** / {s['agent_kind']} — {s['message_count']} messages (thread: <#{s['thread_id']}>)"
                  for s in sessions]
         return "\n".join(lines)
+
+    elif name == "send_message":
+        result = control_request("send_message", arguments)
+        if "error" in result:
+            return result["error"]
+        tid = result.get("thread_id", "")
+        hops = result.get("remaining_hops", 0)
+        return f"Sent message to <#{tid}>. remaining_hops={hops}."
 
     elif name == "stop_session":
         result = control_request("stop_session", arguments)

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -1689,6 +1689,53 @@ let test_send_inter_agent_message_rejects_missing_target () =
       Alcotest.(check bool) "did not post" false !posted
     | _ -> Alcotest.fail "expected rejected outcome")
 
+let test_send_inter_agent_message_rejects_stopping_target () =
+  with_test_bot (fun bot ->
+    let target_thread_id = "1234567890" in
+    let session =
+      make_session ~thread_id:target_thread_id Discord_agents.Config.Codex
+    in
+    session.stop_requested <- true;
+    Discord_agents.Session_store.add bot.sessions
+      ~thread_id:target_thread_id session;
+    let posted = ref false in
+    let hooks = inter_agent_hooks
+      ~post:(fun _rest ~channel_id:_ ~content:_ ->
+        posted := true;
+        Ok (make_posted_message ~channel_id:target_thread_id
+              ~message_id:"posted-1" "unused"))
+      ()
+    in
+    match Discord_agents.Bot.send_inter_agent_message_with_hooks hooks bot
+            ~thread_id:target_thread_id ~message:"hello" () with
+    | Discord_agents.Bot.Inter_agent_message_rejected err ->
+      Alcotest.(check string) "error" "Target session is stopping." err;
+      Alcotest.(check bool) "did not post" false !posted
+    | _ -> Alcotest.fail "expected rejected outcome")
+
+let test_send_inter_agent_message_rejects_claimed_self_send () =
+  with_test_bot (fun bot ->
+    let target_thread_id = "1234567890" in
+    Discord_agents.Session_store.add bot.sessions
+      ~thread_id:target_thread_id
+      (make_session ~thread_id:target_thread_id Discord_agents.Config.Codex);
+    let posted = ref false in
+    let hooks = inter_agent_hooks
+      ~post:(fun _rest ~channel_id:_ ~content:_ ->
+        posted := true;
+        Ok (make_posted_message ~channel_id:target_thread_id
+              ~message_id:"posted-1" "unused"))
+      ()
+    in
+    match Discord_agents.Bot.send_inter_agent_message_with_hooks hooks bot
+            ~source_thread_id:target_thread_id
+            ~thread_id:target_thread_id ~message:"hello" () with
+    | Discord_agents.Bot.Inter_agent_message_rejected err ->
+      Alcotest.(check string) "error"
+        "source_thread_id and thread_id must be different" err;
+      Alcotest.(check bool) "did not post" false !posted
+    | _ -> Alcotest.fail "expected rejected outcome")
+
 let test_send_inter_agent_message_reports_post_failure () =
   with_test_bot (fun bot ->
     let target_thread_id = "1234567890" in
@@ -1917,6 +1964,10 @@ let () =
         test_send_inter_agent_message_posts_and_routes_user_style_message;
       Alcotest.test_case "send inter-agent message rejects missing target" `Quick
         test_send_inter_agent_message_rejects_missing_target;
+      Alcotest.test_case "send inter-agent message rejects stopping target" `Quick
+        test_send_inter_agent_message_rejects_stopping_target;
+      Alcotest.test_case "send inter-agent message rejects claimed self-send" `Quick
+        test_send_inter_agent_message_rejects_claimed_self_send;
       Alcotest.test_case "send inter-agent message reports post failure" `Quick
         test_send_inter_agent_message_reports_post_failure;
       Alcotest.test_case "send inter-agent message reports posted not routed" `Quick

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -1563,6 +1563,37 @@ let test_process_session_message_keeps_run_replayable_on_completion_persist_fail
         true (Option.is_some saved.active_run)
     | None -> Alcotest.fail "expected reloaded session")
 
+let test_prepare_inter_agent_message_formats_origin_and_hop_marker () =
+  match Discord_agents.Bot.prepare_inter_agent_message
+          ~source_thread_id:"source-thread"
+          ~remaining_hops:3
+          "please review this"
+  with
+  | Error err -> Alcotest.fail err
+  | Ok prepared ->
+    Alcotest.(check int) "remaining hops"
+      2 prepared.delivered_remaining_hops;
+    Alcotest.(check string) "visible content"
+      "[inter-agent message; origin=source-thread; remaining_hops=2]\n\nplease review this"
+      prepared.visible_content
+
+let test_prepare_inter_agent_message_rejects_commands () =
+  match Discord_agents.Bot.prepare_inter_agent_message "!stop 123" with
+  | Ok _ -> Alcotest.fail "expected command-looking message to be rejected"
+  | Error err ->
+    Alcotest.(check string) "error"
+      "inter-agent messages cannot start with ! commands" err
+
+let test_prepare_inter_agent_message_rejects_exhausted_hops () =
+  match Discord_agents.Bot.prepare_inter_agent_message
+          ~remaining_hops:0
+          "loop back"
+  with
+  | Ok _ -> Alcotest.fail "expected exhausted hop count to be rejected"
+  | Error err ->
+    Alcotest.(check string) "error"
+      "inter-agent hop limit exhausted" err
+
 let test_reap_tracked_process_group_leader () =
   with_test_bot (fun bot ->
     let pid = Unix.create_process "/usr/bin/setsid"
@@ -1740,6 +1771,12 @@ let () =
         test_process_session_message_aborts_on_session_id_persist_failure;
       Alcotest.test_case "process message keeps run replayable on completion persist failure" `Quick
         test_process_session_message_keeps_run_replayable_on_completion_persist_failure;
+      Alcotest.test_case "inter-agent message includes origin and hop marker" `Quick
+        test_prepare_inter_agent_message_formats_origin_and_hop_marker;
+      Alcotest.test_case "inter-agent message rejects commands" `Quick
+        test_prepare_inter_agent_message_rejects_commands;
+      Alcotest.test_case "inter-agent message rejects exhausted hops" `Quick
+        test_prepare_inter_agent_message_rejects_exhausted_hops;
       Alcotest.test_case "reap tracked process-group leader" `Quick
         test_reap_tracked_process_group_leader;
       Alcotest.test_case "busy stop signals tracked child" `Quick

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -1565,7 +1565,7 @@ let test_process_session_message_keeps_run_replayable_on_completion_persist_fail
 
 let test_prepare_inter_agent_message_formats_origin_and_hop_marker () =
   match Discord_agents.Bot.prepare_inter_agent_message
-          ~source_thread_id:"source-thread"
+          ~source_thread_id:"1234567890"
           ~remaining_hops:3
           "please review this"
   with
@@ -1574,7 +1574,7 @@ let test_prepare_inter_agent_message_formats_origin_and_hop_marker () =
     Alcotest.(check int) "remaining hops"
       2 prepared.delivered_remaining_hops;
     Alcotest.(check string) "visible content"
-      "[inter-agent message; origin=source-thread; remaining_hops=2]\n\nplease review this"
+      "[inter-agent message; claimed_source=1234567890; remaining_hops=2]\n\nplease review this"
       prepared.visible_content
 
 let test_prepare_inter_agent_message_rejects_commands () =
@@ -1593,6 +1593,140 @@ let test_prepare_inter_agent_message_rejects_exhausted_hops () =
   | Error err ->
     Alcotest.(check string) "error"
       "inter-agent hop limit exhausted" err
+
+let test_prepare_inter_agent_message_rejects_invalid_source () =
+  match Discord_agents.Bot.prepare_inter_agent_message
+          ~source_thread_id:"not-a-snowflake"
+          "hello"
+  with
+  | Ok _ -> Alcotest.fail "expected invalid source thread id to be rejected"
+  | Error err ->
+    Alcotest.(check string) "error"
+      "source_thread_id must be a Discord snowflake" err
+
+let make_posted_message ~channel_id ~message_id content =
+  {
+    (make_message ~message_id ~channel_id content) with
+    author = {
+      Discord_agents.Discord_types.id = "bot-1";
+      username = "discord-agents";
+      bot = Some true;
+    };
+  }
+
+let inter_agent_hooks ?post ?route () =
+  let post_inter_agent_message =
+    match post with
+    | Some f -> f
+    | None ->
+      (fun _rest ~channel_id ~content ->
+         Ok (make_posted_message ~channel_id ~message_id:"posted-1" content))
+  in
+  let route_inter_agent_message =
+    match route with
+    | Some f -> f
+    | None -> (fun _bot _msg -> ())
+  in
+  Discord_agents.Bot.{ post_inter_agent_message; route_inter_agent_message }
+
+let test_send_inter_agent_message_posts_and_routes_user_style_message () =
+  with_test_bot (fun bot ->
+    let target_thread_id = "1234567890" in
+    let session =
+      make_session ~thread_id:target_thread_id Discord_agents.Config.Codex
+    in
+    Discord_agents.Session_store.add bot.sessions
+      ~thread_id:target_thread_id session;
+    let posted_content = ref None in
+    let routed_message = ref None in
+    let hooks = inter_agent_hooks
+      ~post:(fun _rest ~channel_id ~content ->
+        posted_content := Some content;
+        Ok (make_posted_message ~channel_id ~message_id:"posted-1" content))
+      ~route:(fun _bot msg -> routed_message := Some msg)
+      ()
+    in
+    match Discord_agents.Bot.send_inter_agent_message_with_hooks hooks bot
+            ~source_thread_id:"9876543210"
+            ~remaining_hops:3
+            ~thread_id:target_thread_id
+            ~message:"please review this" () with
+    | Discord_agents.Bot.Inter_agent_message_sent sent ->
+      Alcotest.(check string) "message id" "posted-1" sent.message_id;
+      Alcotest.(check int) "remaining hops" 2 sent.remaining_hops;
+      let content = match !posted_content with
+        | Some content -> content
+        | None -> Alcotest.fail "expected posted content"
+      in
+      Alcotest.(check string) "visible claimed source"
+        "**Message from another agent (claimed source: <#9876543210>)**\n[inter-agent message; claimed_source=9876543210; remaining_hops=2]\n\nplease review this"
+        content;
+      (match !routed_message with
+       | Some msg ->
+         Alcotest.(check string) "routed content"
+           content msg.Discord_agents.Discord_types.content;
+         Alcotest.(check string) "routed author"
+           "inter-agent" msg.author.username;
+         Alcotest.(check (option bool)) "routed as user"
+           (Some false) msg.author.bot
+       | None -> Alcotest.fail "expected routed message")
+    | _ -> Alcotest.fail "expected sent outcome")
+
+let test_send_inter_agent_message_rejects_missing_target () =
+  with_test_bot (fun bot ->
+    let posted = ref false in
+    let hooks = inter_agent_hooks
+      ~post:(fun _rest ~channel_id:_ ~content:_ ->
+        posted := true;
+        Ok (make_posted_message ~channel_id:"1234567890"
+              ~message_id:"posted-1" "unused"))
+      ()
+    in
+    match Discord_agents.Bot.send_inter_agent_message_with_hooks hooks bot
+            ~thread_id:"1234567890" ~message:"hello" () with
+    | Discord_agents.Bot.Inter_agent_message_rejected err ->
+      Alcotest.(check string) "error" "Target session not found." err;
+      Alcotest.(check bool) "did not post" false !posted
+    | _ -> Alcotest.fail "expected rejected outcome")
+
+let test_send_inter_agent_message_reports_post_failure () =
+  with_test_bot (fun bot ->
+    let target_thread_id = "1234567890" in
+    Discord_agents.Session_store.add bot.sessions
+      ~thread_id:target_thread_id
+      (make_session ~thread_id:target_thread_id Discord_agents.Config.Codex);
+    let hooks = inter_agent_hooks
+      ~post:(fun _rest ~channel_id:_ ~content:_ -> Error "discord down")
+      ()
+    in
+    match Discord_agents.Bot.send_inter_agent_message_with_hooks hooks bot
+            ~thread_id:target_thread_id ~message:"hello" () with
+    | Discord_agents.Bot.Inter_agent_message_rejected err ->
+      Alcotest.(check string) "error"
+        "Failed to post message: discord down" err
+    | _ -> Alcotest.fail "expected rejected outcome")
+
+let test_send_inter_agent_message_reports_posted_not_routed () =
+  with_test_bot (fun bot ->
+    let target_thread_id = "1234567890" in
+    Discord_agents.Session_store.add bot.sessions
+      ~thread_id:target_thread_id
+      (make_session ~thread_id:target_thread_id Discord_agents.Config.Codex);
+    let routed = ref false in
+    let hooks = inter_agent_hooks
+      ~post:(fun _rest ~channel_id ~content ->
+        Discord_agents.Session_store.remove bot.sessions
+          ~thread_id:target_thread_id;
+        Ok (make_posted_message ~channel_id ~message_id:"posted-1" content))
+      ~route:(fun _bot _msg -> routed := true)
+      ()
+    in
+    match Discord_agents.Bot.send_inter_agent_message_with_hooks hooks bot
+            ~thread_id:target_thread_id ~message:"hello" () with
+    | Discord_agents.Bot.Inter_agent_message_posted_not_routed sent ->
+      Alcotest.(check string) "message id" "posted-1" sent.message_id;
+      Alcotest.(check bool) "did not route" false !routed
+    | _ -> Alcotest.fail "expected posted_not_routed outcome")
 
 let test_reap_tracked_process_group_leader () =
   with_test_bot (fun bot ->
@@ -1777,6 +1911,16 @@ let () =
         test_prepare_inter_agent_message_rejects_commands;
       Alcotest.test_case "inter-agent message rejects exhausted hops" `Quick
         test_prepare_inter_agent_message_rejects_exhausted_hops;
+      Alcotest.test_case "inter-agent message rejects invalid source" `Quick
+        test_prepare_inter_agent_message_rejects_invalid_source;
+      Alcotest.test_case "send inter-agent message posts and routes" `Quick
+        test_send_inter_agent_message_posts_and_routes_user_style_message;
+      Alcotest.test_case "send inter-agent message rejects missing target" `Quick
+        test_send_inter_agent_message_rejects_missing_target;
+      Alcotest.test_case "send inter-agent message reports post failure" `Quick
+        test_send_inter_agent_message_reports_post_failure;
+      Alcotest.test_case "send inter-agent message reports posted not routed" `Quick
+        test_send_inter_agent_message_reports_posted_not_routed;
       Alcotest.test_case "reap tracked process-group leader" `Quick
         test_reap_tracked_process_group_leader;
       Alcotest.test_case "busy stop signals tracked child" `Quick

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -1775,6 +1775,29 @@ let test_send_inter_agent_message_reports_posted_not_routed () =
       Alcotest.(check bool) "did not route" false !routed
     | _ -> Alcotest.fail "expected posted_not_routed outcome")
 
+let test_send_inter_agent_message_reports_stopped_after_post () =
+  with_test_bot (fun bot ->
+    let target_thread_id = "1234567890" in
+    let session =
+      make_session ~thread_id:target_thread_id Discord_agents.Config.Codex
+    in
+    Discord_agents.Session_store.add bot.sessions
+      ~thread_id:target_thread_id session;
+    let routed = ref false in
+    let hooks = inter_agent_hooks
+      ~post:(fun _rest ~channel_id ~content ->
+        session.stop_requested <- true;
+        Ok (make_posted_message ~channel_id ~message_id:"posted-1" content))
+      ~route:(fun _bot _msg -> routed := true)
+      ()
+    in
+    match Discord_agents.Bot.send_inter_agent_message_with_hooks hooks bot
+            ~thread_id:target_thread_id ~message:"hello" () with
+    | Discord_agents.Bot.Inter_agent_message_posted_not_routed sent ->
+      Alcotest.(check string) "message id" "posted-1" sent.message_id;
+      Alcotest.(check bool) "did not route" false !routed
+    | _ -> Alcotest.fail "expected posted_not_routed outcome")
+
 let test_reap_tracked_process_group_leader () =
   with_test_bot (fun bot ->
     let pid = Unix.create_process "/usr/bin/setsid"
@@ -1972,6 +1995,8 @@ let () =
         test_send_inter_agent_message_reports_post_failure;
       Alcotest.test_case "send inter-agent message reports posted not routed" `Quick
         test_send_inter_agent_message_reports_posted_not_routed;
+      Alcotest.test_case "send inter-agent message reports stopped after post" `Quick
+        test_send_inter_agent_message_reports_stopped_after_post;
       Alcotest.test_case "reap tracked process-group leader" `Quick
         test_reap_tracked_process_group_leader;
       Alcotest.test_case "busy stop signals tracked child" `Quick


### PR DESCRIPTION
## Summary

- Add a `send_message` MCP tool that posts a visible user-style message to another active session thread.
- Route the posted Discord message through the existing thread handler so busy targets queue normally and idle targets process/reply normally.
- Add validation for empty messages, command-looking messages, oversized messages, invalid thread IDs, stopping targets, claimed self-sends, and exhausted hop counts.
- Include a visible claimed-source / `remaining_hops` marker so reply chains can carry loop state while making caller-provided source identity explicitly untrusted.
- Report the rare partial-delivery case where Discord accepted the visible post but the target session disappeared before routing.

Closes #72.

## Issue decisions

- Cross-agent messages are fully visible in the destination Discord thread.
- No extra auth layer beyond MCP access for v1.
- The tool sends only plain messages and rejects `!` commands, so one agent cannot invoke bot commands via Discord command syntax. Natural-language requests to a tool-enabled target agent remain possible and visible by design for this v1 single-tenant workflow.

## Follow-up

- #77 tracks making MCP calls session-aware so `source_thread_id` can be auto-populated and trusted later, and so loop guards can become less advisory.

## Validation

- `nix develop --command dune build`
- `nix develop --command dune exec ./test/test_bot_defaults.exe`
- `nix develop --command dune runtest`
- `python3 -m py_compile scripts/mcp-server.py`
- Council review: initial pass found Important issues; fixed in `f8aa081`; convergence pass on fix delta returned CLEAN from Codex. Post-restack review found stopping-target and loop-guard concerns; stopping targets and claimed self-sends were fixed in `7a8ad64`; the trusted caller / non-resettable loop guard limitation remains tracked by #77. Gemini lacked non-interactive auth.
