### PR TITLE
Refactor command route metadata

### DIFF
--- a/lib/bot.ml
+++ b/lib/bot.ml
@@ -2433,36 +2433,7 @@ let handle_command t msg cmd =
       ) in
       reply (String.concat "\n" status_lines))
   | Command.Help ->
-    reply (String.concat "\n" [
-      "**Commands:**";
-      "`!projects` — list discovered projects";
-      "`!sessions` — list active bot sessions";
-      "`!claude-sessions` — list recent Claude sessions";
-      "`!codex-sessions` — list recent Codex sessions";
-      "`!gemini-sessions` — list recent Gemini sessions";
-      "`!start <project> [agent]` — start a session (defaults to the current effective top-level agent)";
-      "`!import-project <github-url> [name]` — clone a GitHub repo into the project registry";
-      "`!default-agent [agent]` / `!default_agent [agent]` — show or set the default agent (claude|codex|gemini)";
-      "`!rescue-agent [agent|off]` / `!rescue_agent [agent|off]` — show or set the rescue agent used under disk pressure";
-      "`!session-agent [agent]` / `!session_agent [agent]` — show or set the current channel session agent";
-      "`!resume [agent] <session_id>` — resume a session (no agent = try the current effective top-level agent first)";
-      "`!fork [--move|--no-move]` — create a new thread for context management";
-      "`!reset` — clear this channel's session context";
-      "`!stop <thread_id>` — stop a session";
-      "`!esc` / `!int` / `!interrupt` — stop this thread's active session";
-      "`!rename [thread_id] <name>` — rename a thread";
-      "`!status` — bot status and running processes";
-      "`!refresh` — re-scan for new projects";
-      "`!cleanup` — delete stale channels";
-      "`!restart` — rebuild and restart (warns but doesn't block active sessions)";
-      "`!version` — build info and runtime status";
-      "`!desktop` — set wrapping to desktop width";
-      "`!mobile` — set wrapping to mobile width";
-      "`!wrapping [n]` — show or set line wrap width";
-      "`!lines [n]` — show or set output lines for tool/code display";
-      "`!scroll [n]` — view truncated output (n=block: 1=last, 2=2nd last; repeats advance)";
-      "`!help` — this message";
-    ])
+    reply (String.concat "\n" ("**Commands:**" :: Command.help_lines))
   | Command.Desktop ->
     t.wrap_width <- Agent_process.desktop_width;
     reply (Printf.sprintf "Wrapping set to desktop (%d chars)."
@@ -3137,13 +3108,9 @@ let handle_message t (msg : Discord_types.message) =
   if t.draining then begin
     if Command.is_command msg.content then
       let cmd = Command.parse msg.content in
-      match cmd with
-      | Command.Status | Command.List_projects | Command.List_sessions
-      | Command.List_claude_sessions | Command.List_codex_sessions
-      | Command.List_gemini_sessions
-      | Command.Help ->
+      if Command.is_allowed_during_drain cmd then
         handle_command_safely t msg cmd
-      | _ ->
+      else
         ignore (Discord_rest.create_message t.rest
           ~channel_id:msg.Discord_types.channel_id
           ~content:"Bot is restarting. Try again shortly." ())

--- a/lib/command.ml
+++ b/lib/command.ml
@@ -34,10 +34,249 @@ type t =
   | Help
   | Unknown of string
 
+type id =
+  | List_projects_id
+  | List_sessions_id
+  | List_claude_sessions_id
+  | List_codex_sessions_id
+  | List_gemini_sessions_id
+  | Start_agent_id
+  | Import_project_id
+  | Resume_session_id
+  | Fork_session_id
+  | Reset_session_id
+  | Stop_session_id
+  | Interrupt_session_id
+  | Cleanup_channels_id
+  | Default_agent_id
+  | Rescue_agent_id
+  | Session_agent_id
+  | Restart_id
+  | Refresh_id
+  | Rename_thread_id
+  | Status_id
+  | Desktop_id
+  | Mobile_id
+  | Wrapping_id
+  | Lines_id
+  | Scroll_id
+  | Help_id
+  | Unknown_id
+
+type drain_policy =
+  | Allow_during_drain
+  | Block_during_drain
+
+type spec = {
+  id : id;
+  primary : string;
+  aliases : string list;
+  help : string list;
+  no_arg_command : t option;
+  drain_policy : drain_policy;
+}
+
+let id_of = function
+  | List_projects -> List_projects_id
+  | List_sessions -> List_sessions_id
+  | List_claude_sessions -> List_claude_sessions_id
+  | List_codex_sessions -> List_codex_sessions_id
+  | List_gemini_sessions -> List_gemini_sessions_id
+  | Start_agent _ -> Start_agent_id
+  | Import_project _ -> Import_project_id
+  | Resume_session _ -> Resume_session_id
+  | Fork_session _ -> Fork_session_id
+  | Reset_session -> Reset_session_id
+  | Stop_session _ -> Stop_session_id
+  | Interrupt_session -> Interrupt_session_id
+  | Cleanup_channels -> Cleanup_channels_id
+  | Default_agent _ -> Default_agent_id
+  | Rescue_agent _ -> Rescue_agent_id
+  | Session_agent _ -> Session_agent_id
+  | Restart -> Restart_id
+  | Refresh -> Refresh_id
+  | Rename_thread _ -> Rename_thread_id
+  | Status -> Status_id
+  | Desktop -> Desktop_id
+  | Mobile -> Mobile_id
+  | Wrapping _ -> Wrapping_id
+  | Lines _ -> Lines_id
+  | Scroll _ -> Scroll_id
+  | Help -> Help_id
+  | Unknown _ -> Unknown_id
+
+let string_of_id = function
+  | List_projects_id -> "list_projects"
+  | List_sessions_id -> "list_sessions"
+  | List_claude_sessions_id -> "list_claude_sessions"
+  | List_codex_sessions_id -> "list_codex_sessions"
+  | List_gemini_sessions_id -> "list_gemini_sessions"
+  | Start_agent_id -> "start_agent"
+  | Import_project_id -> "import_project"
+  | Resume_session_id -> "resume_session"
+  | Fork_session_id -> "fork_session"
+  | Reset_session_id -> "reset_session"
+  | Stop_session_id -> "stop_session"
+  | Interrupt_session_id -> "interrupt_session"
+  | Cleanup_channels_id -> "cleanup_channels"
+  | Default_agent_id -> "default_agent"
+  | Rescue_agent_id -> "rescue_agent"
+  | Session_agent_id -> "session_agent"
+  | Restart_id -> "restart"
+  | Refresh_id -> "refresh"
+  | Rename_thread_id -> "rename_thread"
+  | Status_id -> "status"
+  | Desktop_id -> "desktop"
+  | Mobile_id -> "mobile"
+  | Wrapping_id -> "wrapping"
+  | Lines_id -> "lines"
+  | Scroll_id -> "scroll"
+  | Help_id -> "help"
+  | Unknown_id -> "unknown"
+
+let command_spec ?(aliases=[]) ?no_arg_command ~id ~primary ~help
+    ~drain_policy () =
+  { id; primary; aliases; help; no_arg_command; drain_policy }
+
+let read_only ?aliases ?no_arg_command ~id ~primary ~help () =
+  command_spec ?aliases ?no_arg_command ~id ~primary ~help
+    ~drain_policy:Allow_during_drain ()
+
+let mutating ?aliases ?no_arg_command ~id ~primary ~help () =
+  command_spec ?aliases ?no_arg_command ~id ~primary ~help
+    ~drain_policy:Block_during_drain ()
+
+let all_specs = [
+  read_only ~id:List_projects_id ~primary:"projects" ~aliases:["list"]
+    ~help:["`!projects` — list discovered projects"]
+    ~no_arg_command:List_projects ();
+  read_only ~id:List_sessions_id ~primary:"sessions"
+    ~help:["`!sessions` — list active bot sessions"]
+    ~no_arg_command:List_sessions ();
+  read_only ~id:List_claude_sessions_id ~primary:"claude-sessions"
+    ~help:["`!claude-sessions` — list recent Claude sessions"]
+    ~no_arg_command:List_claude_sessions ();
+  read_only ~id:List_codex_sessions_id ~primary:"codex-sessions"
+    ~help:["`!codex-sessions` — list recent Codex sessions"]
+    ~no_arg_command:List_codex_sessions ();
+  read_only ~id:List_gemini_sessions_id ~primary:"gemini-sessions"
+    ~help:["`!gemini-sessions` — list recent Gemini sessions"]
+    ~no_arg_command:List_gemini_sessions ();
+  mutating ~id:Start_agent_id ~primary:"start"
+    ~help:[
+      "`!start <project> [agent]` — start a session (defaults to the current effective top-level agent)";
+    ] ();
+  mutating ~id:Import_project_id ~primary:"import-project"
+    ~aliases:["import_project"]
+    ~help:[
+      "`!import-project <github-url> [name]` — clone a GitHub repo into the project registry";
+    ] ();
+  mutating ~id:Default_agent_id ~primary:"default-agent"
+    ~aliases:["default_agent"]
+    ~help:[
+      "`!default-agent [agent]` / `!default_agent [agent]` — show or set the default agent (claude|codex|gemini)";
+    ]
+    ~no_arg_command:(Default_agent None) ();
+  mutating ~id:Rescue_agent_id ~primary:"rescue-agent"
+    ~aliases:["rescue_agent"]
+    ~help:[
+      "`!rescue-agent [agent|off]` / `!rescue_agent [agent|off]` — show or set the rescue agent used under disk pressure";
+    ]
+    ~no_arg_command:(Rescue_agent None) ();
+  mutating ~id:Session_agent_id ~primary:"session-agent"
+    ~aliases:["session_agent"]
+    ~help:[
+      "`!session-agent [agent]` / `!session_agent [agent]` — show or set the current channel session agent";
+    ]
+    ~no_arg_command:(Session_agent None) ();
+  mutating ~id:Resume_session_id ~primary:"resume"
+    ~help:[
+      "`!resume [agent] <session_id>` — resume a session (no agent = try the current effective top-level agent first)";
+    ] ();
+  mutating ~id:Fork_session_id ~primary:"fork"
+    ~help:["`!fork [--move|--no-move]` — create a new thread for context management"]
+    ~no_arg_command:(Fork_session { move = None }) ();
+  mutating ~id:Reset_session_id ~primary:"reset"
+    ~help:["`!reset` — clear this channel's session context"]
+    ~no_arg_command:Reset_session ();
+  mutating ~id:Stop_session_id ~primary:"stop"
+    ~help:["`!stop <thread_id>` — stop a session"] ();
+  mutating ~id:Interrupt_session_id ~primary:"esc"
+    ~aliases:["int"; "interrupt"]
+    ~help:["`!esc` / `!int` / `!interrupt` — stop this thread's active session"]
+    ~no_arg_command:Interrupt_session ();
+  mutating ~id:Rename_thread_id ~primary:"rename"
+    ~help:["`!rename [thread_id] <name>` — rename a thread"] ();
+  read_only ~id:Status_id ~primary:"status" ~aliases:["version"; "info"]
+    ~help:[
+      "`!status` — bot status and running processes";
+      "`!version` — build info and runtime status";
+    ]
+    ~no_arg_command:Status ();
+  mutating ~id:Refresh_id ~primary:"refresh"
+    ~help:["`!refresh` — re-scan for new projects"]
+    ~no_arg_command:Refresh ();
+  mutating ~id:Cleanup_channels_id ~primary:"cleanup"
+    ~aliases:["cleanup-channels"]
+    ~help:["`!cleanup` — delete stale channels"]
+    ~no_arg_command:Cleanup_channels ();
+  mutating ~id:Restart_id ~primary:"restart"
+    ~help:["`!restart` — rebuild and restart (warns but doesn't block active sessions)"]
+    ~no_arg_command:Restart ();
+  mutating ~id:Desktop_id ~primary:"desktop"
+    ~help:["`!desktop` — set wrapping to desktop width"]
+    ~no_arg_command:Desktop ();
+  mutating ~id:Mobile_id ~primary:"mobile"
+    ~help:["`!mobile` — set wrapping to mobile width"]
+    ~no_arg_command:Mobile ();
+  mutating ~id:Wrapping_id ~primary:"wrapping"
+    ~help:["`!wrapping [n]` — show or set line wrap width"]
+    ~no_arg_command:(Wrapping None) ();
+  mutating ~id:Lines_id ~primary:"lines"
+    ~help:["`!lines [n]` — show or set output lines for tool/code display"]
+    ~no_arg_command:(Lines None) ();
+  mutating ~id:Scroll_id ~primary:"scroll"
+    ~help:[
+      "`!scroll [n]` — view truncated output (n=block: 1=last, 2=2nd last; repeats advance)";
+    ]
+    ~no_arg_command:(Scroll None) ();
+  read_only ~id:Help_id ~primary:"help"
+    ~help:["`!help` — this message"]
+    ~no_arg_command:Help ();
+]
+
+let names spec = spec.primary :: spec.aliases
+
+let command_without_args name =
+  let is_name spec = List.exists (( = ) name) (names spec) in
+  match List.find_opt is_name all_specs with
+  | Some { no_arg_command = Some cmd; _ } -> Some cmd
+  | _ -> None
+
+let spec_of_id id =
+  List.find_opt (fun spec -> spec.id = id) all_specs
+
+let spec_id spec = spec.id
+
+let no_arg_command spec = spec.no_arg_command
+
+let is_allowed_during_drain cmd =
+  match spec_of_id (id_of cmd) with
+  | Some { drain_policy = Allow_during_drain; _ } -> true
+  | _ -> false
+
+let help_lines =
+  all_specs
+  |> List.map (fun spec -> spec.help)
+  |> List.flatten
+
 (** Does this message look like a bot command? Requires ! prefix. *)
 let is_command content =
   let trimmed = String.trim content in
   String.length trimmed > 0 && trimmed.[0] = '!'
+
+let parse_agent_kind kind_str =
+  Config.agent_kind_of_string (String.lowercase_ascii kind_str)
 
 let parse content =
   let parts = String.split_on_char ' ' (String.trim content) in
@@ -47,13 +286,8 @@ let parse content =
     | other -> other
   in
   match parts with
-  | ["projects"] | ["list"] -> List_projects
-  | ["sessions"] -> List_sessions
-  | ["claude-sessions"] -> List_claude_sessions
-  | ["codex-sessions"] -> List_codex_sessions
-  | ["gemini-sessions"] -> List_gemini_sessions
   | "start" :: project :: kind_str :: _ ->
-    (match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with
+    (match parse_agent_kind kind_str with
      | Ok kind -> Start_agent { project; kind = Some kind }
      | Error _ -> Unknown content)
   | ["start"; project] ->
@@ -66,35 +300,30 @@ let parse content =
     Import_project { url; name = Some name }
   | ["resume"; session_id] -> Resume_session { session_id; kind = None }
   | ["resume"; kind_str; session_id] ->
-    (match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with
+    (match parse_agent_kind kind_str with
      | Ok k -> Resume_session { session_id; kind = Some k }
      | Error _ -> Unknown content)
   | ["fork"] -> Fork_session { move = None }
   | ["fork"; "--move"] -> Fork_session { move = Some true }
   | ["fork"; "--no-move"] -> Fork_session { move = Some false }
   | ["reset"] -> Reset_session
-  | ["default-agent"] | ["default_agent"] -> Default_agent None
   | ["default-agent"; kind_str] | ["default_agent"; kind_str] ->
-    (match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with
+    (match parse_agent_kind kind_str with
      | Ok k -> Default_agent (Some k)
      | Error _ -> Unknown content)
-  | ["rescue-agent"] | ["rescue_agent"] -> Rescue_agent None
   | ["rescue-agent"; kind_str] | ["rescue_agent"; kind_str] ->
     let kind_str = String.lowercase_ascii kind_str in
     if kind_str = "off" || kind_str = "none" then
       Rescue_agent (Some None)
     else
-      (match Config.agent_kind_of_string kind_str with
+      (match parse_agent_kind kind_str with
        | Ok k -> Rescue_agent (Some (Some k))
        | Error _ -> Unknown content)
-  | ["session-agent"] | ["session_agent"] -> Session_agent None
   | ["session-agent"; kind_str] | ["session_agent"; kind_str] ->
-    (match Config.agent_kind_of_string (String.lowercase_ascii kind_str) with
+    (match parse_agent_kind kind_str with
      | Ok k -> Session_agent (Some k)
      | Error _ -> Unknown content)
   | ["stop"; thread_id] -> Stop_session { thread_id }
-  | ["esc"] | ["int"] | ["interrupt"] -> Interrupt_session
-  | ["cleanup-channels"] | ["cleanup"] -> Cleanup_channels
   | "rename" :: rest when rest <> [] ->
     (* !rename <name> — rename current thread
        !rename <thread_id> <name> — rename a specific thread *)
@@ -109,17 +338,10 @@ let parse content =
     else
       Rename_thread { thread_id = None;
                       name = String.concat " " rest }
-  | ["restart"] -> Restart
-  | ["refresh"] -> Refresh
-  | ["status"] | ["version"] | ["info"] -> Status
-  | ["desktop"] -> Desktop
-  | ["mobile"] -> Mobile
-  | ["wrapping"] -> Wrapping None
   | ["wrapping"; n] ->
     (match int_of_string_opt n with
      | Some w when w > 0 -> Wrapping (Some w)
      | _ -> Unknown content)
-  | ["lines"] -> Lines None
   | ["lines"; n] ->
     (* Accept any positive int here; the handler enforces the upper
        bound (currently 1000) so the user gets a friendly message
@@ -127,12 +349,14 @@ let parse content =
     (match int_of_string_opt n with
      | Some l when l > 0 -> Lines (Some l)
      | _ -> Unknown content)
-  | ["scroll"] -> Scroll None
   | ["scroll"; n] ->
     (match int_of_string_opt n with
      | Some s when s <> 0 -> Scroll (Some s)
      | _ -> Unknown content)
-  | ["help"] -> Help
+  | [name] ->
+    (match command_without_args name with
+     | Some cmd -> cmd
+     | None -> Unknown content)
   | _ -> Unknown content
 
 (** Fuzzy-match a query against project names.

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,5 @@
 (tests
- (names test_formatting test_project test_agent_contracts test_discord_rest test_gateway
+ (names test_command test_formatting test_project test_agent_contracts test_discord_rest test_gateway
  test_runtime_settings test_bot_defaults test_session_store test_disk_health test_config
   test_runtime_limits test_stream_interrupt)
  (libraries discord_agents alcotest str unix yojson eio.mock eio_main cohttp-eio

--- a/test/test_bot_defaults.ml
+++ b/test/test_bot_defaults.ml
@@ -33,7 +33,17 @@ let with_tmp_home f =
       Unix.putenv "XDG_CONFIG_HOME" "";
       f ())
 
-let with_test_bot f =
+let test_rest ~env ~token call : Discord_agents.Discord_rest.t =
+  Mirage_crypto_rng_unix.use_default ();
+  {
+    token;
+    call;
+    clock = Eio.Stdenv.mono_clock env;
+    rest_state = Discord_agents.Discord_rest.create_health_state ();
+    api_base = Discord_agents.Discord_rest.api_base;
+  }
+
+let with_test_bot ?rest_call f =
   with_tmp_home (fun () ->
     Eio_main.run @@ fun env ->
     Eio.Switch.run @@ fun sw ->
@@ -52,10 +62,15 @@ let with_test_bot f =
         projects = [];
         channels = Discord_agents.Channel_manager.create ();
       } in
+      let rest = match rest_call with
+        | Some call -> test_rest ~env ~token:"test-token" call
+        | None ->
+          Discord_agents.Discord_rest.create ~sw ~env ~token:"test-token"
+      in
       let bot : Discord_agents.Bot.t = {
         config;
         settings;
-        rest = Discord_agents.Discord_rest.create ~sw ~env ~token:"test-token";
+        rest;
         gateway = Discord_agents.Discord_gateway.create
           ~token:"test-token"
           ~intents:Discord_agents.Discord_gateway.default_intents
@@ -145,6 +160,76 @@ let make_message ?(message_id="message-1") ?(channel_id="control") content =
     attachments = [];
     referenced_message = None;
   }
+
+let response ?(headers=Http.Header.of_list []) code body =
+  (Http.Response.make ~status:(Http.Status.of_int code) ~headers (),
+   body,
+   false)
+
+let posted_message_json ~id ~channel_id ~content =
+  `Assoc [
+    ("id", `String id);
+    ("channel_id", `String channel_id);
+    ("author", `Assoc [
+      ("id", `String "bot-1");
+      ("username", `String "discord-agents");
+      ("bot", `Bool true);
+    ]);
+    ("content", `String content);
+    ("timestamp", `String "2026-01-01T00:00:00.000000+00:00");
+  ]
+  |> Yojson.Safe.to_string
+
+let request_body_content = function
+  | None -> ""
+  | Some body ->
+    let open Yojson.Safe.Util in
+    Discord_agents.Discord_rest.read_body body
+    |> Yojson.Safe.from_string
+    |> member "content"
+    |> to_string
+
+let channel_id_of_create_message_path path =
+  match String.split_on_char '/' path with
+  | [""; "api"; "v10"; "channels"; channel_id; "messages"] -> channel_id
+  | [""; "channels"; channel_id; "messages"] -> channel_id
+  | _ -> Alcotest.failf "unexpected create_message path: %s" path
+
+let test_draining_routes_commands_through_command_policy () =
+  let posted = ref [] in
+  let next_id = ref 0 in
+  let rest_call ~headers:_ ?body meth uri =
+    Alcotest.(check string) "drain reply uses create_message POST"
+      "POST" (Http.Method.to_string meth);
+    let channel_id = channel_id_of_create_message_path (Uri.path uri) in
+    let content = request_body_content body in
+    posted := content :: !posted;
+    incr next_id;
+    response 200
+      (posted_message_json
+        ~id:(Printf.sprintf "reply-%d" !next_id)
+        ~channel_id
+        ~content)
+  in
+  with_test_bot ~rest_call (fun bot ->
+    bot.Discord_agents.Bot.draining <- true;
+    Discord_agents.Bot.handle_message bot
+      (make_message ~message_id:"m-help" "!help");
+    Discord_agents.Bot.handle_message bot
+      (make_message ~message_id:"m-start" "!start demo");
+    Discord_agents.Bot.handle_message bot
+      (make_message ~message_id:"m-unknown" "!bogus");
+    match List.rev !posted with
+    | [help; start; unknown] ->
+      Alcotest.(check bool) "help command allowed during drain"
+        true (String.starts_with ~prefix:"**Commands:**" help);
+      Alcotest.(check string) "mutating command blocked during drain"
+        "Bot is restarting. Try again shortly." start;
+      Alcotest.(check string) "unknown command blocked during drain"
+        "Bot is restarting. Try again shortly." unknown
+    | other ->
+      Alcotest.failf "expected 3 posted messages, got %d"
+        (List.length other))
 
 let wait_for_process_exit pid =
   let deadline = Unix.gettimeofday () +. 5.0 in
@@ -1975,6 +2060,8 @@ let () =
         test_process_session_message_aborts_on_session_id_persist_failure;
       Alcotest.test_case "process message keeps run replayable on completion persist failure" `Quick
         test_process_session_message_keeps_run_replayable_on_completion_persist_failure;
+      Alcotest.test_case "draining routes commands through command policy" `Quick
+        test_draining_routes_commands_through_command_policy;
       Alcotest.test_case "inter-agent message includes origin and hop marker" `Quick
         test_prepare_inter_agent_message_formats_origin_and_hop_marker;
       Alcotest.test_case "inter-agent message rejects commands" `Quick

--- a/test/test_command.ml
+++ b/test/test_command.ml
@@ -1,0 +1,172 @@
+module Command = Discord_agents.Command
+
+let id_testable =
+  Alcotest.testable
+    (fun fmt id -> Format.fprintf fmt "%s" (Command.string_of_id id))
+    ( = )
+
+let failf fmt = Format.kasprintf (fun message -> Alcotest.fail message) fmt
+
+let check_parse_id raw expected =
+  let actual = Command.(id_of (parse raw)) in
+  Alcotest.(check id_testable) raw expected actual
+
+let test_spec_names_are_unique () =
+  let seen = Hashtbl.create 32 in
+  Command.all_specs
+  |> List.iter (fun spec ->
+    Command.names spec
+    |> List.iter (fun name ->
+      if Hashtbl.mem seen name then
+        failf "duplicate command name in specs: %s" name
+      else
+        Hashtbl.add seen name (Command.spec_id spec)))
+
+let test_no_arg_spec_names_parse_to_spec_id () =
+  Command.all_specs
+  |> List.iter (fun spec ->
+    match Command.no_arg_command spec with
+    | None -> ()
+    | Some expected ->
+      let expected_id = Command.id_of expected in
+      Command.names spec
+      |> List.iter (fun name -> check_parse_id ("!" ^ name) expected_id))
+
+let test_start_without_project_keeps_project_list_shortcut () =
+  check_parse_id "!start" Command.List_projects_id
+
+let require_spec id =
+  match Command.spec_of_id id with
+  | Some spec -> spec
+  | None ->
+    failf "missing command spec for %s" (Command.string_of_id id)
+
+let check_all_spec_names_parse ~id ~raw_of_name =
+  let spec = require_spec id in
+  Command.names spec
+  |> List.iter (fun name -> check_parse_id (raw_of_name name) id)
+
+let test_argument_spec_names_parse_to_spec_id () =
+  [
+    Command.Start_agent_id, (fun name -> Printf.sprintf "!%s demo" name);
+    Start_agent_id, (fun name -> Printf.sprintf "!%s demo codex" name);
+    Import_project_id,
+    (fun name -> Printf.sprintf "!%s https://github.com/tedks/demo.git" name);
+    Import_project_id,
+    (fun name -> Printf.sprintf
+       "!%s https://github.com/tedks/demo.git local-demo" name);
+    Default_agent_id, (fun name -> Printf.sprintf "!%s codex" name);
+    Rescue_agent_id, (fun name -> Printf.sprintf "!%s codex" name);
+    Rescue_agent_id, (fun name -> Printf.sprintf "!%s off" name);
+    Session_agent_id, (fun name -> Printf.sprintf "!%s codex" name);
+    Resume_session_id, (fun name -> Printf.sprintf "!%s session-1" name);
+    Resume_session_id, (fun name -> Printf.sprintf "!%s codex session-1" name);
+    Fork_session_id, (fun name -> Printf.sprintf "!%s --move" name);
+    Fork_session_id, (fun name -> Printf.sprintf "!%s --no-move" name);
+    Stop_session_id, (fun name -> Printf.sprintf "!%s 123456789012" name);
+    Rename_thread_id, (fun name -> Printf.sprintf "!%s new-name" name);
+    Wrapping_id, (fun name -> Printf.sprintf "!%s 80" name);
+    Lines_id, (fun name -> Printf.sprintf "!%s 80" name);
+    Scroll_id, (fun name -> Printf.sprintf "!%s 2" name);
+  ]
+  |> List.iter (fun (id, raw_of_name) ->
+    check_all_spec_names_parse ~id ~raw_of_name)
+
+let test_drain_policy_matches_existing_read_only_set () =
+  let allowed = [
+    Command.List_projects;
+    List_sessions;
+    List_claude_sessions;
+    List_codex_sessions;
+    List_gemini_sessions;
+    Status;
+    Help;
+  ] in
+  allowed
+  |> List.iter (fun cmd ->
+    Alcotest.(check bool)
+      (Command.string_of_id (Command.id_of cmd))
+      true
+      (Command.is_allowed_during_drain cmd));
+  let blocked = [
+    Command.Start_agent { project = "p"; kind = None };
+    Import_project { url = "https://github.com/owner/repo.git"; name = None };
+    Resume_session { session_id = "abc"; kind = None };
+    Fork_session { move = None };
+    Reset_session;
+    Stop_session { thread_id = "123" };
+    Interrupt_session;
+    Cleanup_channels;
+    Default_agent None;
+    Rescue_agent None;
+    Session_agent None;
+    Restart;
+    Refresh;
+    Rename_thread { thread_id = None; name = "x" };
+    Desktop;
+    Mobile;
+    Wrapping None;
+    Lines None;
+    Scroll None;
+    Unknown "!bogus";
+  ] in
+  blocked
+  |> List.iter (fun cmd ->
+    Alcotest.(check bool)
+      (Command.string_of_id (Command.id_of cmd))
+      false
+      (Command.is_allowed_during_drain cmd))
+
+let expected_spec_ids = [
+  Command.List_projects_id;
+  List_sessions_id;
+  List_claude_sessions_id;
+  List_codex_sessions_id;
+  List_gemini_sessions_id;
+  Start_agent_id;
+  Import_project_id;
+  Default_agent_id;
+  Rescue_agent_id;
+  Session_agent_id;
+  Resume_session_id;
+  Fork_session_id;
+  Reset_session_id;
+  Stop_session_id;
+  Interrupt_session_id;
+  Rename_thread_id;
+  Status_id;
+  Refresh_id;
+  Cleanup_channels_id;
+  Restart_id;
+  Desktop_id;
+  Mobile_id;
+  Wrapping_id;
+  Lines_id;
+  Scroll_id;
+  Help_id;
+]
+
+let test_specs_cover_command_ids () =
+  let actual = List.map Command.spec_id Command.all_specs in
+  Alcotest.(check (list id_testable))
+    "command specs cover expected ids"
+    expected_spec_ids
+    actual
+
+let () =
+  Alcotest.run "command" [
+    ("metadata", [
+      Alcotest.test_case "spec names are unique" `Quick
+        test_spec_names_are_unique;
+      Alcotest.test_case "no-arg spec names parse to spec id" `Quick
+        test_no_arg_spec_names_parse_to_spec_id;
+      Alcotest.test_case "start without project remains project list shortcut"
+        `Quick test_start_without_project_keeps_project_list_shortcut;
+      Alcotest.test_case "argument spec names parse to spec id" `Quick
+        test_argument_spec_names_parse_to_spec_id;
+      Alcotest.test_case "drain policy matches existing read-only set" `Quick
+        test_drain_policy_matches_existing_read_only_set;
+      Alcotest.test_case "specs cover command ids" `Quick
+        test_specs_cover_command_ids;
+    ]);
+  ]


### PR DESCRIPTION
## Summary
- add typed command ids and route descriptors for aliases, help text, no-arg parsing, and drain-mode policy
- route bot help output and restart-drain command allowlisting through `Command` metadata
- add command metadata tests to catch alias, no-arg, drain-policy, and descriptor coverage drift

## Validation
- `nix develop --command dune exec ./test/test_command.exe`
- `nix develop --command dune runtest`
- `git diff --check`

Refs #85