### PR TITLE
Trust Gemini worktrees in headless runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ There is a `!command` interface to server management, and control channels also 
 discord-agents is intended to be a simple interface to agentic coding on your personal machines and is not intended to be used in shared Discord servers. There is no authentication, and it has the full capabilities of a coding agent launched as the user you started it as. There is no sandboxing in discord-agents itself; use Unix and Claude sandboxing if you require it.
 
 Only tested on GNU+Linux. Environment managed by Nix. Built with OCaml 5.3.
+Claude Code is the default agent CLI. Gemini sessions require
+`@google/gemini-cli` 0.40.0 or newer.
 
 ![discord-agents screenshot](docs/screenshot.png)
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -27,6 +27,10 @@ npm install -g @anthropic-ai/claude-code
 
 Make sure `claude` is on your PATH and you've authenticated (`claude` will prompt on first run).
 
+Gemini sessions are optional. To use them, install `@google/gemini-cli`
+version 0.40.0 or newer; older Gemini CLI releases reject the
+`--skip-trust` flag that discord-agents uses for headless worktree runs.
+
 ## 3. Create a Discord bot
 
 1. Go to the [Discord Developer Portal](https://discord.com/developers/applications)

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1463,9 +1463,12 @@ let codex_args ~model ~reasoning_effort
     Result. Subsequent runs resume only when [session_id_confirmed],
     matching the same coherence contract Codex uses.
 
-    [--yolo] auto-approves tool calls so Gemini doesn't block on an
-    interactive approval prompt that the non-interactive subprocess
-    can't answer. It is *not* a full equivalent of Codex's
+    [--skip-trust] is required for bot-created worktrees that Gemini
+    has not seen interactively before; without it, headless runs exit
+    before emitting stream-json events. [--yolo] auto-approves tool
+    calls so Gemini doesn't block on an interactive approval prompt
+    that the non-interactive subprocess can't answer. It is *not* a
+    full equivalent of Codex's
     [--dangerously-bypass-approvals-and-sandbox]: that flag also
     drops Codex's filesystem sandbox, while Gemini's [--yolo] only
     covers approvals. The closer Codex analogue for [--yolo] is
@@ -1475,7 +1478,7 @@ let codex_args ~model ~reasoning_effort
     by [setup_gemini_mcp], which run_streaming calls before invoking
     [gemini_args]. *)
 let gemini_args ~model ~session_id ~session_id_confirmed ~prompt =
-  let base = ["gemini"] @ model_arg model
+  let base = ["gemini"; "--skip-trust"] @ model_arg model
              @ ["-p"; prompt; "-o"; "stream-json"; "--yolo"] in
   if not session_id_confirmed then base
   else base @ ["--resume"; session_id]

--- a/test/test_agent_contracts.ml
+++ b/test/test_agent_contracts.ml
@@ -131,6 +131,12 @@ let codex_command ~ephemeral ~session_id ~session_id_confirmed prompt =
   in
   String.concat " " (List.map Filename.quote args)
 
+let gemini_command ~session_id ~session_id_confirmed prompt =
+  Discord_agents.Agent_process.gemini_args
+    ~model:None ~session_id ~session_id_confirmed ~prompt
+  |> List.map Filename.quote
+  |> String.concat " "
+
 let codex_fresh =
   Alcotest.test_case "fresh exec emits thread.started + agent_message"
     `Slow (fun () ->
@@ -214,9 +220,9 @@ let claude_resume =
 let gemini_fresh =
   Alcotest.test_case "fresh -p emits init session_id + assistant text"
     `Slow (fun () ->
-      let cmd =
-        "gemini -p 'reply with the single word ok' -o stream-json --yolo"
-      in
+      let cmd = gemini_command ~session_id:""
+        ~session_id_confirmed:false
+        "reply with the single word ok" in
       let events = invoke_or_skip ~label:"gemini fresh" ~cmd
         ~parse:Discord_agents.Agent_process.parse_gemini_stream_json_line in
       Alcotest.(check bool)
@@ -229,9 +235,9 @@ let gemini_fresh =
 let gemini_resume =
   Alcotest.test_case "resume preserves the captured session id"
     `Slow (fun () ->
-      let fresh_cmd =
-        "gemini -p 'reply with the single word ok' -o stream-json --yolo"
-      in
+      let fresh_cmd = gemini_command ~session_id:""
+        ~session_id_confirmed:false
+        "reply with the single word ok" in
       let fresh_events = invoke_or_skip ~label:"gemini fresh (for resume)"
         ~cmd:fresh_cmd
         ~parse:Discord_agents.Agent_process.parse_gemini_stream_json_line in
@@ -239,10 +245,9 @@ let gemini_resume =
         | Some s -> s
         | None -> Alcotest.fail "gemini fresh did not emit a session id"
       in
-      let resume_cmd = Printf.sprintf
-        "gemini -p 'reply with the single word ok' -o stream-json --yolo \
-         --resume %s" sid
-      in
+      let resume_cmd = gemini_command ~session_id:sid
+        ~session_id_confirmed:true
+        "reply with the single word ok" in
       let resume_events = invoke_or_skip ~label:"gemini resume"
         ~cmd:resume_cmd
         ~parse:Discord_agents.Agent_process.parse_gemini_stream_json_line in

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -3171,8 +3171,8 @@ let test_gemini_args_fresh () =
   let args = gemini_args ~session_id:"placeholder"
     ~session_id_confirmed:false ~prompt:"hello" in
   Alcotest.(check (list string))
-    "fresh invocation: -p prompt, -o stream-json, --yolo, no resume"
-    ["gemini"; "-p"; "hello"; "-o"; "stream-json"; "--yolo"]
+    "fresh invocation: skip trust, -p prompt, stream-json, --yolo, no resume"
+    ["gemini"; "--skip-trust"; "-p"; "hello"; "-o"; "stream-json"; "--yolo"]
     args
 
 let test_gemini_args_resume () =
@@ -3180,7 +3180,7 @@ let test_gemini_args_resume () =
     ~session_id_confirmed:true ~prompt:"continue" in
   Alcotest.(check (list string))
     "resume invocation appends --resume <id>"
-    ["gemini"; "-p"; "continue"; "-o"; "stream-json"; "--yolo";
+    ["gemini"; "--skip-trust"; "-p"; "continue"; "-o"; "stream-json"; "--yolo";
      "--resume"; "abc-123"]
     args
 
@@ -3191,7 +3191,7 @@ let test_gemini_args_model_override () =
     ~session_id_confirmed:false ~prompt:"hello" in
   Alcotest.(check (list string))
     "model flag appears before prompt"
-    ["gemini"; "--model"; "gemini-2.5-pro";
+    ["gemini"; "--skip-trust"; "--model"; "gemini-2.5-pro";
      "-p"; "hello"; "-o"; "stream-json"; "--yolo"]
     args
 


### PR DESCRIPTION
## Summary

- Pass `--skip-trust` to Gemini invocations so bot-created worktrees do not block on an interactive trust prompt before stream-json starts.
- Keep model overrides in the current argument shape.
- Build live Gemini contract commands through `gemini_args` so contract runs exercise the same invocation shape as the bot.

Codex-default changes from #70 are intentionally excluded.

## Validation

- `git diff --check`
- `nix develop --command dune exec ./test/test_formatting.exe`
- `nix develop --command dune exec ./test/test_agent_contracts.exe` (Gemini live checks skipped in this environment)
- `nix develop --command dune runtest`

Part of #85 / salvage from #70.