### PR TITLE
Validate config schema explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cat > ~/.config/discord-agents/config.json << 'EOF'
 {
   "discord_token": "your-bot-token",
   "guild_id": "your-server-id",
-  "base_dirs": ["~/Projects"]
+  "base_directories": ["~/Projects"]
 }
 EOF
 
@@ -40,6 +40,13 @@ Then in Discord:
 Or just chat in any project channel -- the agent will respond directly.
 
 See [SETUP.md](SETUP.md) for detailed installation and Discord bot setup instructions.
+
+`config.json` is validated at startup. The required fields are
+`discord_token` (or `DISCORD_BOT_TOKEN`) and `guild_id`; optional
+fields default to `base_directories: []`, `control_channel_id: null`,
+and `projects: []`. The older `base_dirs` key is still accepted as an
+alias, but new configs should use `base_directories`. See
+[`config.example.json`](config.example.json).
 
 ## Commands
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -58,13 +58,13 @@ Create `~/.config/discord-agents/config.json`:
 {
   "discord_token": "your-bot-token-from-step-3",
   "guild_id": "your-server-id-from-step-4",
-  "base_dirs": ["~/Projects"]
+  "base_directories": ["~/Projects"]
 }
 ```
 
 - `discord_token` -- The bot token from step 3. Alternatively, set the `DISCORD_BOT_TOKEN` environment variable.
 - `guild_id` -- Your Discord server ID from step 4.
-- `base_dirs` -- List of directories to scan for git repos. Each repo becomes a project channel.
+- `base_directories` -- List of directories to scan for git repos. Each repo becomes a project channel. `base_dirs` is accepted as a legacy alias.
 - `control_channel_id` (optional) -- A specific channel ID for the control channel. If omitted, the bot creates one.
 
 ## 6. Build and run
@@ -78,7 +78,7 @@ nix develop --command dune exec discord-agents
 The bot will:
 1. Connect to Discord
 2. Create an "Agent Projects" category if it doesn't exist
-3. Scan your `base_dirs` for git repos and create a channel for each
+3. Scan your `base_directories` for git repos and create a channel for each
 4. Set up a control channel with a Claude session
 
 ### Smoke test

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -130,11 +130,13 @@ let () =
   let _lock_fd = if not test_mode then Some (acquire_pidfile ()) else None in
   Random.self_init ();  (* Seed PRNG for heartbeat jitter *)
   let config = Discord_agents.Config.load () in
-  if config.discord_token = "" then (
-    Logs.err (fun m -> m "no discord token configured");
-    Logs.err (fun m -> m "set discord_token in %s" (Discord_agents.Config.config_path ()));
-    exit 1
-  );
+  (match Discord_agents.Config.validate
+           ~require_guild_id:(not test_mode) config with
+   | Ok () -> ()
+   | Error errors ->
+     List.iter (fun err -> Logs.err (fun m -> m "config: %s" err)) errors;
+     Logs.err (fun m -> m "update %s" (Discord_agents.Config.config_path ()));
+     exit 1);
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   if test_mode then

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -126,17 +126,25 @@ let () =
     | _ -> None
   in
   Logs.info (fun m -> m "discord-agents starting%s" (if test_mode then " (test mode)" else ""));
-  (* Acquire pidfile lock — keeps fd open for process lifetime *)
-  let _lock_fd = if not test_mode then Some (acquire_pidfile ()) else None in
   Random.self_init ();  (* Seed PRNG for heartbeat jitter *)
-  let config = Discord_agents.Config.load () in
-  (match Discord_agents.Config.validate
-           ~require_guild_id:(not test_mode) config with
+  let config =
+    match Discord_agents.Config.load_result () with
+    | Ok config -> config
+    | Error errors ->
+      List.iter (fun err -> Logs.err (fun m -> m "config: %s" err)) errors;
+      Logs.err (fun m -> m "update %s" (Discord_agents.Config.config_path ()));
+      exit 1
+  in
+  (match Discord_agents.Config.validate ~require_guild_id:(not test_mode) config with
    | Ok () -> ()
    | Error errors ->
      List.iter (fun err -> Logs.err (fun m -> m "config: %s" err)) errors;
      Logs.err (fun m -> m "update %s" (Discord_agents.Config.config_path ()));
      exit 1);
+  (* Acquire pidfile lock after config validation so a bad config cannot
+     terminate a healthy running bot and then fail to start. Keeps fd open
+     for process lifetime. *)
+  let _lock_fd = if not test_mode then Some (acquire_pidfile ()) else None in
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   if test_mode then

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,7 @@
+{
+  "discord_token": "your-bot-token",
+  "guild_id": "your-server-id",
+  "base_directories": ["~/Projects"],
+  "control_channel_id": null,
+  "projects": []
+}

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -99,7 +99,7 @@ type t = {
   guild_id : string; (** Discord server/guild to operate in *)
   control_channel_id : string option; (** Top-level channel for server-wide commands *)
   projects : project list;
-} [@@deriving show, yojson]
+} [@@deriving show]
 
 let default = {
   discord_token = "";
@@ -108,6 +108,95 @@ let default = {
   control_channel_id = None;
   projects = [];
 }
+
+let field fields name = List.assoc_opt name fields
+
+let string_field ~name = function
+  | `String s -> s
+  | _ -> failwith (Printf.sprintf "%s: expected string" name)
+
+let optional_string_field ~name = function
+  | `Null -> None
+  | `String s -> Some s
+  | _ -> failwith (Printf.sprintf "%s: expected string or null" name)
+
+let string_list_field ~name = function
+  | `List xs -> List.map (string_field ~name) xs
+  | _ -> failwith (Printf.sprintf "%s: expected array of strings" name)
+
+let project_list_field ~name = function
+  | `List xs -> List.map project_of_yojson xs
+  | _ -> failwith (Printf.sprintf "%s: expected array of project objects" name)
+
+let t_of_yojson = function
+  | `Assoc fields ->
+    let discord_token =
+      match field fields "discord_token" with
+      | Some json -> string_field ~name:"discord_token" json
+      | None -> default.discord_token
+    in
+    let base_directories =
+      match field fields "base_directories", field fields "base_dirs" with
+      | Some json, _ -> string_list_field ~name:"base_directories" json
+      | None, Some json -> string_list_field ~name:"base_dirs" json
+      | None, None -> default.base_directories
+    in
+    let guild_id =
+      match field fields "guild_id" with
+      | Some json -> string_field ~name:"guild_id" json
+      | None -> default.guild_id
+    in
+    let control_channel_id =
+      match field fields "control_channel_id" with
+      | Some json -> optional_string_field ~name:"control_channel_id" json
+      | None -> default.control_channel_id
+    in
+    let projects =
+      match field fields "projects" with
+      | Some json -> project_list_field ~name:"projects" json
+      | None -> default.projects
+    in
+    { discord_token; base_directories; guild_id; control_channel_id; projects }
+  | _ -> failwith "config: expected object"
+
+let yojson_of_t t =
+  `Assoc [
+    ("discord_token", `String t.discord_token);
+    ("base_directories",
+     `List (List.map (fun path -> `String path) t.base_directories));
+    ("guild_id", `String t.guild_id);
+    ("control_channel_id",
+     (match t.control_channel_id with
+      | Some id -> `String id
+      | None -> `Null));
+    ("projects", `List (List.map yojson_of_project t.projects));
+  ]
+
+let blank s = String.trim s = ""
+
+let validation_errors ?(require_guild_id=true) config =
+  let errors = ref [] in
+  let add msg = errors := msg :: !errors in
+  if blank config.discord_token then
+    add "discord_token is required, unless DISCORD_BOT_TOKEN is set";
+  if require_guild_id && blank config.guild_id then
+    add "guild_id is required";
+  List.iteri (fun i path ->
+    if blank path then
+      add (Printf.sprintf "base_directories[%d] must not be empty" i)
+  ) config.base_directories;
+  List.iteri (fun i project ->
+    if blank project.name then
+      add (Printf.sprintf "projects[%d].name must not be empty" i);
+    if blank project.path then
+      add (Printf.sprintf "projects[%d].path must not be empty" i)
+  ) config.projects;
+  List.rev !errors
+
+let validate ?require_guild_id config =
+  match validation_errors ?require_guild_id config with
+  | [] -> Ok ()
+  | errors -> Error errors
 
 let config_path () =
   Filename.concat (Resource.app_config_dir ()) "config.json"
@@ -132,7 +221,7 @@ let load () =
   in
   (* Allow env var override for the token *)
   match Sys.getenv_opt "DISCORD_BOT_TOKEN" with
-  | Some token when token <> "" && config.discord_token = "" ->
+  | Some token when not (blank token) && blank config.discord_token ->
     { config with discord_token = token }
   | _ -> config
 

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -90,7 +90,7 @@ let yojson_of_agent_kind k = `String (string_of_agent_kind k)
 type project = {
   name : string;
   path : string; (** Absolute path to the project's bare repo or working directory *)
-  channel_id : string option; (** Discord channel ID, populated once created *)
+  channel_id : string option [@default None]; (** Discord channel ID, populated once created *)
 } [@@deriving show, yojson]
 
 type t = {
@@ -111,6 +111,15 @@ let default = {
 
 let field fields name = List.assoc_opt name fields
 
+let known_top_level_fields =
+  ["discord_token"; "base_directories"; "base_dirs"; "guild_id";
+   "control_channel_id"; "projects"]
+
+let unknown_top_level_fields fields =
+  List.filter_map (fun (name, _) ->
+    if List.mem name known_top_level_fields then None else Some name
+  ) fields
+
 let string_field ~name = function
   | `String s -> s
   | _ -> failwith (Printf.sprintf "%s: expected string" name)
@@ -130,6 +139,9 @@ let project_list_field ~name = function
 
 let t_of_yojson = function
   | `Assoc fields ->
+    (match unknown_top_level_fields fields with
+     | [] -> ()
+     | name :: _ -> failwith (Printf.sprintf "unknown config field: %s" name));
     let discord_token =
       match field fields "discord_token" with
       | Some json -> string_field ~name:"discord_token" json
@@ -181,6 +193,9 @@ let validation_errors ?(require_guild_id=true) config =
     add "discord_token is required, unless DISCORD_BOT_TOKEN is set";
   if require_guild_id && blank config.guild_id then
     add "guild_id is required";
+  (match config.control_channel_id with
+   | Some id when blank id -> add "control_channel_id must not be empty"
+   | _ -> ());
   List.iteri (fun i path ->
     if blank path then
       add (Printf.sprintf "base_directories[%d] must not be empty" i)
@@ -189,7 +204,11 @@ let validation_errors ?(require_guild_id=true) config =
     if blank project.name then
       add (Printf.sprintf "projects[%d].name must not be empty" i);
     if blank project.path then
-      add (Printf.sprintf "projects[%d].path must not be empty" i)
+      add (Printf.sprintf "projects[%d].path must not be empty" i);
+    match project.channel_id with
+    | Some id when blank id ->
+      add (Printf.sprintf "projects[%d].channel_id must not be empty" i)
+    | _ -> ()
   ) config.projects;
   List.rev !errors
 
@@ -224,6 +243,15 @@ let load () =
   | Some token when not (blank token) && blank config.discord_token ->
     { config with discord_token = token }
   | _ -> config
+
+let load_result () =
+  try Ok (load ()) with
+  | Yojson.Json_error msg ->
+    Error [Printf.sprintf "invalid JSON: %s" msg]
+  | Failure msg ->
+    Error [msg]
+  | exn ->
+    Error [Printexc.to_string exn]
 
 let save config =
   let path = config_path () in

--- a/test/test_config.ml
+++ b/test/test_config.ml
@@ -63,6 +63,25 @@ let test_load_prefers_canonical_base_directories () =
     Alcotest.(check (list string)) "canonical base directories"
       ["~/Projects"] config.base_directories)
 
+let test_load_accepts_project_without_channel_id () =
+  with_tmp_home (fun home ->
+    let path = config_path home in
+    Discord_agents.Resource.ensure_parent_dir path;
+    Discord_agents.Resource.write_file_atomic path
+      {|{
+  "discord_token": "test-token",
+  "guild_id": "guild-1",
+  "projects": [{"name": "repo", "path": "/srv/repo"}]
+}|};
+    let config = Discord_agents.Config.load () in
+    match config.projects with
+    | [project] ->
+      Alcotest.(check string) "project name" "repo" project.name;
+      Alcotest.(check string) "project path" "/srv/repo" project.path;
+      Alcotest.(check (option string)) "channel id default"
+        None project.channel_id
+    | _ -> Alcotest.fail "expected one project")
+
 let test_load_env_token_replaces_blank_config_token () =
   with_tmp_home (fun home ->
     let old_token = Sys.getenv_opt "DISCORD_BOT_TOKEN" in
@@ -92,9 +111,10 @@ let test_validate_reports_required_fields () =
   let config = {
     Discord_agents.Config.default with
     base_directories = ["~/Projects"; ""];
+    control_channel_id = Some " ";
     projects = [
       { name = ""; path = "/tmp/project"; channel_id = None };
-      { name = "missing-path"; path = ""; channel_id = None };
+      { name = "missing-path"; path = ""; channel_id = Some "" };
     ];
   } in
   match Discord_agents.Config.validate config with
@@ -106,10 +126,14 @@ let test_validate_reports_required_fields () =
       true (has_error_substring "guild_id" errors);
     Alcotest.(check bool) "rejects empty base dir"
       true (has_error_substring "base_directories[1]" errors);
+    Alcotest.(check bool) "rejects empty control channel"
+      true (has_error_substring "control_channel_id" errors);
     Alcotest.(check bool) "rejects empty project name"
       true (has_error_substring "projects[0].name" errors);
     Alcotest.(check bool) "rejects empty project path"
-      true (has_error_substring "projects[1].path" errors)
+      true (has_error_substring "projects[1].path" errors);
+    Alcotest.(check bool) "rejects empty project channel"
+      true (has_error_substring "projects[1].channel_id" errors)
 
 let test_validate_smoke_test_allows_missing_guild () =
   let config = {
@@ -121,6 +145,46 @@ let test_validate_smoke_test_allows_missing_guild () =
   | Error errors ->
     Alcotest.failf "expected smoke-test config to validate, got: %s"
       (String.concat "; " errors)
+
+let test_load_result_reports_parse_errors () =
+  with_tmp_home (fun home ->
+    let path = config_path home in
+    Discord_agents.Resource.ensure_parent_dir path;
+    Discord_agents.Resource.write_file_atomic path
+      {|{"discord_token": }|};
+    match Discord_agents.Config.load_result () with
+    | Ok _ -> Alcotest.fail "expected parse error"
+    | Error errors ->
+      Alcotest.(check bool) "reports invalid JSON"
+        true (has_error_substring "invalid JSON" errors))
+
+let test_load_result_reports_schema_errors () =
+  with_tmp_home (fun home ->
+    let path = config_path home in
+    Discord_agents.Resource.ensure_parent_dir path;
+    Discord_agents.Resource.write_file_atomic path
+      {|{"discord_token": 42}|};
+    match Discord_agents.Config.load_result () with
+    | Ok _ -> Alcotest.fail "expected schema error"
+    | Error errors ->
+      Alcotest.(check bool) "reports field type error"
+        true (has_error_substring "discord_token: expected string" errors))
+
+let test_load_result_reports_unknown_fields () =
+  with_tmp_home (fun home ->
+    let path = config_path home in
+    Discord_agents.Resource.ensure_parent_dir path;
+    Discord_agents.Resource.write_file_atomic path
+      {|{
+  "discord_token": "test-token",
+  "guild_id": "guild-1",
+  "base_directores": ["~/Projects"]
+}|};
+    match Discord_agents.Config.load_result () with
+    | Ok _ -> Alcotest.fail "expected unknown field error"
+    | Error errors ->
+      Alcotest.(check bool) "reports unknown field"
+        true (has_error_substring "unknown config field: base_directores" errors))
 
 let test_save_reaps_stale_atomic_temp () =
   with_tmp_home (fun home ->
@@ -179,12 +243,20 @@ let () =
         test_load_accepts_basic_schema_alias;
       Alcotest.test_case "canonical base_directories wins" `Quick
         test_load_prefers_canonical_base_directories;
+      Alcotest.test_case "load accepts project without channel_id" `Quick
+        test_load_accepts_project_without_channel_id;
       Alcotest.test_case "env token replaces blank config token" `Quick
         test_load_env_token_replaces_blank_config_token;
       Alcotest.test_case "validation reports required fields" `Quick
         test_validate_reports_required_fields;
       Alcotest.test_case "smoke-test validation allows missing guild" `Quick
         test_validate_smoke_test_allows_missing_guild;
+      Alcotest.test_case "load_result reports parse errors" `Quick
+        test_load_result_reports_parse_errors;
+      Alcotest.test_case "load_result reports schema errors" `Quick
+        test_load_result_reports_schema_errors;
+      Alcotest.test_case "load_result reports unknown fields" `Quick
+        test_load_result_reports_unknown_fields;
     ]);
     ("persistence", [
       Alcotest.test_case "save reaps stale atomic temp" `Quick

--- a/test/test_config.ml
+++ b/test/test_config.ml
@@ -29,6 +29,99 @@ let with_tmp_home f =
 let config_path home =
   Filename.concat home ".config/discord-agents/config.json"
 
+let test_load_accepts_basic_schema_alias () =
+  with_tmp_home (fun home ->
+    let path = config_path home in
+    Discord_agents.Resource.ensure_parent_dir path;
+    Discord_agents.Resource.write_file_atomic path
+      {|{
+  "discord_token": "test-token",
+  "guild_id": "guild-1",
+  "base_dirs": ["~/Projects"]
+}|};
+    let config = Discord_agents.Config.load () in
+    Alcotest.(check string) "token" "test-token" config.discord_token;
+    Alcotest.(check string) "guild" "guild-1" config.guild_id;
+    Alcotest.(check (list string)) "base dirs"
+      ["~/Projects"] config.base_directories;
+    Alcotest.(check (option string)) "control channel default"
+      None config.control_channel_id;
+    Alcotest.(check int) "projects default" 0 (List.length config.projects))
+
+let test_load_prefers_canonical_base_directories () =
+  with_tmp_home (fun home ->
+    let path = config_path home in
+    Discord_agents.Resource.ensure_parent_dir path;
+    Discord_agents.Resource.write_file_atomic path
+      {|{
+  "discord_token": "test-token",
+  "guild_id": "guild-1",
+  "base_dirs": ["~/Old"],
+  "base_directories": ["~/Projects"]
+}|};
+    let config = Discord_agents.Config.load () in
+    Alcotest.(check (list string)) "canonical base directories"
+      ["~/Projects"] config.base_directories)
+
+let test_load_env_token_replaces_blank_config_token () =
+  with_tmp_home (fun home ->
+    let old_token = Sys.getenv_opt "DISCORD_BOT_TOKEN" in
+    Fun.protect
+      ~finally:(fun () -> restore_env "DISCORD_BOT_TOKEN" old_token)
+      (fun () ->
+        let path = config_path home in
+        Discord_agents.Resource.ensure_parent_dir path;
+        Discord_agents.Resource.write_file_atomic path
+          {|{
+  "discord_token": "   ",
+  "guild_id": "guild-1",
+  "base_directories": ["~/Projects"]
+}|};
+        Unix.putenv "DISCORD_BOT_TOKEN" "env-token";
+        let config = Discord_agents.Config.load () in
+        Alcotest.(check string) "env token"
+          "env-token" config.discord_token))
+
+let has_error_substring needle errors =
+  List.exists (fun err ->
+    try ignore (Str.search_forward (Str.regexp_string needle) err 0); true
+    with Not_found -> false
+  ) errors
+
+let test_validate_reports_required_fields () =
+  let config = {
+    Discord_agents.Config.default with
+    base_directories = ["~/Projects"; ""];
+    projects = [
+      { name = ""; path = "/tmp/project"; channel_id = None };
+      { name = "missing-path"; path = ""; channel_id = None };
+    ];
+  } in
+  match Discord_agents.Config.validate config with
+  | Ok () -> Alcotest.fail "expected config validation errors"
+  | Error errors ->
+    Alcotest.(check bool) "requires token"
+      true (has_error_substring "discord_token" errors);
+    Alcotest.(check bool) "requires guild"
+      true (has_error_substring "guild_id" errors);
+    Alcotest.(check bool) "rejects empty base dir"
+      true (has_error_substring "base_directories[1]" errors);
+    Alcotest.(check bool) "rejects empty project name"
+      true (has_error_substring "projects[0].name" errors);
+    Alcotest.(check bool) "rejects empty project path"
+      true (has_error_substring "projects[1].path" errors)
+
+let test_validate_smoke_test_allows_missing_guild () =
+  let config = {
+    Discord_agents.Config.default with
+    discord_token = "test-token";
+  } in
+  match Discord_agents.Config.validate ~require_guild_id:false config with
+  | Ok () -> ()
+  | Error errors ->
+    Alcotest.failf "expected smoke-test config to validate, got: %s"
+      (String.concat "; " errors)
+
 let test_save_reaps_stale_atomic_temp () =
   with_tmp_home (fun home ->
     let path = config_path home in
@@ -48,10 +141,55 @@ let test_save_reaps_stale_atomic_temp () =
     let mode = (Unix.stat path).Unix.st_perm land 0o777 in
     Alcotest.(check int) "config mode remains private" 0o600 mode)
 
+let test_save_load_roundtrip () =
+  with_tmp_home (fun _home ->
+    let config = {
+      Discord_agents.Config.discord_token = "test-token";
+      guild_id = "guild";
+      base_directories = ["~/Projects"; "/srv/src"];
+      control_channel_id = Some "control";
+      projects = [
+        { name = "repo"; path = "/srv/src/repo"; channel_id = Some "chan" };
+      ];
+    } in
+    Discord_agents.Config.save config;
+    let loaded = Discord_agents.Config.load () in
+    Alcotest.(check string) "token"
+      config.discord_token loaded.discord_token;
+    Alcotest.(check string) "guild"
+      config.guild_id loaded.guild_id;
+    Alcotest.(check (list string)) "base directories"
+      config.base_directories loaded.base_directories;
+    Alcotest.(check (option string)) "control channel"
+      config.control_channel_id loaded.control_channel_id;
+    Alcotest.(check int) "project count"
+      1 (List.length loaded.projects);
+    match loaded.projects with
+    | [project] ->
+      Alcotest.(check string) "project name" "repo" project.name;
+      Alcotest.(check string) "project path" "/srv/src/repo" project.path;
+      Alcotest.(check (option string)) "project channel"
+        (Some "chan") project.channel_id
+    | _ -> Alcotest.fail "expected one project")
+
 let () =
   Alcotest.run "config" [
+    ("schema", [
+      Alcotest.test_case "load accepts base_dirs alias" `Quick
+        test_load_accepts_basic_schema_alias;
+      Alcotest.test_case "canonical base_directories wins" `Quick
+        test_load_prefers_canonical_base_directories;
+      Alcotest.test_case "env token replaces blank config token" `Quick
+        test_load_env_token_replaces_blank_config_token;
+      Alcotest.test_case "validation reports required fields" `Quick
+        test_validate_reports_required_fields;
+      Alcotest.test_case "smoke-test validation allows missing guild" `Quick
+        test_validate_smoke_test_allows_missing_guild;
+    ]);
     ("persistence", [
       Alcotest.test_case "save reaps stale atomic temp" `Quick
         test_save_reaps_stale_atomic_temp;
+      Alcotest.test_case "save/load roundtrip" `Quick
+        test_save_load_roundtrip;
     ]);
   ]


### PR DESCRIPTION
## Summary

- Replace derived config parsing for the top-level config with explicit parsing that supplies defaults for optional fields.
- Accept legacy `base_dirs` while writing canonical `base_directories`.
- Validate startup config before launching the bot and document the schema with `config.example.json`.

Codex-default changes from #70 are intentionally excluded.

## Validation

- `git diff --check`
- `nix develop --command dune exec ./test/test_config.exe`
- `nix develop --command dune runtest`

Part of #85 / salvage from #70.