### PR TITLE
Add fork and reset context commands

### DIFF
--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1137,10 +1137,13 @@ let model_arg = function
   | _ -> []
 
 let claude_args ~model ~reasoning_effort
-    ~session_id ~message_count ~prompt =
+    ~session_id ~message_count ~fork_from_session_id ~prompt =
   let session_flag =
-    if message_count = 0 then ["--session-id"; session_id]
-    else ["--resume"; session_id]
+    match fork_from_session_id with
+    | Some fork_from -> ["--resume"; fork_from; "--fork-session"]
+    | None when message_count = 0 -> ["--session-id"; session_id]
+    | None ->
+      ["--resume"; session_id]
   in
   let effort_arg = match reasoning_effort with
     | Some effort ->
@@ -1545,8 +1548,9 @@ let compose_session_prompt ~agent_kind ~system_prompt ~message_count
     so the caller can track active subprocesses for cleanup.
     Returns when the process exits. *)
 let run_streaming ~sw ~env ~working_dir ~kind ~session_id ~message_count
-    ?(session_id_confirmed=true) ?system_prompt ?(model=None)
-    ?(reasoning_effort=None) ?(goal_context=None) ~prompt ~on_event ?on_pid () =
+    ?fork_from_session_id ?(session_id_confirmed=true) ?system_prompt
+    ?(model=None) ?(reasoning_effort=None) ?(goal_context=None)
+    ~prompt ~on_event ?on_pid () =
   let mgr = Eio.Stdenv.process_mgr env in
   let fs = Eio.Stdenv.fs env in
   let cwd = Eio.Path.(fs / working_dir) in
@@ -1562,7 +1566,8 @@ let run_streaming ~sw ~env ~working_dir ~kind ~session_id ~message_count
   let args = match kind with
     | Config.Claude ->
       let base = claude_args ~model ~reasoning_effort
-        ~session_id ~message_count ~prompt in
+          ~fork_from_session_id ~session_id ~message_count ~prompt
+      in
       let base = base @ ["--mcp-config"; claude_mcp_config_path ()] in
       (match system_prompt with
        | Some sp -> base @ ["--append-system-prompt"; sp]

--- a/lib/agent_runner.ml
+++ b/lib/agent_runner.ml
@@ -342,10 +342,10 @@ let run ~sw ~env ~rest ~session ~(channel_id : Discord_types.channel_id)
         last_edit := now
       end
     | Agent_process.Result { text = _; session_id } ->
-      (* Codex assigns session ids server-side (via thread.started);
-         forward any new id so the caller can persist it for resume.
-         Claude's final result also carries session_id but it matches
-         the pre-assigned value, so the callback is a no-op there. *)
+      (* Codex assigns session ids server-side (via thread.started), and
+         Claude native forks emit a new id from the result event. Forward any
+         id so the caller can persist it for resume and clear one-shot fork
+         state. *)
       (match session_id, on_session_id with
        | Some sid, Some cb -> cb sid
        | _ -> ());

--- a/lib/agent_runner.ml
+++ b/lib/agent_runner.ml
@@ -431,6 +431,7 @@ let run ~sw ~env ~rest ~session ~(channel_id : Discord_types.channel_id)
           ~working_dir:session.working_dir
           ~kind:session.agent_kind
           ~session_id:session.session_id
+          ?fork_from_session_id:session.fork_from_session_id
           ~session_id_confirmed:session.session_id_confirmed
           ~message_count:session.message_count
           ?system_prompt:session.system_prompt

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -864,6 +864,9 @@ let fresh_context_session t (session : Session_store.session) ~thread_id =
     ~session_id:(Resource.generate_uuid ())
     ~thread_id
     ~system_prompt:(refreshed_system_prompt t session)
+    ~model:session.model
+    ~reasoning_effort:session.reasoning_effort
+    ~goal:session.goal
     ~initial_prompt:None
     ()
 

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -844,6 +844,112 @@ let replacement_session_for_agent t (session : Session_store.session)
   } in
   replacement
 
+let session_busy_for_context_change (session : Session_store.session) =
+  session.processing
+  || not (Queue.is_empty session.pending_queue)
+  || Option.is_some session.active_run
+  || session.stop_requested
+
+let context_change_busy_message action =
+  Printf.sprintf
+    "Cannot %s while this session is running, stopping, or has queued messages. Stop or wait for it to finish first."
+    action
+
+let fresh_context_session t (session : Session_store.session) ~thread_id =
+  Session_store.make_session
+    ~project_name:session.project_name
+    ~working_dir:session.working_dir
+    ~agent_kind:session.agent_kind
+    ~session_override_kind:session.session_override_kind
+    ~session_id:(Resource.generate_uuid ())
+    ~thread_id
+    ~system_prompt:(refreshed_system_prompt t session)
+    ~initial_prompt:None
+    ()
+
+let thread_name_max = 80
+
+let truncate_for_thread_name s =
+  let s = Resource.single_line s |> String.trim in
+  let s = if s = "" then "session" else s in
+  if String.length s <= thread_name_max then s
+  else String.sub s 0 thread_name_max
+
+let fork_thread_name ~move ~base ~session_id =
+  let prefix = if move then "archive" else "fork" in
+  truncate_for_thread_name
+    (Printf.sprintf "%s %s %s" prefix base (Resource.short_id session_id))
+
+let thread_parent_for_context_command t ~channel_id
+    ~(session : Session_store.session) =
+  match Discord_rest.get_channel t.rest ~channel_id () with
+  | Error err ->
+    Error (Printf.sprintf "Could not inspect this channel: %s" err)
+  | Ok ch ->
+    let name = Option.value ch.Discord_types.name
+      ~default:session.project_name in
+    match ch.type_ with
+    | Discord_types.Guild_public_thread
+    | Discord_types.Guild_private_thread ->
+      (match ch.parent_id with
+       | Some parent_id -> Ok (parent_id, name)
+       | None -> Error "This thread has no parent channel.")
+    | _ ->
+      Ok (channel_id, name)
+
+let replace_session_map t sessions =
+  Session_store.replace_sessions_with t.sessions sessions
+
+let reset_session_context t (session : Session_store.session) =
+  let replacement =
+    fresh_context_session t session ~thread_id:session.thread_id
+  in
+  try
+    Session_store.add t.sessions ~thread_id:session.thread_id replacement;
+    Hashtbl.remove t.scroll_states session.thread_id;
+    Ok replacement
+  with exn ->
+    Error (Printexc.to_string exn)
+
+let move_session_context_to_thread t (session : Session_store.session)
+    ~archive_thread_id =
+  let archived_session = {
+    session with
+    thread_id = archive_thread_id;
+    processing = false;
+    pending_queue = Queue.create ();
+    child_pid = None;
+  } in
+  let fresh_session =
+    fresh_context_session t session ~thread_id:session.thread_id
+  in
+  let sessions =
+    t.sessions.sessions
+    |> Session_store.SessionMap.remove session.thread_id
+    |> Session_store.SessionMap.add archive_thread_id archived_session
+    |> Session_store.SessionMap.add session.thread_id fresh_session
+  in
+  match replace_session_map t sessions with
+  | Error err -> Error err
+  | Ok () ->
+    (match Hashtbl.find_opt t.scroll_states session.thread_id with
+     | Some state ->
+       Hashtbl.replace t.scroll_states archive_thread_id state;
+       Hashtbl.remove t.scroll_states session.thread_id
+     | None -> ());
+    Ok fresh_session
+
+let fork_session_context_to_thread t (session : Session_store.session)
+    ~fork_thread_id =
+  let forked_session =
+    fresh_context_session t session ~thread_id:fork_thread_id
+  in
+  try
+    Session_store.add t.sessions ~thread_id:fork_thread_id forked_session;
+    Ok forked_session
+  with exn ->
+    Error (Printexc.to_string exn)
+
 let align_persistent_sessions_to_agent
     ?(replacement_session=replacement_session_for_agent)
     t ~current_channel_id ~new_agent =
@@ -1784,6 +1890,80 @@ let handle_command t msg cmd =
     reply_stop_outcome reply (stop_session t ~thread_id)
   | Command.Interrupt_session ->
     reply_stop_outcome reply (stop_session t ~thread_id:channel_id)
+  | Command.Reset_session ->
+    (match Session_store.find_opt t.sessions ~thread_id:channel_id with
+     | None ->
+       reply "No session exists in this channel."
+     | Some session when session_busy_for_context_change session ->
+       reply (context_change_busy_message "reset context")
+     | Some session ->
+       (match reset_session_context t session with
+        | Ok replacement ->
+          reply (Printf.sprintf
+            "Context reset. Fresh `%s` session `%s` will be used for the next message."
+            (Config.string_of_agent_kind replacement.agent_kind)
+            (Resource.short_id replacement.session_id))
+        | Error err ->
+          reply (Printf.sprintf "Failed to reset context: %s" err)))
+  | Command.Fork_session { move } ->
+    (match Session_store.find_opt t.sessions ~thread_id:channel_id with
+     | None ->
+       reply "No session exists in this channel."
+     | Some session when session_busy_for_context_change session ->
+       reply (context_change_busy_message "fork context")
+     | Some session ->
+       let move =
+         Option.value move ~default:(is_persistent_channel t ~channel_id)
+       in
+       (match thread_parent_for_context_command t ~channel_id ~session with
+        | Error err -> reply err
+        | Ok (thread_parent, base_name) ->
+          let thread_name =
+            fork_thread_name ~move ~base:base_name
+              ~session_id:session.session_id
+          in
+          (match Discord_rest.create_thread_no_message t.rest
+                  ~channel_id:thread_parent ~name:thread_name () with
+           | Error err ->
+             reply (Printf.sprintf "Failed to create fork thread: %s" err)
+           | Ok thread_ch ->
+             let thread_id = thread_ch.Discord_types.id in
+             if move then
+               (match move_session_context_to_thread t session
+                        ~archive_thread_id:thread_id with
+                | Error err ->
+                  cleanup_orphan_thread t ~thread_id
+                    ~context:"fork move persistence failure";
+                  reply (Printf.sprintf "Failed to persist forked context: %s" err)
+                | Ok fresh_session ->
+                  ignore (Discord_rest.create_message t.rest
+                    ~channel_id:thread_id
+                    ~content:(Printf.sprintf
+                      "Archived context from <#%s>.\nSession `%s` continues here."
+                      channel_id (Resource.short_id session.session_id)) ());
+                  reply (Printf.sprintf
+                    "Moved context to <#%s>. This channel now has fresh `%s` session `%s`."
+                    thread_id
+                    (Config.string_of_agent_kind fresh_session.agent_kind)
+                    (Resource.short_id fresh_session.session_id)))
+             else
+               (match fork_session_context_to_thread t session
+                        ~fork_thread_id:thread_id with
+                | Error err ->
+                  cleanup_orphan_thread t ~thread_id
+                    ~context:"fork persistence failure";
+                  reply (Printf.sprintf "Failed to persist forked session: %s" err)
+                | Ok forked_session ->
+                  ignore (Discord_rest.create_message t.rest
+                    ~channel_id:thread_id
+                    ~content:(Printf.sprintf
+                      "Forked from <#%s>.\nFresh `%s` session `%s` is ready here."
+                      channel_id
+                      (Config.string_of_agent_kind forked_session.agent_kind)
+                      (Resource.short_id forked_session.session_id)) ());
+                  reply (Printf.sprintf
+                    "Fork created: <#%s>. The current session remains unchanged."
+                    thread_id)))))
   | Command.Default_agent None ->
     refresh_disk_state ();
     let base = Printf.sprintf "Default agent: `%s`."
@@ -2129,6 +2309,8 @@ let handle_command t msg cmd =
       "`!rescue-agent [agent|off]` / `!rescue_agent [agent|off]` — show or set the rescue agent used under disk pressure";
       "`!session-agent [agent]` / `!session_agent [agent]` — show or set the current channel session agent";
       "`!resume [agent] <session_id>` — resume a session (no agent = try the current effective top-level agent first)";
+      "`!fork [--move|--no-move]` — create a new thread for context management";
+      "`!reset` — clear this channel's session context";
       "`!stop <thread_id>` — stop a session";
       "`!esc` / `!int` / `!interrupt` — stop this thread's active session";
       "`!rename [thread_id] <name>` — rename a thread";

--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -870,10 +870,13 @@ let fresh_context_session t (session : Session_store.session) ~thread_id =
 let thread_name_max = 80
 
 let truncate_for_thread_name s =
-  let s = Resource.single_line s |> String.trim in
+  let s =
+    Resource.single_line s
+    |> Resource.sanitize_utf8
+    |> String.trim
+  in
   let s = if s = "" then "session" else s in
-  if String.length s <= thread_name_max then s
-  else String.sub s 0 thread_name_max
+  Resource.truncate_utf8 ~max_bytes:thread_name_max s
 
 let fork_thread_name ~move ~base ~session_id =
   let prefix = if move then "archive" else "fork" in
@@ -941,8 +944,17 @@ let move_session_context_to_thread t (session : Session_store.session)
 
 let fork_session_context_to_thread t (session : Session_store.session)
     ~fork_thread_id =
+  let fork_from_session_id =
+    match session.agent_kind with
+    | Config.Claude -> Some session.session_id
+    | Config.Codex
+    | Config.Gemini -> None
+  in
   let forked_session =
-    fresh_context_session t session ~thread_id:fork_thread_id
+    {
+      (fresh_context_session t session ~thread_id:fork_thread_id) with
+      fork_from_session_id;
+    }
   in
   try
     Session_store.add t.sessions ~thread_id:fork_thread_id forked_session;
@@ -1954,13 +1966,24 @@ let handle_command t msg cmd =
                     ~context:"fork persistence failure";
                   reply (Printf.sprintf "Failed to persist forked session: %s" err)
                 | Ok forked_session ->
+                  let thread_content =
+                    match forked_session.fork_from_session_id with
+                    | Some source_id ->
+                      Printf.sprintf
+                        "Forked from <#%s>.\nNative `%s` fork from session `%s` will be created on the first message here."
+                        channel_id
+                        (Config.string_of_agent_kind forked_session.agent_kind)
+                        (Resource.short_id source_id)
+                    | None ->
+                      Printf.sprintf
+                        "Forked from <#%s>.\nFresh `%s` session `%s` is ready here."
+                        channel_id
+                        (Config.string_of_agent_kind forked_session.agent_kind)
+                        (Resource.short_id forked_session.session_id)
+                  in
                   ignore (Discord_rest.create_message t.rest
                     ~channel_id:thread_id
-                    ~content:(Printf.sprintf
-                      "Forked from <#%s>.\nFresh `%s` session `%s` is ready here."
-                      channel_id
-                      (Config.string_of_agent_kind forked_session.agent_kind)
-                      (Resource.short_id forked_session.session_id)) ());
+                    ~content:thread_content ());
                   reply (Printf.sprintf
                     "Fork created: <#%s>. The current session remains unchanged."
                     thread_id)))))

--- a/lib/command.ml
+++ b/lib/command.ml
@@ -12,6 +12,9 @@ type t =
   | Start_agent of { project : string; kind : Config.agent_kind option }
   (** [kind = None] means use the current effective top-level agent. *)
   | Resume_session of { session_id : string; kind : Config.agent_kind option }
+  | Fork_session of { move : bool option }
+  (** [move = None] means the handler applies the channel-specific default. *)
+  | Reset_session
   | Stop_session of { thread_id : string }
   | Interrupt_session
   | Cleanup_channels
@@ -61,6 +64,10 @@ let parse content =
     (match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with
      | Ok k -> Resume_session { session_id; kind = Some k }
      | Error _ -> Unknown content)
+  | ["fork"] -> Fork_session { move = None }
+  | ["fork"; "--move"] -> Fork_session { move = Some true }
+  | ["fork"; "--no-move"] -> Fork_session { move = Some false }
+  | ["reset"] -> Reset_session
   | ["default-agent"] | ["default_agent"] -> Default_agent None
   | ["default-agent"; kind_str] | ["default_agent"; kind_str] ->
     (match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with

--- a/lib/session_store.ml
+++ b/lib/session_store.ml
@@ -159,6 +159,11 @@ type session = {
      [init]). Claude accepts a caller-supplied id, so its value
      never changes after creation. See [Config.caller_pinned_session_id]. *)
   mutable session_id : string;
+  (* One-shot native fork source. For Claude, the next run resumes
+     this session id with --fork-session and captures the new emitted
+     id through [set_session_id]. None for normal fresh/resumed runs
+     and for agents without a non-interactive fork path. *)
+  mutable fork_from_session_id : string option;
   (* True once the agent has acknowledged [session_id] as resumable.
      Always true for Claude (caller-supplied ids). For Codex and
      Gemini, starts false and flips true when the first server-side
@@ -211,6 +216,9 @@ let sessions_to_json sessions =
          | Some kind ->
            [("session_override_kind",
              `String (Config.string_of_agent_kind kind))]
+         | None -> [])
+      @ (match s.fork_from_session_id with
+         | Some sid -> [("fork_from_session_id", `String sid)]
          | None -> [])
       @ (match s.system_prompt with
          | Some sp -> [("system_prompt", `String sp)]
@@ -308,6 +316,8 @@ let sessions_of_json json =
             | Error _ -> None)
          | _ -> None);
       session_id = j |> member "session_id" |> to_string;
+      fork_from_session_id =
+        j |> member "fork_from_session_id" |> to_string_option;
       session_id_confirmed;
       thread_id;
       system_prompt = j |> member "system_prompt" |> to_string_option;
@@ -487,13 +497,15 @@ let make_session ~project_name ~working_dir ~agent_kind ~session_id
     ?(goal = None)
     ?(pending_agent_change = None)
     ?(active_run = None)
+    ?fork_from_session_id
     ?session_id_confirmed () =
   let session_id_confirmed = match session_id_confirmed with
     | Some b -> b
     | None -> Config.caller_pinned_session_id agent_kind
   in
   { project_name; working_dir; agent_kind; session_override_kind; session_id;
-    session_id_confirmed; thread_id; system_prompt; model; reasoning_effort; goal;
+    fork_from_session_id; session_id_confirmed; thread_id; system_prompt;
+    model; reasoning_effort; goal;
     message_count; processing = false;
     pending_queue = Queue.create (); pending_agent_change; initial_prompt;
     active_run; child_pid = None; stop_requested = false }
@@ -640,12 +652,15 @@ let set_session_id t session ~session_id =
   if not already then begin
     let prior_id = session.session_id in
     let prior_confirmed = session.session_id_confirmed in
+    let prior_fork_from = session.fork_from_session_id in
     session.session_id <- session_id;
     session.session_id_confirmed <- true;
+    session.fork_from_session_id <- None;
     match persist_or_rollback
             (fun () ->
               session.session_id <- prior_id;
-              session.session_id_confirmed <- prior_confirmed)
+              session.session_id_confirmed <- prior_confirmed;
+              session.fork_from_session_id <- prior_fork_from)
             (fun () -> save t) with
     | Ok () -> ()
     | Error err -> failwith err

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -194,6 +194,90 @@ let find_session bot thread_id =
   | Some session -> session
   | None -> Alcotest.failf "expected session %s" thread_id
 
+let test_reset_session_context_replaces_current_session () =
+  with_test_bot (fun bot ->
+    let session =
+      make_session Discord_agents.Config.Codex
+    in
+    session.message_count <- 4;
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    let original_session_id = session.session_id in
+    match Discord_agents.Bot.reset_session_context bot session with
+    | Error err -> Alcotest.failf "reset_session_context failed: %s" err
+    | Ok replacement ->
+      let saved = find_control_session bot in
+      Alcotest.(check string) "returned session is persisted"
+        replacement.session_id saved.session_id;
+      Alcotest.(check bool) "fresh session id allocated"
+        true (saved.session_id <> original_session_id);
+      Alcotest.(check int) "message count reset" 0 saved.message_count;
+      Alcotest.(check string) "agent preserved"
+        "codex" (kind_string saved.agent_kind);
+      Alcotest.(check bool) "server-allocated id starts unconfirmed"
+        false saved.session_id_confirmed)
+
+let test_move_session_context_to_thread_archives_old_session () =
+  with_test_bot (fun bot ->
+    let session = make_session Discord_agents.Config.Claude in
+    session.message_count <- 7;
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    let original_session_id = session.session_id in
+    let block : Discord_agents.Bot.output_block = {
+      lines = [| "old output" |];
+      output_lines_used = 1;
+      next_line = 1;
+    } in
+    let scroll_state : Discord_agents.Bot.scroll_state = {
+      blocks = [block];
+      current_block = 1;
+    } in
+    Hashtbl.replace bot.scroll_states "control" scroll_state;
+    match Discord_agents.Bot.move_session_context_to_thread bot session
+            ~archive_thread_id:"archive-thread" with
+    | Error err -> Alcotest.failf "move_session_context_to_thread failed: %s" err
+    | Ok fresh ->
+      let archived = find_session bot "archive-thread" in
+      let current = find_control_session bot in
+      Alcotest.(check string) "old session id moved"
+        original_session_id archived.session_id;
+      Alcotest.(check int) "old message count moved"
+        7 archived.message_count;
+      Alcotest.(check string) "fresh session persisted"
+        fresh.session_id current.session_id;
+      Alcotest.(check bool) "current got fresh id"
+        true (current.session_id <> original_session_id);
+      Alcotest.(check int) "current message count reset"
+        0 current.message_count;
+      Alcotest.(check bool) "scroll state moved"
+        true (Option.is_some (Hashtbl.find_opt bot.scroll_states "archive-thread"));
+      Alcotest.(check bool) "current scroll state cleared"
+        true (Option.is_none (Hashtbl.find_opt bot.scroll_states "control")))
+
+let test_fork_session_context_to_thread_keeps_current_session () =
+  with_test_bot (fun bot ->
+    let session = make_session Discord_agents.Config.Gemini in
+    session.message_count <- 3;
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    let original_session_id = session.session_id in
+    match Discord_agents.Bot.fork_session_context_to_thread bot session
+            ~fork_thread_id:"fork-thread" with
+    | Error err -> Alcotest.failf "fork_session_context_to_thread failed: %s" err
+    | Ok forked ->
+      let current = find_control_session bot in
+      let saved_fork = find_session bot "fork-thread" in
+      Alcotest.(check string) "current session id unchanged"
+        original_session_id current.session_id;
+      Alcotest.(check int) "current message count unchanged"
+        3 current.message_count;
+      Alcotest.(check string) "forked session persisted"
+        forked.session_id saved_fork.session_id;
+      Alcotest.(check bool) "fork got fresh id"
+        true (saved_fork.session_id <> original_session_id);
+      Alcotest.(check int) "fork message count starts fresh"
+        0 saved_fork.message_count;
+      Alcotest.(check bool) "Gemini fork starts unconfirmed"
+        false saved_fork.session_id_confirmed)
+
 let test_set_default_agent_defers_busy_control_session () =
   with_test_bot (fun bot ->
     let session = make_session ~processing:true Discord_agents.Config.Claude in
@@ -1504,6 +1588,12 @@ let () =
         test_apply_pending_same_kind_session_override_pins_existing_session;
       Alcotest.test_case "busy pending change stays pending" `Quick
         test_apply_pending_busy_session_leaves_pending_intact;
+      Alcotest.test_case "reset context replaces current session" `Quick
+        test_reset_session_context_replaces_current_session;
+      Alcotest.test_case "move fork archives old session" `Quick
+        test_move_session_context_to_thread_archives_old_session;
+      Alcotest.test_case "no-move fork keeps current session" `Quick
+        test_fork_session_context_to_thread_keeps_current_session;
       Alcotest.test_case "default rotation rechecks policy after pressure clears" `Quick
         test_finalize_pending_default_rotation_uses_current_policy_after_pressure_clears;
       Alcotest.test_case "default rotation rechecks active rescue policy" `Quick

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -255,7 +255,7 @@ let test_move_session_context_to_thread_archives_old_session () =
 
 let test_fork_session_context_to_thread_keeps_current_session () =
   with_test_bot (fun bot ->
-    let session = make_session Discord_agents.Config.Gemini in
+    let session = make_session Discord_agents.Config.Claude in
     session.message_count <- 3;
     Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
     let original_session_id = session.session_id in
@@ -275,8 +275,37 @@ let test_fork_session_context_to_thread_keeps_current_session () =
         true (saved_fork.session_id <> original_session_id);
       Alcotest.(check int) "fork message count starts fresh"
         0 saved_fork.message_count;
+      Alcotest.(check (option string)) "Claude fork resumes source once"
+        (Some original_session_id) saved_fork.fork_from_session_id)
+
+let test_fork_session_context_to_thread_fresh_for_gemini () =
+  with_test_bot (fun bot ->
+    let session = make_session Discord_agents.Config.Gemini in
+    Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
+    let original_session_id = session.session_id in
+    match Discord_agents.Bot.fork_session_context_to_thread bot session
+            ~fork_thread_id:"fork-thread" with
+    | Error err -> Alcotest.failf "fork_session_context_to_thread failed: %s" err
+    | Ok _forked ->
+      let saved_fork = find_session bot "fork-thread" in
+      Alcotest.(check bool) "fork got fresh id"
+        true (saved_fork.session_id <> original_session_id);
+      Alcotest.(check (option string)) "Gemini has no native fork source"
+        None saved_fork.fork_from_session_id;
       Alcotest.(check bool) "Gemini fork starts unconfirmed"
         false saved_fork.session_id_confirmed)
+
+let test_fork_thread_name_truncates_utf8_safely () =
+  let name =
+    Discord_agents.Bot.fork_thread_name
+      ~move:false
+      ~base:(String.make 79 'a' ^ "\xF0\x9F\x98\x80")
+      ~session_id:"12345678-1234-1234-1234-123456789abc"
+  in
+  Alcotest.(check bool) "thread name under Discord limit"
+    true (String.length name <= 80);
+  Alcotest.(check string) "thread name remains valid UTF-8"
+    name (Discord_agents.Resource.sanitize_utf8 name)
 
 let test_set_default_agent_defers_busy_control_session () =
   with_test_bot (fun bot ->
@@ -1594,6 +1623,10 @@ let () =
         test_move_session_context_to_thread_archives_old_session;
       Alcotest.test_case "no-move fork keeps current session" `Quick
         test_fork_session_context_to_thread_keeps_current_session;
+      Alcotest.test_case "Gemini no-move fork uses fresh fallback" `Quick
+        test_fork_session_context_to_thread_fresh_for_gemini;
+      Alcotest.test_case "fork thread name truncates UTF-8 safely" `Quick
+        test_fork_thread_name_truncates_utf8_safely;
       Alcotest.test_case "default rotation rechecks policy after pressure clears" `Quick
         test_finalize_pending_default_rotation_uses_current_policy_after_pressure_clears;
       Alcotest.test_case "default rotation rechecks active rescue policy" `Quick

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -194,12 +194,34 @@ let find_session bot thread_id =
   | Some session -> session
   | None -> Alcotest.failf "expected session %s" thread_id
 
+let configure_session session =
+  session.Discord_agents.Session_store.model <- Some "review-model";
+  session.reasoning_effort <- Some Discord_agents.Config.Xhigh;
+  session.goal <- Some {
+    Discord_agents.Session_store.objective = "Keep focused";
+    status = Discord_agents.Session_store.Goal_active;
+    token_budget = Some 1234;
+  }
+
+let check_config_preserved session =
+  Alcotest.(check (option string)) "model preserved"
+    (Some "review-model") session.Discord_agents.Session_store.model;
+  Alcotest.(check (option string)) "effort preserved"
+    (Some "xhigh")
+    (Option.map Discord_agents.Config.string_of_reasoning_effort
+       session.reasoning_effort);
+  Alcotest.(check (option string)) "goal preserved"
+    (Some "Keep focused")
+    (Option.map (fun goal -> goal.Discord_agents.Session_store.objective)
+       session.goal)
+
 let test_reset_session_context_replaces_current_session () =
   with_test_bot (fun bot ->
     let session =
       make_session Discord_agents.Config.Codex
     in
     session.message_count <- 4;
+    configure_session session;
     Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
     let original_session_id = session.session_id in
     match Discord_agents.Bot.reset_session_context bot session with
@@ -214,7 +236,8 @@ let test_reset_session_context_replaces_current_session () =
       Alcotest.(check string) "agent preserved"
         "codex" (kind_string saved.agent_kind);
       Alcotest.(check bool) "server-allocated id starts unconfirmed"
-        false saved.session_id_confirmed)
+        false saved.session_id_confirmed;
+      check_config_preserved saved)
 
 let test_move_session_context_to_thread_archives_old_session () =
   with_test_bot (fun bot ->
@@ -257,6 +280,7 @@ let test_fork_session_context_to_thread_keeps_current_session () =
   with_test_bot (fun bot ->
     let session = make_session Discord_agents.Config.Claude in
     session.message_count <- 3;
+    configure_session session;
     Discord_agents.Session_store.add bot.sessions ~thread_id:"control" session;
     let original_session_id = session.session_id in
     match Discord_agents.Bot.fork_session_context_to_thread bot session
@@ -276,7 +300,8 @@ let test_fork_session_context_to_thread_keeps_current_session () =
       Alcotest.(check int) "fork message count starts fresh"
         0 saved_fork.message_count;
       Alcotest.(check (option string)) "Claude fork resumes source once"
-        (Some original_session_id) saved_fork.fork_from_session_id)
+        (Some original_session_id) saved_fork.fork_from_session_id;
+      check_config_preserved saved_fork)
 
 let test_fork_session_context_to_thread_fresh_for_gemini () =
   with_test_bot (fun bot ->

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -1710,6 +1710,36 @@ let test_make_session_default_claude_confirmed () =
     "Claude default is confirmed (--session-id pins it)"
     true s.session_id_confirmed
 
+let test_fork_from_session_id_roundtrip_and_set_session_id_clears () =
+  let session = Discord_agents.Session_store.make_session
+    ~project_name:"foo" ~working_dir:"/tmp/foo"
+    ~agent_kind:Discord_agents.Config.Claude
+    ~session_id:"placeholder-new-session"
+    ~fork_from_session_id:"source-session"
+    ~thread_id:"123" ~system_prompt:None ~initial_prompt:None ()
+  in
+  let map =
+    Discord_agents.Session_store.SessionMap.empty
+    |> Discord_agents.Session_store.SessionMap.add "123" session
+  in
+  let reparsed =
+    Discord_agents.Session_store.sessions_to_json map
+    |> Discord_agents.Session_store.sessions_of_json
+  in
+  let store = { Discord_agents.Session_store.sessions = reparsed;
+                last_reload = 0.0 } in
+  match Discord_agents.Session_store.SessionMap.bindings reparsed with
+  | [(_, s)] ->
+    Alcotest.(check (option string)) "fork source survives roundtrip"
+      (Some "source-session") s.fork_from_session_id;
+    Discord_agents.Session_store.set_session_id store s
+      ~session_id:"native-fork-result";
+    Alcotest.(check string) "new session id stored"
+      "native-fork-result" s.session_id;
+    Alcotest.(check (option string)) "fork source cleared"
+      None s.fork_from_session_id
+  | _ -> Alcotest.fail "expected exactly one session"
+
 let test_pending_agent_kind_roundtrip () =
   let session = Discord_agents.Session_store.make_session
     ~project_name:"foo" ~working_dir:"/tmp/foo"
@@ -1840,6 +1870,8 @@ let session_store_tests = [
     test_make_session_default_gemini_unconfirmed;
   Alcotest.test_case "fresh Claude default confirmed" `Quick
     test_make_session_default_claude_confirmed;
+  Alcotest.test_case "fork source roundtrip and clear" `Quick
+    test_fork_from_session_id_roundtrip_and_set_session_id_clears;
   Alcotest.test_case "pending agent kind roundtrip" `Quick
     test_pending_agent_kind_roundtrip;
   Alcotest.test_case "legacy pending agent defaults to default rotation" `Quick
@@ -2092,6 +2124,7 @@ let test_context_header_truncates_utf8_boundary () =
     agent_kind = Discord_agents.Config.Claude;
     session_override_kind = None;
     session_id = "sid";
+    fork_from_session_id = None;
     session_id_confirmed = true;
     thread_id = "thread";
     system_prompt = None;
@@ -2696,6 +2729,44 @@ let resume_helpers_tests = [
     test_format_session_listing_strips_newlines_in_wd;
 ]
 
+(* ── claude_args ───────────────────────────────────────────────────── *)
+
+let claude_args = Discord_agents.Agent_process.claude_args
+
+let test_claude_args_fresh () =
+  let args = claude_args ~session_id:"new-id"
+    ~message_count:0 ~fork_from_session_id:None
+    ~model:None ~reasoning_effort:None ~prompt:"hello" in
+  Alcotest.(check (list string)) "fresh pins caller id"
+    ["claude"; "-p"; "--verbose"; "--output-format"; "stream-json";
+     "--session-id"; "new-id"; "hello"]
+    args
+
+let test_claude_args_resume () =
+  let args = claude_args ~session_id:"existing-id"
+    ~message_count:2 ~fork_from_session_id:None
+    ~model:None ~reasoning_effort:None ~prompt:"continue" in
+  Alcotest.(check (list string)) "resume existing id"
+    ["claude"; "-p"; "--verbose"; "--output-format"; "stream-json";
+     "--resume"; "existing-id"; "continue"]
+    args
+
+let test_claude_args_native_fork () =
+  let args = claude_args ~fork_from_session_id:(Some "source-id")
+    ~session_id:"placeholder-new-id" ~message_count:0
+    ~model:None ~reasoning_effort:None ~prompt:"fork turn" in
+  Alcotest.(check (list string)) "fork resumes source with --fork-session"
+    ["claude"; "-p"; "--verbose"; "--output-format"; "stream-json";
+     "--resume"; "source-id"; "--fork-session"; "fork turn"]
+    args
+
+let claude_args_tests = [
+  Alcotest.test_case "fresh invocation args" `Quick test_claude_args_fresh;
+  Alcotest.test_case "resume invocation args" `Quick test_claude_args_resume;
+  Alcotest.test_case "native fork invocation args" `Quick
+    test_claude_args_native_fork;
+]
+
 (* ── codex_args ────────────────────────────────────────────────────── *)
 
 let codex_args ~session_id ~session_id_confirmed ~prompt =
@@ -3145,6 +3216,7 @@ let () =
     "escape_nested_fences", escape_nested_fences_tests;
     "codex_json", codex_json_tests;
     "codex_safety", codex_safety_tests;
+    "claude_args", claude_args_tests;
     "codex_args", codex_args_tests;
     "prompt_helpers", prompt_helpers_tests;
     "gemini_json", gemini_json_tests;

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -676,6 +676,10 @@ let cmd_testable =
       | Resume_session { session_id; kind = Some k } ->
         Printf.sprintf "Resume_session(%s,%s)"
           (Discord_agents.Config.string_of_agent_kind k) session_id
+      | Fork_session { move = None } -> "Fork_session(default)"
+      | Fork_session { move = Some true } -> "Fork_session(move)"
+      | Fork_session { move = Some false } -> "Fork_session(no_move)"
+      | Reset_session -> "Reset_session"
       | Stop_session { thread_id } -> "Stop_session(" ^ thread_id ^ ")"
       | Interrupt_session -> "Interrupt_session"
       | Cleanup_channels -> "Cleanup_channels"
@@ -825,6 +829,38 @@ let test_parse_resume_invalid_kind () =
     Alcotest.(check pass) "invalid kind is Unknown" () ()
   | _ -> Alcotest.fail "expected Unknown for invalid agent kind"
 
+let test_parse_fork_default () =
+  Alcotest.(check cmd_testable) "fork default"
+    (Discord_agents.Command.Fork_session { move = None })
+    (Discord_agents.Command.parse "!fork")
+
+let test_parse_fork_move () =
+  Alcotest.(check cmd_testable) "fork --move"
+    (Discord_agents.Command.Fork_session { move = Some true })
+    (Discord_agents.Command.parse "!fork --move")
+
+let test_parse_fork_no_move () =
+  Alcotest.(check cmd_testable) "fork --no-move"
+    (Discord_agents.Command.Fork_session { move = Some false })
+    (Discord_agents.Command.parse "!fork --no-move")
+
+let test_parse_fork_rejects_extra_args () =
+  match Discord_agents.Command.parse "!fork --move --no-move" with
+  | Discord_agents.Command.Unknown _ ->
+    Alcotest.(check pass) "fork with extra args is Unknown" () ()
+  | _ -> Alcotest.fail "expected Unknown for fork extra args"
+
+let test_parse_reset () =
+  Alcotest.(check cmd_testable) "reset"
+    Discord_agents.Command.Reset_session
+    (Discord_agents.Command.parse "!reset")
+
+let test_parse_reset_rejects_args () =
+  match Discord_agents.Command.parse "!reset now" with
+  | Discord_agents.Command.Unknown _ ->
+    Alcotest.(check pass) "reset with args is Unknown" () ()
+  | _ -> Alcotest.fail "expected Unknown for reset args"
+
 let test_parse_codex_sessions () =
   Alcotest.(check cmd_testable) "codex-sessions"
     Discord_agents.Command.List_codex_sessions
@@ -966,6 +1002,12 @@ let command_tests = [
   Alcotest.test_case "resume with gemini kind" `Quick test_parse_resume_with_gemini_kind;
   Alcotest.test_case "resume with claude kind" `Quick test_parse_resume_with_claude_kind;
   Alcotest.test_case "resume invalid kind" `Quick test_parse_resume_invalid_kind;
+  Alcotest.test_case "fork default" `Quick test_parse_fork_default;
+  Alcotest.test_case "fork move" `Quick test_parse_fork_move;
+  Alcotest.test_case "fork no-move" `Quick test_parse_fork_no_move;
+  Alcotest.test_case "fork rejects extra args" `Quick test_parse_fork_rejects_extra_args;
+  Alcotest.test_case "reset" `Quick test_parse_reset;
+  Alcotest.test_case "reset rejects args" `Quick test_parse_reset_rejects_args;
   Alcotest.test_case "codex-sessions" `Quick test_parse_codex_sessions;
   Alcotest.test_case "gemini-sessions" `Quick test_parse_gemini_sessions;
   Alcotest.test_case "resume with codex kind" `Quick test_parse_resume_with_codex_kind;


### PR DESCRIPTION
## Summary

Adds `!fork [--move|--no-move]` and `!reset` context-management commands for Discord agent sessions.

Implementation decisions from issue #82:

- `!fork --move` creates an archive thread, moves the existing persisted session record there, and resets the invoking channel to a fresh session.
- `!fork --no-move` creates a new thread while leaving the current thread/session untouched.
- Claude no-move forks use the native `--resume <source> --fork-session` path on first message and persist the emitted fork session ID.
- Codex/Gemini no-move forks use fresh session records because the bot's non-interactive runner does not expose a safe native fork path for them today.
- `!reset` replaces the current session with a fresh session ID and clears scroll state.
- Busy, stopping, active-run, or queued sessions refuse fork/reset so persisted context cannot diverge from an in-flight agent process.
- Thread names are auto-generated from the current channel/thread name plus the short session ID and truncated on UTF-8 boundaries.

Agent CLI investigation:

- Claude Code help exposes `--fork-session` for resumed sessions.
- Codex help exposes `codex fork [SESSION_ID]`, but `codex exec --json` only exposes `resume` in the non-interactive path this bot uses.
- Gemini help exposes `--resume`/`--session-id` but no fork command.

Codex/Gemini native fork follow-up is tracked in #84.

## Validation

- `nix develop --command dune build`
- `nix develop --command dune runtest`

## Council Review

Initial native review found two Important issues and both were fixed:

- no-move fork did not preserve context for Claude despite native CLI support
- fork thread-name truncation could split UTF-8 mid-codepoint

Convergence review on the fix delta was clean from native review. Gemini was unavailable due local non-interactive auth. Claude review attempts hung without producing output and were stopped.

Closes #82.
