### PR TITLE
Avoid word splits in Discord output

### DIFF
--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -78,6 +78,24 @@ let is_separator_row cells =
     String.to_seq cell |> Seq.for_all (fun c -> c = '-' || c = ':')
   ) cells
 
+let utf8_prefix_len_for_table_cell ~max_bytes s =
+  let n = String.length s in
+  let rec loop i =
+    if i >= n || i >= max_bytes then i
+    else
+      let c = Char.code s.[i] in
+      let raw_step =
+        if c < 0x80 then 1
+        else if c < 0xC0 then 1
+        else if c < 0xE0 then 2
+        else if c < 0xF0 then 3
+        else 4
+      in
+      let step = min raw_step (n - i) in
+      if i + step > max_bytes then i else loop (i + step)
+  in
+  loop 0
+
 (** Default wrapping widths for desktop and mobile Discord clients. *)
 let desktop_width = 120
 let mobile_width = 60
@@ -195,7 +213,9 @@ let render_padded_table ?(max_width=desktop_width) table_lines =
       end else begin
         Buffer.add_char buf ' ';
         let display = if String.length cell > w
-          then String.sub cell 0 w
+          then
+            let taken = utf8_prefix_len_for_table_cell ~max_bytes:w cell in
+            String.sub cell 0 taken
           else cell in
         Buffer.add_string buf display;
         for _ = 1 to w - String.length display do Buffer.add_char buf ' ' done;
@@ -385,6 +405,29 @@ let take_fitting_prefix ?(start=0) ~max_chars s =
       let raw_step = if is_triple then 3 else utf8_step s start in
       min raw_step (n - start)
 
+let is_ascii_whitespace = function
+  | ' ' | '\t' | '\r' | '\n' -> true
+  | _ -> false
+
+(** Largest display-safe prefix, preferring a prior whitespace boundary
+    over the hard UTF-8 budget boundary. If no whitespace fits in the
+    window, falls back to [take_fitting_prefix] so long unbroken tokens
+    still make progress. *)
+let take_word_safe_fitting_prefix ?(start=0) ~max_chars s =
+  let n = String.length s in
+  let hard_len = take_fitting_prefix ~start ~max_chars s in
+  let hard_end = start + hard_len in
+  if hard_end >= n then hard_len
+  else
+    let rec find_space i =
+      if i <= start then None
+      else if is_ascii_whitespace s.[i - 1] then Some i
+      else find_space (i - 1)
+    in
+    match find_space hard_end with
+    | Some i when i > start -> i - start
+    | _ -> hard_len
+
 (** UTF-8 safe truncation for inline summary strings: caps at [max_chars]
     bytes (post-fence-escape) and appends "...".  Returns [s] unchanged
     if it already fits.  Always lands on a UTF-8 codepoint boundary. *)
@@ -403,7 +446,7 @@ let chunk_long_line ~max_chars line =
     let chunks = ref [] in
     let pos = ref 0 in
     while !pos < n do
-      let len = take_fitting_prefix ~start:!pos ~max_chars line in
+      let len = take_word_safe_fitting_prefix ~start:!pos ~max_chars line in
       chunks := String.sub line !pos len :: !chunks;
       pos := !pos + len
     done;
@@ -453,7 +496,7 @@ let truncate_for_display ~max_lines ~max_chars (lines : string list) =
         else if shown = 0 then
           (* First line alone exceeds budget — char-truncate it so the
              user always sees something rather than an empty block. *)
-          let taken = take_fitting_prefix ~max_chars l in
+          let taken = take_word_safe_fitting_prefix ~max_chars l in
           let trimmed = String.sub l 0 taken in
           { display = [trimmed]; shown = 1;
             total = 1 + List.length rest;

--- a/lib/agent_runner.ml
+++ b/lib/agent_runner.ml
@@ -13,6 +13,53 @@
 (** Typing indicator refresh interval in seconds. *)
 let typing_interval = 8.0
 
+let stream_message_max = 1796
+
+let take_stream_delta_chunk_len ~current_len text ~start =
+  let remaining_capacity = stream_message_max - current_len in
+  if remaining_capacity <= 0 then 0
+  else
+    let hard_len =
+      Agent_process.take_fitting_prefix
+        ~start ~max_chars:remaining_capacity text
+    in
+    let hard_end = start + hard_len in
+    if hard_end >= String.length text then hard_len
+    else
+      let rec find_space i =
+        if i <= start then None
+        else if Agent_process.is_ascii_whitespace text.[i - 1] then Some i
+        else find_space (i - 1)
+      in
+      match find_space hard_end with
+      | Some i when i > start -> i - start
+      | _ when current_len > 0 -> 0
+      | _ -> hard_len
+
+let split_trailing_word_for_carry s =
+  let n = String.length s in
+  if n = 0 || Agent_process.is_ascii_whitespace s.[n - 1] then None
+  else
+    let rec find_start i =
+      if i <= 0 then 0
+      else if Agent_process.is_ascii_whitespace s.[i - 1] then i
+      else find_start (i - 1)
+    in
+    let start = find_start n in
+    if start = 0 then None
+    else
+      Some (String.sub s 0 start, String.sub s start (n - start))
+
+let buffer_ends_with_table text =
+  let rec last_nonblank = function
+    | [] -> None
+    | line :: rest ->
+      if String.trim line = "" then last_nonblank rest else Some line
+  in
+  match last_nonblank (List.rev (String.split_on_char '\n' text)) with
+  | Some line -> Agent_process.is_table_line line
+  | None -> false
+
 (** Map tool names to emoji + verb for compact status display. *)
 (** Escape underscores in a tool name for Discord display.
     Discord interprets __ as underline and _ as italic, so we
@@ -281,6 +328,29 @@ let run ~sw ~env ~rest ~session ~(channel_id : Discord_types.channel_id)
       (* No table boundary (or entire buffer is a table) — split normally *)
       flush_and_reset ()
   in
+  let carry_trailing_word_to_next_message () =
+    let buf_text = Buffer.contents current_msg_buf in
+    if buffer_ends_with_table buf_text then false
+    else match split_trailing_word_for_carry buf_text with
+    | None -> false
+    | Some (before, carry) ->
+      Buffer.clear current_msg_buf;
+      Buffer.add_string current_msg_buf before;
+      let (in_code, lang) = Agent_process.scan_fences before in
+      if in_code then
+        Buffer.add_string current_msg_buf "\n```";
+      flush_to_discord ();
+      Buffer.clear current_msg_buf;
+      current_msg_id := None;
+      if in_code then
+        Buffer.add_string current_msg_buf ("```" ^ lang ^ "\n");
+      Buffer.add_string current_msg_buf carry;
+      true
+  in
+  let start_new_message_preserving_trailing_word () =
+    if not (carry_trailing_word_to_next_message ()) then
+      start_new_message ()
+  in
   (* Flush accumulated tool status lines to a single Discord message.
      Consecutive tool calls get batched into one message, edited in-place.
      Sanitization here mirrors flush_to_discord — tool inputs (file paths,
@@ -320,21 +390,41 @@ let run ~sw ~env ~rest ~session ~(channel_id : Discord_types.channel_id)
         current_msg_id := None
       end;
       Buffer.add_string result_buf text;
-      (* Split at 1800-char boundaries, reserving space for closing ```
+      (* Split near 1800-char boundaries, reserving space for closing ```
          if we might be inside a code block (worst case: 4 chars for "\n```") *)
       let text_len = String.length text in
       let pos = ref 0 in
       while !pos < text_len do
         (* Flush first if buffer is already at capacity (e.g. from a
            reopened code block prefix) to avoid zero-progress loops *)
-        if Buffer.length current_msg_buf >= 1796 then
-          start_new_message ();
-        let remaining_capacity = 1796 - Buffer.length current_msg_buf in
-        let chunk_len = min remaining_capacity (text_len - !pos) in
-        Buffer.add_substring current_msg_buf text !pos chunk_len;
-        pos := !pos + chunk_len;
-        if Buffer.length current_msg_buf >= 1796 then
-          start_new_message ()
+        if Buffer.length current_msg_buf >= stream_message_max then
+          start_new_message_preserving_trailing_word ();
+        let chunk_len =
+          take_stream_delta_chunk_len
+            ~current_len:(Buffer.length current_msg_buf) text ~start:!pos
+        in
+        if chunk_len = 0 then begin
+          let before_len = Buffer.length current_msg_buf in
+          let carried = carry_trailing_word_to_next_message () in
+          if not carried then
+            start_new_message ();
+          if Buffer.length current_msg_buf >= before_len then begin
+            let remaining_capacity =
+              max 1 (stream_message_max - Buffer.length current_msg_buf)
+            in
+            let forced_len =
+              Agent_process.take_fitting_prefix
+                ~start:!pos ~max_chars:remaining_capacity text
+            in
+            Buffer.add_substring current_msg_buf text !pos forced_len;
+            pos := !pos + forced_len
+          end
+        end else begin
+          Buffer.add_substring current_msg_buf text !pos chunk_len;
+          pos := !pos + chunk_len
+        end;
+        if Buffer.length current_msg_buf >= stream_message_max then
+          start_new_message_preserving_trailing_word ()
       done;
       let now = Unix.gettimeofday () in
       if now -. !last_edit > 2.0 && Buffer.length current_msg_buf > 0 then begin

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -131,6 +131,43 @@ let test_reformat_separator_regenerated () =
        true (String.length sep > 10)
    | [] -> Alcotest.fail "no separator row found")
 
+let test_render_padded_table_truncates_utf8_safely () =
+  let input = [
+    "| Icon | Description |";
+    "|---|---|";
+    "| " ^ String.concat "" (List.init 8 (fun _ -> "😀")) ^ " | " ^
+      String.concat "" (List.init 8 (fun _ -> "界")) ^ " |";
+  ] in
+  let result =
+    Discord_agents.Agent_process.render_padded_table ~max_width:20 input
+  in
+  let well_formed s =
+    let n = String.length s in
+    let rec walk i =
+      if i >= n then true
+      else
+        let c = Char.code s.[i] in
+        let need =
+          if c < 0x80 then 0
+          else if c < 0xC0 then -1
+          else if c < 0xE0 then 1
+          else if c < 0xF0 then 2
+          else 3
+        in
+        if need < 0 || i + need >= n then false
+        else
+          let ok = ref true in
+          for k = 1 to need do
+            let cc = Char.code s.[i + k] in
+            if cc < 0x80 || cc >= 0xC0 then ok := false
+          done;
+          !ok && walk (i + 1 + need)
+    in
+    walk 0
+  in
+  Alcotest.(check bool) "rendered table is valid UTF-8"
+    true (well_formed result)
+
 let reformat_tables_tests = [
   Alcotest.test_case "plain text" `Quick test_reformat_plain_text;
   Alcotest.test_case "simple table" `Quick test_reformat_simple_table;
@@ -150,6 +187,8 @@ let reformat_tables_tests = [
   Alcotest.test_case "padding alignment" `Quick test_reformat_padding_alignment;
   Alcotest.test_case "separator regenerated" `Quick
     test_reformat_separator_regenerated;
+  Alcotest.test_case "table truncation is UTF-8 safe" `Quick
+    test_render_padded_table_truncates_utf8_safely;
 ]
 
 (* ── find_trailing_table_start ──────────────────────────────────── *)
@@ -280,6 +319,144 @@ let test_split_no_separator_utf8_safe () =
   List.iter (fun chunk ->
     Alcotest.(check bool) "chunk is well-formed UTF-8" true (well_formed chunk)
   ) chunks
+
+let contains_substring text needle =
+  try ignore (Str.search_forward (Str.regexp_string needle) text 0); true
+  with Not_found -> false
+
+let test_split_message_does_not_split_words () =
+  let input =
+    String.concat " " [
+      String.make 20 'a';
+      "account";
+      "balance";
+      String.make 20 'b';
+    ]
+  in
+  let chunks = Discord_agents.Agent_process.split_message ~max_len:30 input in
+  let marked = String.concat "/" chunks in
+  Alcotest.(check bool) "account not split as ac/count"
+    false (contains_substring marked "ac/count");
+  List.iter (fun chunk ->
+    Alcotest.(check bool) "chunk under test limit"
+      true (String.length chunk <= 30)
+  ) chunks
+
+let test_split_output_chunks_do_not_split_words () =
+  let input =
+    "alpha beta account gamma delta account epsilon zeta"
+  in
+  let chunks =
+    Discord_agents.Agent_process.split_into_chunks ~max_chars:15 input
+  in
+  let marked = String.concat "/" chunks in
+  Alcotest.(check bool) "output chunks avoid ac/count"
+    false (contains_substring marked "ac/count");
+  List.iter (fun chunk ->
+    Alcotest.(check bool) "chunk under display budget"
+      true (Discord_agents.Agent_process.escaped_length chunk <= 15)
+  ) chunks
+
+let test_split_output_keeps_fitting_suffix_together () =
+  let chunks =
+    Discord_agents.Agent_process.split_into_chunks
+      ~max_chars:10 "verylongword bye"
+  in
+  Alcotest.(check (list string)) "suffix stays in one chunk"
+    ["verylongwo"; "rd bye"] chunks
+
+let test_stream_delta_flushes_before_splitting_word () =
+  let len =
+    Discord_agents.Agent_runner.take_stream_delta_chunk_len
+      ~current_len:(Discord_agents.Agent_runner.stream_message_max - 5)
+      "account balance" ~start:0
+  in
+  Alcotest.(check int) "flush before account split" 0 len
+
+let test_stream_delta_splits_long_word_when_fresh () =
+  let text =
+    String.make (Discord_agents.Agent_runner.stream_message_max + 10) 'a'
+  in
+  let len =
+    Discord_agents.Agent_runner.take_stream_delta_chunk_len
+      ~current_len:0 text ~start:0
+  in
+  Alcotest.(check int) "fresh message takes hard budget"
+    Discord_agents.Agent_runner.stream_message_max len
+
+let test_stream_delta_utf8_boundary_after_flush () =
+  let emoji = "\xF0\x9F\x98\x80" in
+  let text = emoji ^ " account" in
+  let len_before_flush =
+    Discord_agents.Agent_runner.take_stream_delta_chunk_len
+      ~current_len:(Discord_agents.Agent_runner.stream_message_max - 1)
+      text ~start:0
+  in
+  Alcotest.(check int) "flush before slicing emoji" 0 len_before_flush;
+  let prefix =
+    String.make (Discord_agents.Agent_runner.stream_message_max - 1) 'a'
+  in
+  let text = prefix ^ emoji ^ " account" in
+  let len_after_flush =
+    Discord_agents.Agent_runner.take_stream_delta_chunk_len
+      ~current_len:0 text ~start:0
+  in
+  Alcotest.(check int) "fresh chunk stops before emoji boundary"
+    (String.length prefix) len_after_flush
+
+let test_stream_delta_carries_cross_delta_word_suffix () =
+  match Discord_agents.Agent_runner.split_trailing_word_for_carry
+          "prefix acc" with
+  | Some (before, carry) ->
+    Alcotest.(check string) "prefix flushed before suffix"
+      "prefix " before;
+    Alcotest.(check string) "suffix carried"
+      "acc" carry;
+    let len =
+      Discord_agents.Agent_runner.take_stream_delta_chunk_len
+        ~current_len:(String.length carry) "ount balance" ~start:0
+    in
+    Alcotest.(check int) "carried suffix joins continuation"
+      (String.length "ount balance") len
+  | None -> Alcotest.fail "expected trailing suffix to be carried"
+
+let test_stream_delta_exact_capacity_suffix_can_be_carried () =
+  let prefix =
+    String.make (Discord_agents.Agent_runner.stream_message_max - 4) 'a'
+    ^ " "
+  in
+  let page = prefix ^ "acc" in
+  Alcotest.(check int) "page exactly fills stream budget"
+    Discord_agents.Agent_runner.stream_message_max
+    (String.length page);
+  match Discord_agents.Agent_runner.split_trailing_word_for_carry page with
+  | Some (before, carry) ->
+    Alcotest.(check string) "exact-fill suffix carried" "acc" carry;
+    Alcotest.(check int) "flushed prefix has room"
+      (String.length prefix) (String.length before);
+    let len =
+      Discord_agents.Agent_runner.take_stream_delta_chunk_len
+        ~current_len:(String.length carry) "ount balance" ~start:0
+    in
+    Alcotest.(check int) "next delta joins exact-fill suffix"
+      (String.length "ount balance") len
+  | None -> Alcotest.fail "expected exact-fill suffix to be carried"
+
+let test_stream_delta_does_not_carry_unbroken_buffer () =
+  Alcotest.(check bool) "no prefix to flush"
+    true
+    (Option.is_none
+       (Discord_agents.Agent_runner.split_trailing_word_for_carry "account"))
+
+let test_stream_delta_detects_table_suffix () =
+  Alcotest.(check bool) "trailing table detected"
+    true
+    (Discord_agents.Agent_runner.buffer_ends_with_table
+       "intro\n| Name | Value |\n| account | balance |");
+  Alcotest.(check bool) "plain text is not table suffix"
+    false
+    (Discord_agents.Agent_runner.buffer_ends_with_table
+       "intro\naccount balance")
 
 (* Regression: !projects output with many entries must be safely chunkable.
    The original bug was that create_message sent a single ~5700-char message
@@ -490,6 +667,26 @@ let split_message_tests = [
     test_split_all_chunks_under_limit;
   Alcotest.test_case "no-separator fallback is UTF-8 safe" `Quick
     test_split_no_separator_utf8_safe;
+  Alcotest.test_case "split_message avoids word splits" `Quick
+    test_split_message_does_not_split_words;
+  Alcotest.test_case "output chunking avoids word splits" `Quick
+    test_split_output_chunks_do_not_split_words;
+  Alcotest.test_case "output chunking keeps fitting suffix" `Quick
+    test_split_output_keeps_fitting_suffix_together;
+  Alcotest.test_case "stream delta flushes before word split" `Quick
+    test_stream_delta_flushes_before_splitting_word;
+  Alcotest.test_case "stream delta splits long fresh word" `Quick
+    test_stream_delta_splits_long_word_when_fresh;
+  Alcotest.test_case "stream delta preserves UTF-8 boundary" `Quick
+    test_stream_delta_utf8_boundary_after_flush;
+  Alcotest.test_case "stream delta carries cross-delta suffix" `Quick
+    test_stream_delta_carries_cross_delta_word_suffix;
+  Alcotest.test_case "stream delta carries exact-capacity suffix" `Quick
+    test_stream_delta_exact_capacity_suffix_can_be_carried;
+  Alcotest.test_case "stream delta leaves unbroken buffer" `Quick
+    test_stream_delta_does_not_carry_unbroken_buffer;
+  Alcotest.test_case "stream delta detects table suffix" `Quick
+    test_stream_delta_detects_table_suffix;
   Alcotest.test_case "projects-list regression" `Quick
     test_split_projects_list_shape;
   Alcotest.test_case "plan: short content → single chunk with reply_to" `Quick
@@ -1157,6 +1354,19 @@ let test_truncate_for_display_fence_heavy () =
   Alcotest.(check bool) "escaped text fits in budget"
     true (String.length escaped <= 1700)
 
+let test_truncate_for_display_does_not_split_words () =
+  let line = "alpha beta account gamma delta" in
+  let t = Discord_agents.Agent_process.truncate_for_display
+    ~max_lines:10 ~max_chars:15 [line] in
+  let marked = String.concat "/" t.display in
+  Alcotest.(check bool) "truncate fallback avoids ac/count"
+    false (contains_substring marked "ac/count");
+  (match t.display with
+   | [display] ->
+     Alcotest.(check bool) "display under budget"
+       true (Discord_agents.Agent_process.escaped_length display <= 15)
+   | _ -> Alcotest.fail "expected one truncated display line")
+
 let test_take_fitting_prefix_plain () =
   let s = String.make 5000 'a' in
   let taken = Discord_agents.Agent_process.take_fitting_prefix
@@ -1230,6 +1440,8 @@ let tool_detail_tests = [
   Alcotest.test_case "safety cap" `Quick test_detail_safety_cap;
   Alcotest.test_case "fence heavy" `Quick test_detail_fence_heavy;
   Alcotest.test_case "truncate fence heavy" `Quick test_truncate_for_display_fence_heavy;
+  Alcotest.test_case "truncate avoids word splits" `Quick
+    test_truncate_for_display_does_not_split_words;
   Alcotest.test_case "take_fitting_prefix plain" `Quick test_take_fitting_prefix_plain;
   Alcotest.test_case "take_fitting_prefix fences" `Quick test_take_fitting_prefix_fences;
   Alcotest.test_case "take_fitting_prefix utf8" `Quick test_take_fitting_prefix_utf8;


### PR DESCRIPTION
## Summary
- keep Discord output chunking on word boundaries where possible
- preserve UTF-8 boundaries when truncating table cells and display chunks
- carry partial trailing words across streaming message boundaries without overriding table-preservation behavior

## Validation
- git diff --check
- nix develop --command dune exec ./test/test_formatting.exe
- nix develop --command dune runtest

Part of the PR #70 salvage split. The Codex default-agent change from #70 is intentionally not included.