### PR TITLE
Import GitHub projects at runtime

### DIFF
--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -712,17 +712,7 @@ let reply_stop_outcome reply = function
 (** Find a usable working directory for a project. *)
 let working_dir_of_project (p : Project.t) =
   if p.is_bare then
-    let branch = Project.default_branch p in
-    let candidates = [branch; "master"; "main"] |> List.sort_uniq String.compare in
-    match List.find_opt (fun name ->
-      let path = Filename.concat p.path name in
-      try Sys.is_directory path with Sys_error _ -> false
-    ) candidates with
-    | Some name -> Ok (Filename.concat p.path name)
-    | None ->
-      (match Project.list_worktrees p with
-       | (_branch, path) :: _ when path <> p.path -> Ok path
-       | _ -> Error "bare repo has no default worktree")
+    Project.default_worktree_path p
   else
     Ok p.path
 

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -261,6 +261,13 @@ type stop_outcome =
   | Session_already_stopping of { project_name : string }
   | Session_stop_failed of string
 
+type import_project_result = {
+  imported_project : Project.t;
+  imported_channel_id : Discord_types.channel_id;
+  imported_working_dir : string;
+  imported_existing : bool;
+}
+
 let fresh_session_like (session : Session_store.session)
     ~agent_kind ~session_override_kind =
   Session_store.make_session
@@ -705,13 +712,17 @@ let reply_stop_outcome reply = function
 (** Find a usable working directory for a project. *)
 let working_dir_of_project (p : Project.t) =
   if p.is_bare then
-    let candidates = ["master"; "main"] in
+    let branch = Project.default_branch p in
+    let candidates = [branch; "master"; "main"] |> List.sort_uniq String.compare in
     match List.find_opt (fun name ->
       let path = Filename.concat p.path name in
       try Sys.is_directory path with Sys_error _ -> false
     ) candidates with
     | Some name -> Ok (Filename.concat p.path name)
-    | None -> Error "bare repo has no master/ or main/ worktree"
+    | None ->
+      (match Project.list_worktrees p with
+       | (_branch, path) :: _ when path <> p.path -> Ok path
+       | _ -> Error "bare repo has no default worktree")
   else
     Ok p.path
 
@@ -734,6 +745,7 @@ let control_system_prompt projects =
 
 You have MCP tools available:
 - start_session: Start a new agent session for a project
+- import_project: Clone a GitHub repository into the project registry and create its Discord project channel
 - list_projects: List all discovered projects
 - list_sessions: List active bot sessions
 - stop_session: Stop an active bot session by Discord thread ID
@@ -774,6 +786,7 @@ let project_system_prompt (project : Project.t) =
 
 You have MCP tools available:
 - start_session: Start a new agent session (creates a thread + worktree)
+- import_project: Clone a GitHub repository into the project registry and create its Discord project channel
 - list_projects: List all discovered projects
 - list_sessions: List active bot sessions
 - stop_session: Stop an active bot session by Discord thread ID
@@ -1464,6 +1477,30 @@ let trigger_restart t ~notify =
     and swaps it in one assignment. No fiber can observe an intermediate
     state where projects and channels disagree.
 
+    Returns (old_count, new_count). Caller owns single-flight gating. *)
+let refresh_projects_snapshot t =
+  let old_count = List.length (projects t) in
+  (* Phase 1: Blocking filesystem scan — runs in a system thread
+     to avoid stalling the Eio event loop *)
+  let new_projects = Eio_unix.run_in_systhread (fun () ->
+    Project.discover ~base_directories:t.config.base_directories) in
+  (* Phase 2: Build new channel mappings in a fresh manager.
+     Must run in Eio context because Channel_manager.setup uses
+     Discord REST (cohttp-eio). The old project_state stays valid
+     for any concurrent message handling during this call. *)
+  let new_channels = Channel_manager.create () in
+  Channel_manager.set_category_id new_channels
+    (Channel_manager.category_id (channels t));
+  Channel_manager.setup ~rest:t.rest ~guild_id:t.config.guild_id
+    ~projects:new_projects new_channels;
+  (* Phase 3: Atomic swap — single assignment, no intermediate state *)
+  t.project_state <- { projects = new_projects; channels = new_channels };
+  let new_count = List.length new_projects in
+  Logs.info (fun m -> m "bot: refreshed projects: %d -> %d" old_count new_count);
+  old_count, new_count
+
+(** Re-run project discovery and update all derived state atomically.
+
     Returns (old_count, new_count), or None if a refresh is already
     in progress (single-flight: concurrent callers are rejected). *)
 let refresh_projects t =
@@ -1473,25 +1510,7 @@ let refresh_projects t =
   end else begin
     t.refreshing <- true;
     Fun.protect ~finally:(fun () -> t.refreshing <- false) (fun () ->
-      let old_count = List.length (projects t) in
-      (* Phase 1: Blocking filesystem scan — runs in a system thread
-         to avoid stalling the Eio event loop *)
-      let new_projects = Eio_unix.run_in_systhread (fun () ->
-        Project.discover ~base_directories:t.config.base_directories) in
-      (* Phase 2: Build new channel mappings in a fresh manager.
-         Must run in Eio context because Channel_manager.setup uses
-         Discord REST (cohttp-eio). The old project_state stays valid
-         for any concurrent message handling during this call. *)
-      let new_channels = Channel_manager.create () in
-      Channel_manager.set_category_id new_channels
-        (Channel_manager.category_id (channels t));
-      Channel_manager.setup ~rest:t.rest ~guild_id:t.config.guild_id
-        ~projects:new_projects new_channels;
-      (* Phase 3: Atomic swap — single assignment, no intermediate state *)
-      t.project_state <- { projects = new_projects; channels = new_channels };
-      let new_count = List.length new_projects in
-      Logs.info (fun m -> m "bot: refreshed projects: %d -> %d" old_count new_count);
-      Some (old_count, new_count))
+      Some (refresh_projects_snapshot t))
   end
 
 (** Render a "recent sessions" Discord listing in a uniform shape so
@@ -1628,6 +1647,93 @@ let create_explicit_channel_session t ~channel_id ~agent_kind =
           ~session_override_kind:(Some agent_kind);
         true
 
+let ensure_imported_project_ready t (project : Project.t) =
+  match Channel_manager.find_or_create ~rest:t.rest
+          ~guild_id:t.config.guild_id ~project (channels t) with
+  | None -> Error "Could not create or find the project channel."
+  | Some channel_id ->
+    (match working_dir_of_project project with
+     | Error err -> Error ("Could not resolve project working directory: " ^ err)
+     | Ok working_dir ->
+       (match Session_store.find_opt t.sessions ~thread_id:channel_id with
+        | Some _ -> Ok (channel_id, working_dir)
+        | None ->
+          try
+            create_persistent_channel_session t ~channel_id
+              ~project_name:project.name ~working_dir
+              ~system_prompt:(Some (project_system_prompt project))
+              ~agent_kind:(effective_top_level_agent t)
+              ~session_override_kind:None;
+            Ok (channel_id, working_dir)
+          with exn ->
+            Error (Printf.sprintf "Failed to create project channel session: %s"
+              (Printexc.to_string exn))))
+
+let import_project t ~url ?name () =
+  if t.draining then
+    Error "Bot is restarting; try again shortly."
+  else if t.refreshing then
+    Error "Project refresh/import already in progress."
+  else
+    match Disk_health.preflight_state_mutation () with
+    | Error err -> Error err
+    | Ok () ->
+      match Project.validate_github_url url with
+      | Error err -> Error err
+      | Ok url ->
+        let requested_name =
+          match name with
+          | Some n ->
+            (match Project.validate_import_name n with
+             | Ok n -> Ok (Some n)
+             | Error err -> Error err)
+          | None -> Ok None
+        in
+        match requested_name with
+        | Error err -> Error err
+        | Ok requested_name ->
+        match Project.find_by_remote_url (projects t) url with
+        | Some existing ->
+          (match ensure_imported_project_ready t existing with
+           | Ok (channel_id, working_dir) ->
+             Ok {
+               imported_project = existing;
+               imported_channel_id = channel_id;
+               imported_working_dir = working_dir;
+               imported_existing = true;
+             }
+           | Error err -> Error err)
+        | None ->
+          let base_directory = match t.config.base_directories with
+            | first :: _ -> first
+            | [] -> "" in
+          if base_directory = "" then
+            Error "No base_directories configured."
+          else begin
+            t.refreshing <- true;
+            Fun.protect ~finally:(fun () -> t.refreshing <- false) (fun () ->
+              match
+                Eio_unix.run_in_systhread (fun () ->
+                  Project.import_github ~base_directory ?name:requested_name url)
+              with
+              | Error err -> Error err
+              | Ok _ ->
+                let _old_count, _new_count = refresh_projects_snapshot t in
+                match Project.find_by_remote_url (projects t) url with
+                | None ->
+                  Error "Imported repository was cloned but was not discovered after refresh."
+                | Some imported ->
+                  match ensure_imported_project_ready t imported with
+                  | Error err -> Error err
+                  | Ok (channel_id, working_dir) ->
+                    Ok {
+                      imported_project = imported;
+                      imported_channel_id = channel_id;
+                      imported_working_dir = working_dir;
+                      imported_existing = false;
+                    })
+          end
+
 let cleanup_orphan_thread t ~thread_id ~context =
   match Discord_rest.delete_channel t.rest ~channel_id:thread_id () with
   | Ok _ -> ()
@@ -1704,6 +1810,17 @@ let handle_command t msg cmd =
     ) entries in
     reply (if lines = [] then "No active sessions."
       else "**Sessions:**\n" ^ String.concat "\n" lines)
+  | Command.Import_project { url; name } ->
+    Eio.Fiber.fork ~sw:t.sw (fun () ->
+      match import_project t ~url ?name () with
+      | Error err -> reply (Printf.sprintf "Import failed: %s" err)
+      | Ok result ->
+        let action =
+          if result.imported_existing then "already existed" else "imported" in
+        reply (Printf.sprintf
+          "Project **%s** %s in <#%s>.\nWorking in: `%s`"
+          result.imported_project.name action result.imported_channel_id
+          result.imported_working_dir))
   | Command.List_claude_sessions ->
     Eio.Fiber.fork ~sw:t.sw (fun () ->
       let entries =
@@ -2331,6 +2448,7 @@ let handle_command t msg cmd =
       "`!codex-sessions` — list recent Codex sessions";
       "`!gemini-sessions` — list recent Gemini sessions";
       "`!start <project> [agent]` — start a session (defaults to the current effective top-level agent)";
+      "`!import-project <github-url> [name]` — clone a GitHub repo into the project registry";
       "`!default-agent [agent]` / `!default_agent [agent]` — show or set the default agent (claude|codex|gemini)";
       "`!rescue-agent [agent|off]` / `!rescue_agent [agent|off]` — show or set the rescue agent used under disk pressure";
       "`!session-agent [agent]` / `!session_agent [agent]` — show or set the current channel session agent";

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -1692,26 +1692,27 @@ let import_project t ~url ?name () =
         match requested_name with
         | Error err -> Error err
         | Ok requested_name ->
-        match Project.find_by_remote_url (projects t) url with
-        | Some existing ->
-          (match ensure_imported_project_ready t existing with
-           | Ok (channel_id, working_dir) ->
-             Ok {
-               imported_project = existing;
-               imported_channel_id = channel_id;
-               imported_working_dir = working_dir;
-               imported_existing = true;
-             }
-           | Error err -> Error err)
-        | None ->
-          let base_directory = match t.config.base_directories with
-            | first :: _ -> first
-            | [] -> "" in
-          if base_directory = "" then
-            Error "No base_directories configured."
-          else begin
-            t.refreshing <- true;
-            Fun.protect ~finally:(fun () -> t.refreshing <- false) (fun () ->
+        let base_directory = match t.config.base_directories with
+          | first :: _ -> first
+          | [] -> "" in
+        if base_directory = "" then
+          Error "No base_directories configured."
+        else begin
+          t.refreshing <- true;
+          Fun.protect ~finally:(fun () -> t.refreshing <- false) (fun () ->
+            let _old_count, _new_count = refresh_projects_snapshot t in
+            match Project.find_by_remote_url (projects t) url with
+            | Some existing ->
+              (match ensure_imported_project_ready t existing with
+               | Ok (channel_id, working_dir) ->
+                 Ok {
+                   imported_project = existing;
+                   imported_channel_id = channel_id;
+                   imported_working_dir = working_dir;
+                   imported_existing = true;
+                 }
+               | Error err -> Error err)
+            | None ->
               match
                 Eio_unix.run_in_systhread (fun () ->
                   Project.import_github ~base_directory ?name:requested_name url)
@@ -1732,7 +1733,7 @@ let import_project t ~url ?name () =
                       imported_working_dir = working_dir;
                       imported_existing = false;
                     })
-          end
+        end
 
 let cleanup_orphan_thread t ~thread_id ~context =
   match Discord_rest.delete_channel t.rest ~channel_id:thread_id () with

--- a/lib/command.ml
+++ b/lib/command.ml
@@ -11,6 +11,7 @@ type t =
   | List_gemini_sessions
   | Start_agent of { project : string; kind : Config.agent_kind option }
   (** [kind = None] means use the current effective top-level agent. *)
+  | Import_project of { url : string; name : string option }
   | Resume_session of { session_id : string; kind : Config.agent_kind option }
   | Fork_session of { move : bool option }
   (** [move = None] means the handler applies the channel-specific default. *)
@@ -59,6 +60,10 @@ let parse content =
     Start_agent { project; kind = None }
   | ["start"] ->
     List_projects
+  | ["import-project"; url] | ["import_project"; url] ->
+    Import_project { url; name = None }
+  | ["import-project"; url; name] | ["import_project"; url; name] ->
+    Import_project { url; name = Some name }
   | ["resume"; session_id] -> Resume_session { session_id; kind = None }
   | ["resume"; kind_str; session_id] ->
     (match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -262,6 +262,27 @@ let handle_list_sessions (bot : Bot.t) =
   ) entries in
   ok_response [("sessions", `List sessions)]
 
+let handle_import_project (bot : Bot.t) params =
+  let open Yojson.Safe.Util in
+  let params = match params with Some p -> p | None ->
+    failwith "missing params" in
+  let url = params |> member "url" |> to_string in
+  let name = params |> member "name" |> to_string_option in
+  match Bot.import_project bot ~url ?name () with
+  | Error err -> error_response err
+  | Ok result ->
+    let project = result.Bot.imported_project in
+    ok_response [
+      ("project_name", `String project.name);
+      ("project_path", `String project.path);
+      ("is_bare", `Bool project.is_bare);
+      ("remote_url", match project.remote_url with
+        | Some url -> `String url | None -> `Null);
+      ("channel_id", `String result.imported_channel_id);
+      ("working_dir", `String result.imported_working_dir);
+      ("existing", `Bool result.imported_existing);
+    ]
+
 (** Extract [hours] from the optional params object, defaulting to 24. *)
 let hours_param params =
   match params with
@@ -1190,6 +1211,7 @@ let dispatch (bot : Bot.t) method_ params =
     | "health" -> handle_health bot
     | "list_projects" -> handle_list_projects bot
     | "list_sessions" -> handle_list_sessions bot
+    | "import_project" -> handle_import_project bot params
     | "list_claude_sessions" -> handle_list_claude_sessions bot params
     | "list_codex_sessions" -> handle_list_codex_sessions bot params
     | "list_gemini_sessions" -> handle_list_gemini_sessions bot params

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -266,7 +266,9 @@ let handle_import_project (bot : Bot.t) params =
   let open Yojson.Safe.Util in
   let params = match params with Some p -> p | None ->
     failwith "missing params" in
-  let url = params |> member "url" |> to_string in
+  let url = match params |> member "url" |> to_string_option with
+    | Some url -> url
+    | None -> failwith "missing url" in
   let name = params |> member "name" |> to_string_option in
   match Bot.import_project bot ~url ?name () with
   | Error err -> error_response err

--- a/lib/project.ml
+++ b/lib/project.ml
@@ -308,20 +308,7 @@ let run_capture ?cwd args =
   | _ -> Error (Buffer.contents output)
 
 let default_branch project =
-  match run_capture ["git"; "-C"; project.path; "symbolic-ref"; "--short"; "HEAD"] with
-  | Ok branch ->
-    let branch = String.trim branch in
-    if branch <> "" then branch
-    else
-      let try_branch name =
-        match run_capture ["git"; "-C"; project.path; "rev-parse"; "--verify"; name] with
-        | Ok _ -> true
-        | Error _ -> false
-      in
-      if try_branch "main" then "main"
-      else if try_branch "master" then "master"
-      else "HEAD"
-  | Error _ ->
+  let fallback () =
     let try_branch name =
       match run_capture ["git"; "-C"; project.path; "rev-parse"; "--verify"; name] with
       | Ok _ -> true
@@ -330,6 +317,28 @@ let default_branch project =
     if try_branch "main" then "main"
     else if try_branch "master" then "master"
     else "HEAD"
+  in
+  let symbolic_ref ref_name =
+    match run_capture ["git"; "-C"; project.path; "symbolic-ref"; "--short"; ref_name] with
+    | Ok branch ->
+      let branch = String.trim branch in
+      if branch = "" then None else Some branch
+    | Error _ -> None
+  in
+  if project.is_bare then
+    match symbolic_ref "HEAD" with
+    | Some branch -> branch
+    | None -> fallback ()
+  else
+    match symbolic_ref "refs/remotes/origin/HEAD" with
+    | Some branch ->
+      let origin_prefix = "origin/" in
+      if String.length branch > String.length origin_prefix
+         && String.sub branch 0 (String.length origin_prefix) = origin_prefix
+      then String.sub branch (String.length origin_prefix)
+        (String.length branch - String.length origin_prefix)
+      else branch
+    | None -> fallback ()
 
 (** List worktrees for a project. Returns (branch_name, worktree_path) pairs. *)
 let list_worktrees project =
@@ -377,19 +386,48 @@ let list_worktrees project =
   in
   parse_groups lines None None []
 
-let ensure_default_worktree project =
+let worktree_dir_name branch =
+  String.map (function '/' | '\\' | ':' -> '-' | c -> c) branch
+
+let unique_preserving_order items =
+  let rec aux seen acc = function
+    | [] -> List.rev acc
+    | x :: xs when List.mem x seen -> aux seen acc xs
+    | x :: xs -> aux (x :: seen) (x :: acc) xs
+  in
+  aux [] [] items
+
+let default_worktree_path project =
   let branch = default_branch project in
-  let existing =
+  match
     list_worktrees project
     |> List.find_opt (fun (b, path) ->
       b = branch && path <> project.path && Sys.file_exists path)
-  in
-  match existing with
+  with
   | Some (_, path) -> Ok path
   | None ->
+    let candidates =
+      unique_preserving_order
+        [branch; worktree_dir_name branch; "master"; "main"]
+    in
+    match List.find_opt (fun name ->
+      let path = Filename.concat project.path name in
+      try Sys.is_directory path with Sys_error _ -> false
+    ) candidates with
+    | Some name -> Ok (Filename.concat project.path name)
+    | None ->
+      (match List.find_opt (fun (_branch, path) ->
+         path <> project.path && Sys.file_exists path) (list_worktrees project) with
+       | Some (_, path) -> Ok path
+       | None -> Error "bare repo has no default worktree")
+
+let ensure_default_worktree project =
+  match default_worktree_path project with
+  | Ok path -> Ok path
+  | Error _ ->
+    let branch = default_branch project in
     let worktree_name =
-      branch
-      |> String.map (function '/' | '\\' | ':' -> '-' | c -> c)
+      worktree_dir_name branch
     in
     let worktree_path = Filename.concat project.path worktree_name in
     match run_capture

--- a/lib/project.ml
+++ b/lib/project.ml
@@ -308,14 +308,14 @@ let run_capture ?cwd args =
   | _ -> Error (Buffer.contents output)
 
 let default_branch project =
+  let branch_exists name =
+    match run_capture ["git"; "-C"; project.path; "rev-parse"; "--verify"; name] with
+    | Ok _ -> true
+    | Error _ -> false
+  in
   let fallback () =
-    let try_branch name =
-      match run_capture ["git"; "-C"; project.path; "rev-parse"; "--verify"; name] with
-      | Ok _ -> true
-      | Error _ -> false
-    in
-    if try_branch "main" then "main"
-    else if try_branch "master" then "master"
+    if branch_exists "main" then "main"
+    else if branch_exists "master" then "master"
     else "HEAD"
   in
   let symbolic_ref ref_name =
@@ -335,8 +335,10 @@ let default_branch project =
       let origin_prefix = "origin/" in
       if String.length branch > String.length origin_prefix
          && String.sub branch 0 (String.length origin_prefix) = origin_prefix
-      then String.sub branch (String.length origin_prefix)
-        (String.length branch - String.length origin_prefix)
+      then
+        let local = String.sub branch (String.length origin_prefix)
+          (String.length branch - String.length origin_prefix) in
+        if branch_exists local then local else branch
       else branch
     | None -> fallback ()
 
@@ -397,6 +399,9 @@ let unique_preserving_order items =
   in
   aux [] [] items
 
+let is_worktree_checkout_path path =
+  Sys.file_exists (Filename.concat path ".git")
+
 let default_worktree_path project =
   let branch = default_branch project in
   match
@@ -412,7 +417,8 @@ let default_worktree_path project =
     in
     match List.find_opt (fun name ->
       let path = Filename.concat project.path name in
-      try Sys.is_directory path with Sys_error _ -> false
+      (try Sys.is_directory path with Sys_error _ -> false)
+      && is_worktree_checkout_path path
     ) candidates with
     | Some name -> Ok (Filename.concat project.path name)
     | None ->

--- a/lib/project.ml
+++ b/lib/project.ml
@@ -13,6 +13,116 @@ type t = {
   remote_url : string option;
 }
 
+let strip_suffix s suffix =
+  let suffix_len = String.length suffix in
+  if String.length s >= suffix_len
+     && String.sub s (String.length s - suffix_len) suffix_len = suffix
+  then String.sub s 0 (String.length s - suffix_len)
+  else s
+
+let is_valid_github_path_part s =
+  s <> ""
+  && s <> "."
+  && s <> ".."
+  && String.for_all (function
+    | 'A'..'Z' | 'a'..'z' | '0'..'9' | '-' | '_' | '.' -> true
+    | _ -> false) s
+
+let parse_github_remote url =
+  let parse_path path =
+    let path = if String.length path > 0 && path.[0] = '/'
+      then String.sub path 1 (String.length path - 1)
+      else path in
+    let path = strip_suffix path ".git" in
+    match String.split_on_char '/' path with
+    | [owner; repo]
+      when is_valid_github_path_part owner
+           && is_valid_github_path_part repo ->
+      Some (String.lowercase_ascii owner, repo)
+    | _ -> None
+  in
+  let lower = String.lowercase_ascii url in
+  let https_prefix = "https://github.com/" in
+  let ssh_prefix = "git@github.com:" in
+  let ssh_url_prefix = "ssh://git@github.com/" in
+  if String.length lower > String.length https_prefix
+     && String.sub lower 0 (String.length https_prefix) = https_prefix
+  then
+    parse_path (String.sub url (String.length https_prefix)
+      (String.length url - String.length https_prefix))
+  else if String.length lower > String.length ssh_prefix
+          && String.sub lower 0 (String.length ssh_prefix) = ssh_prefix
+  then
+    parse_path (String.sub url (String.length ssh_prefix)
+      (String.length url - String.length ssh_prefix))
+  else if String.length lower > String.length ssh_url_prefix
+          && String.sub lower 0 (String.length ssh_url_prefix) = ssh_url_prefix
+  then
+    parse_path (String.sub url (String.length ssh_url_prefix)
+      (String.length url - String.length ssh_url_prefix))
+  else
+    None
+
+let validate_github_url url =
+  let url = String.trim url in
+  if url = "" then
+    Error "GitHub URL is required."
+  else if String.exists (fun c -> Char.code c < 0x20 || c = ' ') url then
+    Error "GitHub URL must not contain spaces or control characters."
+  else
+    match parse_github_remote url with
+    | Some _ -> Ok url
+    | None ->
+      Error "Expected a GitHub HTTPS or SSH URL like https://github.com/owner/repo.git or git@github.com:owner/repo.git."
+
+let repo_name_from_github_url url =
+  match parse_github_remote url with
+  | Some (_, repo) -> Some repo
+  | None -> None
+
+let validate_import_name name =
+  let name = String.trim name in
+  if name = "" then
+    Error "Project name is required."
+  else if String.length name > 100 then
+    Error "Project name must be 100 characters or fewer."
+  else if not (is_valid_github_path_part name) then
+    Error "Project name may contain only letters, numbers, dot, underscore, and hyphen."
+  else
+    Ok name
+
+let remote_key url =
+  match parse_github_remote url with
+  | Some (owner, repo) ->
+    Some ("github.com/" ^ owner ^ "/" ^ String.lowercase_ascii repo)
+  | None ->
+    let norm = String.lowercase_ascii url in
+    let norm = strip_suffix norm ".git" in
+    let stripped = List.fold_left (fun s prefix ->
+      if String.length s > String.length prefix &&
+         String.sub s 0 (String.length prefix) = prefix
+      then String.sub s (String.length prefix) (String.length s - String.length prefix)
+      else s
+    ) norm ["https://"; "http://"] in
+    (match String.split_on_char ':' stripped with
+     | [host; path] when not (String.contains host '/') ->
+       let host = match String.split_on_char '@' host with
+         | [_; h] -> h | _ -> host in
+       Some (host ^ "/" ^ path)
+     | _ when stripped <> "" -> Some stripped
+     | _ -> None)
+
+let same_remote_url a b =
+  match remote_key a, remote_key b with
+  | Some a, Some b -> String.equal a b
+  | _ -> false
+
+let find_by_remote_url projects url =
+  List.find_opt (fun (p : t) ->
+    match p.remote_url with
+    | Some remote -> same_remote_url remote url
+    | None -> false) projects
+
 let is_git_dir path =
   Sys.file_exists (Filename.concat path ".git")
 
@@ -124,28 +234,7 @@ let deduplicate projects =
     match p.remote_url with
     | None -> no_remote := p :: !no_remote
     | Some url ->
-      (* Normalize URL: strip .git, convert SSH to common format *)
-      let norm = String.lowercase_ascii url in
-      let norm = if String.length norm > 4 &&
-        String.sub norm (String.length norm - 4) 4 = ".git"
-        then String.sub norm 0 (String.length norm - 4) else norm in
-      (* Normalize to github.com/user/repo form *)
-      let key =
-        (* Strip protocol prefix first *)
-        let stripped = List.fold_left (fun s prefix ->
-          if String.length s > String.length prefix &&
-             String.sub s 0 (String.length prefix) = prefix
-          then String.sub s (String.length prefix) (String.length s - String.length prefix)
-          else s
-        ) norm ["https://"; "http://"] in
-        (* Handle SSH format: git@github.com:user/repo *)
-        match String.split_on_char ':' stripped with
-        | [host; path] when not (String.contains host '/') ->
-          let host = match String.split_on_char '@' host with
-            | [_; h] -> h | _ -> host in
-          host ^ "/" ^ path
-        | _ -> stripped
-      in
+      let key = Option.value (remote_key url) ~default:(String.lowercase_ascii url) in
       match UrlMap.find_opt key !by_url with
       | None -> by_url := UrlMap.add key p !by_url
       | Some existing ->
@@ -183,6 +272,64 @@ let deduplicate projects =
 let discover ~base_directories =
   let raw = List.concat_map discover_in_directory base_directories in
   deduplicate raw
+
+let rec mkdir_p path =
+  if path = "" || path = Filename.dirname path then ()
+  else if Sys.file_exists path then ()
+  else begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
+let rec rm_rf path =
+  match Unix.lstat path with
+  | exception Unix.Unix_error (ENOENT, _, _) -> ()
+  | { Unix.st_kind = Unix.S_DIR; _ } ->
+    Sys.readdir path
+    |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+    Unix.rmdir path
+  | _ -> Unix.unlink path
+
+let run_capture ?cwd args =
+  let prefix = match cwd with
+    | Some dir -> "cd " ^ Filename.quote dir ^ " && "
+    | None -> "" in
+  let cmd = prefix ^ String.concat " " (List.map Filename.quote args) ^ " 2>&1" in
+  let ic = Unix.open_process_in cmd in
+  let output = Buffer.create 256 in
+  (try
+     while true do
+       Buffer.add_string output (input_line ic);
+       Buffer.add_char output '\n'
+     done
+   with End_of_file -> ());
+  match Unix.close_process_in ic with
+  | Unix.WEXITED 0 -> Ok (Buffer.contents output)
+  | _ -> Error (Buffer.contents output)
+
+let default_branch project =
+  match run_capture ["git"; "-C"; project.path; "symbolic-ref"; "--short"; "HEAD"] with
+  | Ok branch ->
+    let branch = String.trim branch in
+    if branch <> "" then branch
+    else
+      let try_branch name =
+        match run_capture ["git"; "-C"; project.path; "rev-parse"; "--verify"; name] with
+        | Ok _ -> true
+        | Error _ -> false
+      in
+      if try_branch "main" then "main"
+      else if try_branch "master" then "master"
+      else "HEAD"
+  | Error _ ->
+    let try_branch name =
+      match run_capture ["git"; "-C"; project.path; "rev-parse"; "--verify"; name] with
+      | Ok _ -> true
+      | Error _ -> false
+    in
+    if try_branch "main" then "main"
+    else if try_branch "master" then "master"
+    else "HEAD"
 
 (** List worktrees for a project. Returns (branch_name, worktree_path) pairs. *)
 let list_worktrees project =
@@ -230,21 +377,66 @@ let list_worktrees project =
   in
   parse_groups lines None None []
 
-(** Find the default branch for a project (main or master). *)
-let default_branch project =
-  (* Try git symbolic-ref, then fall back to checking common names *)
-  let try_branch name =
-    let cmd = Printf.sprintf "git -C %s rev-parse --verify %s 2>/dev/null"
-      (Filename.quote project.path) (Filename.quote name) in
-    let ic = Unix.open_process_in cmd in
-    let _output = try input_line ic with End_of_file -> "" in
-    match Unix.close_process_in ic with
-    | Unix.WEXITED 0 -> true
-    | _ -> false
+let ensure_default_worktree project =
+  let branch = default_branch project in
+  let existing =
+    list_worktrees project
+    |> List.find_opt (fun (b, path) ->
+      b = branch && path <> project.path && Sys.file_exists path)
   in
-  if try_branch "main" then "main"
-  else if try_branch "master" then "master"
-  else "HEAD"
+  match existing with
+  | Some (_, path) -> Ok path
+  | None ->
+    let worktree_name =
+      branch
+      |> String.map (function '/' | '\\' | ':' -> '-' | c -> c)
+    in
+    let worktree_path = Filename.concat project.path worktree_name in
+    match run_capture
+      ["git"; "-C"; project.path; "worktree"; "add"; worktree_path; branch]
+    with
+    | Ok _ -> Ok worktree_path
+    | Error err ->
+      Error (Printf.sprintf "failed to create default worktree for %s: %s"
+        branch err)
+
+type import_result = {
+  project : t;
+  worktree_path : string;
+}
+
+let import_github ~base_directory ?name url =
+  match validate_github_url url with
+  | Error _ as err -> err
+  | Ok url ->
+    let name =
+      match name with
+      | Some n -> validate_import_name n
+      | None ->
+        (match repo_name_from_github_url url with
+         | Some n -> validate_import_name n
+         | None -> Error "Could not derive a project name from the GitHub URL.")
+    in
+    match name with
+    | Error _ as err -> err
+    | Ok name ->
+      let target = Filename.concat base_directory name in
+      if Sys.file_exists target then
+        Error (Printf.sprintf "Target path already exists: %s" target)
+      else begin
+        mkdir_p base_directory;
+        match run_capture ["git"; "clone"; "--bare"; url; target] with
+        | Error err ->
+          if Sys.file_exists target then rm_rf target;
+          Error (Printf.sprintf "git clone failed: %s" err)
+        | Ok _ ->
+          let project = { name; path = target; is_bare = true; remote_url = Some url } in
+          match ensure_default_worktree project with
+          | Ok worktree_path -> Ok { project; worktree_path }
+          | Error err ->
+            if Sys.file_exists target then rm_rf target;
+            Error err
+      end
 
 (** Create a new worktree with a new branch for an agent session.
     Bases the branch on the project's default branch (main/master). *)

--- a/lib/project.ml
+++ b/lib/project.ml
@@ -309,7 +309,10 @@ let run_capture ?cwd args =
 
 let default_branch project =
   let branch_exists name =
-    match run_capture ["git"; "-C"; project.path; "rev-parse"; "--verify"; name] with
+    match run_capture
+      ["git"; "-C"; project.path; "show-ref"; "--verify"; "--quiet";
+       "refs/heads/" ^ name]
+    with
     | Ok _ -> true
     | Error _ -> false
   in

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -123,6 +123,25 @@ TOOLS = [
         }
     },
     {
+        "name": "import_project",
+        "description": "Clone a GitHub HTTPS or SSH URL into the bot's project registry, create its Discord project channel, and make the channel session-ready. Reuses local git credentials; no token is accepted.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "GitHub repository URL, e.g. https://github.com/owner/repo.git or git@github.com:owner/repo.git"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Optional local project directory name under the configured base directory. Defaults to the GitHub repository name.",
+                    "maxLength": 100
+                }
+            },
+            "required": ["url"]
+        }
+    },
+    {
         "name": "list_sessions",
         "description": "List active bot sessions (Discord threads with agent sessions attached).",
         "inputSchema": {
@@ -391,6 +410,17 @@ def handle_tool_call(name, arguments):
                  + (" [bare]" if p.get("is_bare") else "")
                  for i, p in enumerate(projects)]
         return "\n".join(lines) if lines else "No projects found."
+
+    elif name == "import_project":
+        result = control_request("import_project", arguments, timeout=300)
+        if "error" in result:
+            return result["error"]
+        pname = result.get("project_name", "")
+        cid = result.get("channel_id", "")
+        wd = result.get("working_dir", "")
+        existing = result.get("existing", False)
+        action = "already existed" if existing else "imported"
+        return f"Project **{pname}** {action} in <#{cid}>.\nWorking in: `{wd}`"
 
     elif name == "list_sessions":
         result = control_request("list_sessions")

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -671,6 +671,10 @@ let cmd_testable =
       | Start_agent { project; kind = Some k } ->
         Printf.sprintf "Start_agent(%s,%s)"
           project (Discord_agents.Config.string_of_agent_kind k)
+      | Import_project { url; name = None } ->
+        "Import_project(" ^ url ^ ")"
+      | Import_project { url; name = Some name } ->
+        Printf.sprintf "Import_project(%s,%s)" url name
       | Resume_session { session_id; kind = None } ->
         "Resume_session(" ^ session_id ^ ")"
       | Resume_session { session_id; kind = Some k } ->
@@ -889,6 +893,21 @@ let test_parse_start_default_agent () =
        { project = "myproj"; kind = None })
     (Discord_agents.Command.parse "!start myproj")
 
+let test_parse_import_project () =
+  Alcotest.(check cmd_testable) "import project"
+    (Discord_agents.Command.Import_project
+       { url = "https://github.com/tedks/example.git"; name = None })
+    (Discord_agents.Command.parse
+       "!import-project https://github.com/tedks/example.git")
+
+let test_parse_import_project_with_name () =
+  Alcotest.(check cmd_testable) "import project with name"
+    (Discord_agents.Command.Import_project
+       { url = "git@github.com:tedks/example.git";
+         name = Some "local-example" })
+    (Discord_agents.Command.parse
+       "!import_project git@github.com:tedks/example.git local-example")
+
 let test_parse_default_agent_no_arg () =
   Alcotest.(check cmd_testable) "default-agent no arg"
     (Discord_agents.Command.Default_agent None)
@@ -1013,6 +1032,8 @@ let command_tests = [
   Alcotest.test_case "resume with codex kind" `Quick test_parse_resume_with_codex_kind;
   Alcotest.test_case "start with gemini kind" `Quick test_parse_start_gemini;
   Alcotest.test_case "start with default agent" `Quick test_parse_start_default_agent;
+  Alcotest.test_case "import-project" `Quick test_parse_import_project;
+  Alcotest.test_case "import_project with name" `Quick test_parse_import_project_with_name;
   Alcotest.test_case "default-agent no arg" `Quick test_parse_default_agent_no_arg;
   Alcotest.test_case "default-agent set" `Quick test_parse_default_agent_set;
   Alcotest.test_case "default_agent alias" `Quick test_parse_default_agent_underscore_alias;

--- a/test/test_project.ml
+++ b/test/test_project.ml
@@ -388,6 +388,34 @@ let test_default_branch_for_non_bare_ignores_current_branch () =
     Alcotest.(check string) "falls back to main, not current branch"
       "main" (P.default_branch project))
 
+let test_default_branch_uses_remote_tracking_when_local_missing () =
+  with_tmpdir (fun base ->
+    let src = Filename.concat base "src" in
+    let origin = Filename.concat base "origin.git" in
+    let repo = Filename.concat base "repo" in
+    make_git_repo_with_commit src;
+    let run cmd =
+      let exit_code = Sys.command (Printf.sprintf "%s 2>/dev/null" cmd) in
+      if exit_code <> 0 then
+        Alcotest.failf "setup command failed (%d): %s" exit_code cmd
+    in
+    run (Printf.sprintf "git clone --bare %s %s"
+      (Filename.quote src) (Filename.quote origin));
+    mkdir_p repo;
+    run (Printf.sprintf "git -C %s init -q" (Filename.quote repo));
+    run (Printf.sprintf "git -C %s remote add origin %s"
+      (Filename.quote repo) (Filename.quote origin));
+    run (Printf.sprintf "git -C %s fetch -q origin"
+      (Filename.quote repo));
+    run (Printf.sprintf
+      "git -C %s symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main"
+      (Filename.quote repo));
+    let project =
+      P.{ name = "repo"; path = repo; is_bare = false; remote_url = None }
+    in
+    Alcotest.(check string) "uses remote-tracking ref when local branch missing"
+      "origin/main" (P.default_branch project))
+
 let discovery_tests = [
   Alcotest.test_case "flat repo" `Quick test_flat_repo;
   Alcotest.test_case "bare repo" `Quick test_bare_repo;
@@ -433,5 +461,7 @@ let () =
         test_ensure_default_worktree_uses_symbolic_head;
       Alcotest.test_case "non-bare default branch ignores current branch" `Quick
         test_default_branch_for_non_bare_ignores_current_branch;
+      Alcotest.test_case "non-bare default branch can use origin HEAD" `Quick
+        test_default_branch_uses_remote_tracking_when_local_missing;
     ];
   ]

--- a/test/test_project.ml
+++ b/test/test_project.ml
@@ -407,6 +407,8 @@ let test_default_branch_uses_remote_tracking_when_local_missing () =
       (Filename.quote repo) (Filename.quote origin));
     run (Printf.sprintf "git -C %s fetch -q origin"
       (Filename.quote repo));
+    run (Printf.sprintf "git -C %s tag main origin/main"
+      (Filename.quote repo));
     run (Printf.sprintf
       "git -C %s symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main"
       (Filename.quote repo));

--- a/test/test_project.ml
+++ b/test/test_project.ml
@@ -363,8 +363,30 @@ let test_ensure_default_worktree_uses_symbolic_head () =
         (Filename.concat bare "release-v1") worktree_path;
       Alcotest.(check bool) "worktree exists"
         true (Sys.file_exists worktree_path);
+      (match P.default_worktree_path project with
+       | Error err -> Alcotest.failf "default_worktree_path failed: %s" err
+       | Ok resolved ->
+         Alcotest.(check string) "default worktree resolves sanitized path"
+           worktree_path resolved);
       Alcotest.(check bool) "worktree registered"
         true (List.mem ("release/v1", worktree_path) (P.list_worktrees project)))
+
+let test_default_branch_for_non_bare_ignores_current_branch () =
+  with_tmpdir (fun base ->
+    let repo = Filename.concat base "repo" in
+    make_git_repo_with_commit repo;
+    let run cmd =
+      let exit_code = Sys.command (Printf.sprintf "%s 2>/dev/null" cmd) in
+      if exit_code <> 0 then
+        Alcotest.failf "setup command failed (%d): %s" exit_code cmd
+    in
+    run (Printf.sprintf "git -C %s checkout -q -b feature/work"
+      (Filename.quote repo));
+    let project =
+      P.{ name = "repo"; path = repo; is_bare = false; remote_url = None }
+    in
+    Alcotest.(check string) "falls back to main, not current branch"
+      "main" (P.default_branch project))
 
 let discovery_tests = [
   Alcotest.test_case "flat repo" `Quick test_flat_repo;
@@ -409,5 +431,7 @@ let () =
         test_remove_worktree_prunes_missing_worktree_registration;
       Alcotest.test_case "ensure default worktree follows symbolic HEAD" `Quick
         test_ensure_default_worktree_uses_symbolic_head;
+      Alcotest.test_case "non-bare default branch ignores current branch" `Quick
+        test_default_branch_for_non_bare_ignores_current_branch;
     ];
   ]

--- a/test/test_project.ml
+++ b/test/test_project.ml
@@ -297,6 +297,75 @@ let test_remove_worktree_prunes_missing_worktree_registration () =
       in
       Alcotest.(check bool) "stale registration pruned" false registered)
 
+let test_validate_github_url_accepts_supported_forms () =
+  let urls = [
+    "https://github.com/tedks/discord-agents.git";
+    "git@github.com:tedks/discord-agents.git";
+    "ssh://git@github.com/tedks/discord-agents.git";
+  ] in
+  List.iter (fun url ->
+    match P.validate_github_url url with
+    | Ok normalized -> Alcotest.(check string) "preserves url" url normalized
+    | Error err -> Alcotest.failf "expected valid GitHub URL %s: %s" url err
+  ) urls
+
+let test_validate_github_url_rejects_bad_hosts_and_paths () =
+  let urls = [
+    "https://github.example.com/tedks/discord-agents.git";
+    "https://github.com/tedks";
+    "https://github.com/tedks/discord-agents/extra";
+    "https://github.com/tedks/bad repo.git";
+    "git@example.com:tedks/discord-agents.git";
+  ] in
+  List.iter (fun url ->
+    match P.validate_github_url url with
+    | Ok _ -> Alcotest.failf "expected invalid GitHub URL: %s" url
+    | Error _ -> ()
+  ) urls
+
+let test_validate_import_name_rejects_path_traversal () =
+  List.iter (fun name ->
+    match P.validate_import_name name with
+    | Ok _ -> Alcotest.failf "expected invalid import name: %s" name
+    | Error _ -> ()
+  ) [""; "."; ".."; "../repo"; "owner/repo"; "bad repo"]
+
+let test_same_remote_url_normalizes_github_forms () =
+  Alcotest.(check bool) "https and ssh match"
+    true
+    (P.same_remote_url
+       "https://github.com/TedKS/Discord-Agents.git"
+       "git@github.com:tedks/discord-agents.git")
+
+let test_ensure_default_worktree_uses_symbolic_head () =
+  with_tmpdir (fun base ->
+    let src = Filename.concat base "src" in
+    let bare = Filename.concat base "bare" in
+    make_git_repo_with_commit src;
+    let run cmd =
+      let exit_code = Sys.command (Printf.sprintf "%s 2>/dev/null" cmd) in
+      if exit_code <> 0 then
+        Alcotest.failf "setup command failed (%d): %s" exit_code cmd
+    in
+    run (Printf.sprintf "git -C %s checkout -q -b release/v1"
+      (Filename.quote src));
+    run (Printf.sprintf "git clone --bare %s %s"
+      (Filename.quote src) (Filename.quote bare));
+    let project =
+      P.{ name = "bare"; path = bare; is_bare = true; remote_url = None }
+    in
+    Alcotest.(check string) "symbolic default branch"
+      "release/v1" (P.default_branch project);
+    match P.ensure_default_worktree project with
+    | Error err -> Alcotest.failf "ensure_default_worktree failed: %s" err
+    | Ok worktree_path ->
+      Alcotest.(check string) "sanitized path"
+        (Filename.concat bare "release-v1") worktree_path;
+      Alcotest.(check bool) "worktree exists"
+        true (Sys.file_exists worktree_path);
+      Alcotest.(check bool) "worktree registered"
+        true (List.mem ("release/v1", worktree_path) (P.list_worktrees project)))
+
 let discovery_tests = [
   Alcotest.test_case "flat repo" `Quick test_flat_repo;
   Alcotest.test_case "bare repo" `Quick test_bare_repo;
@@ -323,10 +392,22 @@ let discovery_tests = [
 let () =
   Alcotest.run "discord_project" [
     "discovery", discovery_tests;
+    "import validation", [
+      Alcotest.test_case "accepts supported GitHub URL forms" `Quick
+        test_validate_github_url_accepts_supported_forms;
+      Alcotest.test_case "rejects bad GitHub URLs" `Quick
+        test_validate_github_url_rejects_bad_hosts_and_paths;
+      Alcotest.test_case "rejects path traversal names" `Quick
+        test_validate_import_name_rejects_path_traversal;
+      Alcotest.test_case "normalizes GitHub remote forms" `Quick
+        test_same_remote_url_normalizes_github_forms;
+    ];
     "worktrees", [
       Alcotest.test_case "remove worktree deletes branch" `Quick
         test_remove_worktree_deletes_worktree_and_branch;
       Alcotest.test_case "remove missing worktree prunes registration" `Quick
         test_remove_worktree_prunes_missing_worktree_registration;
+      Alcotest.test_case "ensure default worktree follows symbolic HEAD" `Quick
+        test_ensure_default_worktree_uses_symbolic_head;
     ];
   ]


### PR DESCRIPTION
Closes https://github.com/tedks/discord-agents/issues/75

## Summary
- add GitHub URL/name validation and bare+default-worktree import support
- add `!import-project <url> [name]` and MCP `import_project`
- refresh project/channel state in-process and seed the project channel session without restart
- handle non-main/master default branches, remote-tracking defaults, and idempotent pre-clone discovery

## Open question decisions
- explicit command/tool call clones immediately; no separate approval UX
- rely on local git credentials; no token parameter
- no bot-managed marker; discovery under configured base directories remains source of truth

## Testing
- `nix develop --command dune build`
- `nix develop --command dune exec test/test_project.exe`
- `nix develop --command dune runtest`
- `python3 -m py_compile scripts/mcp-server.py`

## Council review
- Initial council: Claude + external Codex found default-worktree/default-branch issues; Gemini unavailable due non-interactive auth.
- Fixpoint: final convergence delta reviewed by Claude and external Codex: CLEAN.
