### PR TITLE
Centralize agent effort capabilities

### DIFF
--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1482,8 +1482,9 @@ let codex_mcp_overrides () =
     See issue #35 for making this configurable. *)
 let codex_reasoning_effort_overrides = function
   | Some Config.Max ->
-    (* Codex's documented reasoning effort values do not include
-       [max]; callers reject this combination before invoking us. *)
+    (* Callers reject this combination through Config, but keep the
+       process boundary defensive so persisted bad state cannot pass an
+       unsupported Codex override. *)
     []
   | Some effort ->
     ["-c"; Printf.sprintf "model_reasoning_effort=\"%s\""

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -52,6 +52,37 @@ let reasoning_effort_of_yojson = function
 let yojson_of_reasoning_effort effort =
   `String (string_of_reasoning_effort effort)
 
+let reasoning_efforts_for_agent = function
+  | Claude -> [Low; Medium; High; Xhigh; Max]
+  | Codex -> [Low; Medium; High; Xhigh]
+  | Gemini -> []
+
+let reasoning_effort_strings_for_agent agent =
+  List.map string_of_reasoning_effort (reasoning_efforts_for_agent agent)
+
+let supports_reasoning_effort agent =
+  reasoning_efforts_for_agent agent <> []
+
+let unsupported_reasoning_effort_message agent effort =
+  match agent, effort with
+  | Gemini, _ ->
+    "Gemini CLI does not expose a reasoning effort flag in this integration."
+  | Codex, Max ->
+    "Codex reasoning effort does not support max; max is Claude-only."
+  | _ ->
+    Printf.sprintf "%s reasoning effort does not support %s."
+      (String.capitalize_ascii (string_of_agent_kind agent))
+      (string_of_reasoning_effort effort)
+
+let validate_reasoning_effort_for_agent agent effort =
+  match effort with
+  | None -> Ok ()
+  | Some effort ->
+    if List.exists (equal_reasoning_effort effort)
+        (reasoning_efforts_for_agent agent)
+    then Ok ()
+    else Error (unsupported_reasoning_effort_message agent effort)
+
 let preferred_agent_order preferred =
   preferred
   :: List.filter (fun kind -> not (equal_agent_kind kind preferred))

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -844,10 +844,11 @@ let string_list_json values =
 let clear_values_json =
   `List [`String "default"; `String ""; `Null]
 
-let effort_values_for_agent = function
-  | Config.Claude -> ["low"; "medium"; "high"; "xhigh"; "max"]
-  | Config.Codex -> ["low"; "medium"; "high"; "xhigh"]
-  | Config.Gemini -> []
+let effort_notes agent =
+  if Config.supports_reasoning_effort agent then
+    "Supported effort values are listed in values and validated for this thread's agent."
+  else
+    "This agent does not expose a reasoning effort flag in this integration."
 
 let configuration_options_json agent =
   `Assoc [
@@ -863,13 +864,11 @@ let configuration_options_json agent =
       ("clear_values", clear_values_json);
     ]);
     ("effort", `Assoc [
-      ("supported", `Bool (effort_values_for_agent agent <> []));
-      ("values", string_list_json (effort_values_for_agent agent));
+      ("supported", `Bool (Config.supports_reasoning_effort agent));
+      ("values", string_list_json
+        (Config.reasoning_effort_strings_for_agent agent));
       ("clear_values", clear_values_json);
-      ("notes", `String (match agent with
-        | Config.Claude -> "Claude supports low, medium, high, xhigh, and max."
-        | Config.Codex -> "Codex supports low, medium, high, and xhigh here; max is Claude-only."
-        | Config.Gemini -> "Gemini CLI does not expose a reasoning effort flag in this integration."));
+      ("notes", `String (effort_notes agent));
     ]);
     ("goal", `Assoc [
       ("supported", `Bool (Config.equal_agent_kind agent Config.Codex));
@@ -895,7 +894,8 @@ let configuration_options_json agent =
 
 let command_briefing session =
   let effort_text =
-    if effort_values_for_agent session.Session_store.agent_kind = [] then
+    if not (Config.supports_reasoning_effort session.Session_store.agent_kind)
+    then
       "Effort is unsupported for this thread's agent."
     else
       "Set effort with set_effort."
@@ -967,14 +967,6 @@ let handle_set_model (bot : Bot.t) params =
          model_field session;
        ])
 
-let effort_supported_for_agent agent effort =
-  match agent, effort with
-  | Config.Gemini, Some _ ->
-    Error "Gemini CLI does not expose a reasoning effort flag in this integration."
-  | Config.Codex, Some Config.Max ->
-    Error "Codex reasoning effort supports low, medium, high, and xhigh here; max is Claude-only."
-  | _ -> Ok ()
-
 let handle_set_effort (bot : Bot.t) params =
   let open Yojson.Safe.Util in
   let params = match params with Some p -> p | None ->
@@ -997,7 +989,8 @@ let handle_set_effort (bot : Bot.t) params =
            | Error msg -> failwith msg)
       | Some _ -> failwith "effort must be a string or null"
     in
-    (match effort_supported_for_agent session.agent_kind effort with
+    (match Config.validate_reasoning_effort_for_agent
+             session.agent_kind effort with
      | Error err -> error_response err
      | Ok () ->
        (match Session_store.set_reasoning_effort bot.sessions session effort with

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -297,7 +297,7 @@ TOOLS = [
     },
     {
         "name": "set_effort",
-        "description": "Set or clear the reasoning effort override for an existing Discord agent session. Pass effort explicitly. Claude supports low/medium/high/xhigh/max; Codex supports low/medium/high/xhigh here; Gemini effort is unsupported.",
+        "description": "Set or clear the reasoning effort override for an existing Discord agent session. Pass effort explicitly. Use get_agent_config for the selected thread's supported values; set_effort validates against that thread's agent.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -307,8 +307,7 @@ TOOLS = [
                 },
                 "effort": {
                     "type": ["string", "null"],
-                    "description": "Effort: low, medium, high, xhigh, max, or default/null to clear",
-                    "enum": ["low", "medium", "high", "xhigh", "max", "default", None]
+                    "description": "Reasoning effort value for the thread's agent, or default/null to clear"
                 }
             },
             "required": ["thread_id", "effort"]

--- a/test/test_config.ml
+++ b/test/test_config.ml
@@ -236,6 +236,70 @@ let test_save_load_roundtrip () =
         (Some "chan") project.channel_id
     | _ -> Alcotest.fail "expected one project")
 
+let test_reasoning_effort_values_by_agent () =
+  let values agent =
+    Discord_agents.Config.reasoning_effort_strings_for_agent agent
+  in
+  Alcotest.(check (list string)) "claude efforts"
+    ["low"; "medium"; "high"; "xhigh"; "max"]
+    (values Discord_agents.Config.Claude);
+  Alcotest.(check (list string)) "codex efforts"
+    ["low"; "medium"; "high"; "xhigh"]
+    (values Discord_agents.Config.Codex);
+  Alcotest.(check (list string)) "gemini efforts"
+    [] (values Discord_agents.Config.Gemini)
+
+let test_validate_reasoning_effort_for_agent () =
+  let validate = Discord_agents.Config.validate_reasoning_effort_for_agent in
+  let all_efforts = [
+    Discord_agents.Config.Low;
+    Discord_agents.Config.Medium;
+    Discord_agents.Config.High;
+    Discord_agents.Config.Xhigh;
+    Discord_agents.Config.Max;
+  ] in
+  List.iter (fun agent ->
+    let supported = Discord_agents.Config.reasoning_efforts_for_agent agent in
+    List.iter (fun effort ->
+      let result = validate agent (Some effort) in
+      let expected =
+        List.exists (Discord_agents.Config.equal_reasoning_effort effort)
+          supported
+      in
+      Alcotest.(check bool)
+        (Printf.sprintf "%s %s validation follows supported list"
+           (Discord_agents.Config.string_of_agent_kind agent)
+           (Discord_agents.Config.string_of_reasoning_effort effort))
+        expected
+        (match result with Ok () -> true | Error _ -> false)
+    ) all_efforts
+  ) [
+    Discord_agents.Config.Claude;
+    Discord_agents.Config.Codex;
+    Discord_agents.Config.Gemini;
+  ];
+  (match validate Discord_agents.Config.Codex (Some Discord_agents.Config.Max) with
+   | Ok () -> Alcotest.fail "expected Codex max effort to be rejected"
+   | Error msg ->
+     Alcotest.(check bool) "codex max names max as Claude-only"
+       true (has_error_substring "max is Claude-only" [msg]));
+  (match validate Discord_agents.Config.Gemini (Some Discord_agents.Config.High) with
+   | Ok () -> Alcotest.fail "expected Gemini effort to be rejected"
+   | Error msg ->
+     Alcotest.(check bool) "gemini unsupported"
+       true (has_error_substring "Gemini CLI does not expose" [msg]));
+  Alcotest.(check bool) "clearing effort accepted for Gemini"
+    true
+    (match validate Discord_agents.Config.Gemini None with
+     | Ok () -> true
+     | Error _ -> false);
+  Alcotest.(check bool) "xhigh accepted for Codex"
+    true
+    (match validate Discord_agents.Config.Codex
+             (Some Discord_agents.Config.Xhigh) with
+     | Ok () -> true
+     | Error _ -> false)
+
 let () =
   Alcotest.run "config" [
     ("schema", [
@@ -257,6 +321,12 @@ let () =
         test_load_result_reports_schema_errors;
       Alcotest.test_case "load_result reports unknown fields" `Quick
         test_load_result_reports_unknown_fields;
+    ]);
+    ("agent capabilities", [
+      Alcotest.test_case "reasoning effort values by agent" `Quick
+        test_reasoning_effort_values_by_agent;
+      Alcotest.test_case "validate reasoning effort for agent" `Quick
+        test_validate_reasoning_effort_for_agent;
     ]);
     ("persistence", [
       Alcotest.test_case "save reaps stale atomic temp" `Quick


### PR DESCRIPTION
## Summary
- move per-agent reasoning effort capability lists and validation into Config
- route control API option rendering and set_effort validation through the shared helpers
- add config tests for the Claude/Codex/Gemini effort matrix

## Validation
- git diff --check
- nix develop --command dune exec ./test/test_config.exe
- nix develop --command dune runtest

Part of #85.