### PR TITLE
Refactor control API method dispatch

### DIFF
--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -55,6 +55,79 @@ let error_response msg =
 let json_of_int64 n =
   `Intlit (Int64.to_string n)
 
+type method_id =
+  | Health_id
+  | List_projects_id
+  | List_sessions_id
+  | Import_project_id
+  | List_claude_sessions_id
+  | List_codex_sessions_id
+  | List_gemini_sessions_id
+  | Start_session_id
+  | Resume_session_id
+  | Stop_session_id
+  | Send_message_id
+  | Default_agent_id
+  | Rescue_agent_id
+  | Get_agent_config_id
+  | Set_model_id
+  | Set_effort_id
+  | Set_goal_id
+  | Start_login_flow_id
+  | Restart_id
+  | Rename_thread_id
+  | Cleanup_channels_id
+  | Refresh_projects_id
+
+type mutability =
+  | Read_only
+  | Mutates_session
+  | Mutates_runtime
+  | Mutates_projects
+  | Mutates_discord
+  | Restarts_process
+
+type method_spec = {
+  id : method_id;
+  name : string;
+  mutability : mutability;
+  mcp_exposed : bool;
+  timeout_s : int;
+  handler : Bot.t -> Yojson.Safe.t option -> Yojson.Safe.t;
+}
+
+let string_of_method_id = function
+  | Health_id -> "health"
+  | List_projects_id -> "list_projects"
+  | List_sessions_id -> "list_sessions"
+  | Import_project_id -> "import_project"
+  | List_claude_sessions_id -> "list_claude_sessions"
+  | List_codex_sessions_id -> "list_codex_sessions"
+  | List_gemini_sessions_id -> "list_gemini_sessions"
+  | Start_session_id -> "start_session"
+  | Resume_session_id -> "resume_session"
+  | Stop_session_id -> "stop_session"
+  | Send_message_id -> "send_message"
+  | Default_agent_id -> "default_agent"
+  | Rescue_agent_id -> "rescue_agent"
+  | Get_agent_config_id -> "get_agent_config"
+  | Set_model_id -> "set_model"
+  | Set_effort_id -> "set_effort"
+  | Set_goal_id -> "set_goal"
+  | Start_login_flow_id -> "start_login_flow"
+  | Restart_id -> "restart"
+  | Rename_thread_id -> "rename_thread"
+  | Cleanup_channels_id -> "cleanup_channels"
+  | Refresh_projects_id -> "refresh_projects"
+
+let string_of_mutability = function
+  | Read_only -> "read_only"
+  | Mutates_session -> "mutates_session"
+  | Mutates_runtime -> "mutates_runtime"
+  | Mutates_projects -> "mutates_projects"
+  | Mutates_discord -> "mutates_discord"
+  | Restarts_process -> "restarts_process"
+
 let cleanup_orphan_thread rest ~thread_id ~context =
   match Discord_rest.delete_channel rest ~channel_id:thread_id () with
   | Ok _ -> ()
@@ -1250,32 +1323,87 @@ let handle_cleanup_channels (bot : Bot.t) =
 
 (* ── Router ────────────────────────────────────────────────────── *)
 
+let method_spec ?(mcp_exposed=true) ?(timeout_s=60) ~id ~mutability ~handler () =
+  { id; name = string_of_method_id id; mutability; mcp_exposed; timeout_s;
+    handler }
+
+let all_method_specs = [
+  method_spec ~id:Health_id ~mutability:Read_only ~mcp_exposed:false
+    ~handler:(fun bot _params -> handle_health bot) ();
+  method_spec ~id:List_projects_id ~mutability:Read_only
+    ~handler:(fun bot _params -> handle_list_projects bot) ();
+  method_spec ~id:List_sessions_id ~mutability:Read_only
+    ~handler:(fun bot _params -> handle_list_sessions bot) ();
+  method_spec ~id:Import_project_id ~mutability:Mutates_projects
+    ~timeout_s:300
+    ~handler:(fun bot params -> handle_import_project bot params) ();
+  method_spec ~id:List_claude_sessions_id ~mutability:Read_only
+    ~handler:(fun bot params -> handle_list_claude_sessions bot params) ();
+  method_spec ~id:List_codex_sessions_id ~mutability:Read_only
+    ~handler:(fun bot params -> handle_list_codex_sessions bot params) ();
+  method_spec ~id:List_gemini_sessions_id ~mutability:Read_only
+    ~handler:(fun bot params -> handle_list_gemini_sessions bot params) ();
+  method_spec ~id:Start_session_id ~mutability:Mutates_session
+    ~timeout_s:120
+    ~handler:(fun bot params -> handle_start_session bot params) ();
+  method_spec ~id:Resume_session_id ~mutability:Mutates_session
+    ~timeout_s:120
+    ~handler:(fun bot params -> handle_resume_session bot params) ();
+  method_spec ~id:Stop_session_id ~mutability:Mutates_session
+    ~handler:(fun bot params -> handle_stop_session bot params) ();
+  method_spec ~id:Send_message_id ~mutability:Mutates_session
+    ~handler:(fun bot params -> handle_send_message bot params) ();
+  method_spec ~id:Default_agent_id ~mutability:Mutates_runtime
+    ~handler:(fun bot params -> handle_default_agent bot params) ();
+  method_spec ~id:Rescue_agent_id ~mutability:Mutates_runtime
+    ~handler:(fun bot params -> handle_rescue_agent bot params) ();
+  method_spec ~id:Get_agent_config_id ~mutability:Read_only
+    ~handler:(fun bot params -> handle_get_agent_config bot params) ();
+  method_spec ~id:Set_model_id ~mutability:Mutates_session
+    ~handler:(fun bot params -> handle_set_model bot params) ();
+  method_spec ~id:Set_effort_id ~mutability:Mutates_session
+    ~handler:(fun bot params -> handle_set_effort bot params) ();
+  method_spec ~id:Set_goal_id ~mutability:Mutates_session
+    ~handler:(fun bot params -> handle_set_goal bot params) ();
+  method_spec ~id:Start_login_flow_id ~mutability:Read_only
+    ~handler:(fun bot params -> handle_start_login_flow bot params) ();
+  method_spec ~id:Restart_id ~mutability:Restarts_process
+    ~handler:(fun bot _params -> handle_restart bot) ();
+  method_spec ~id:Rename_thread_id ~mutability:Mutates_discord
+    ~handler:(fun bot params -> handle_rename_thread bot params) ();
+  method_spec ~id:Cleanup_channels_id ~mutability:Mutates_discord
+    ~handler:(fun bot _params -> handle_cleanup_channels bot) ();
+  method_spec ~id:Refresh_projects_id ~mutability:Mutates_projects
+    ~handler:(fun bot _params -> handle_refresh_projects bot) ();
+]
+
+let method_spec_id spec = spec.id
+
+let method_spec_name spec = spec.name
+
+let method_spec_mutability spec = spec.mutability
+
+let method_spec_timeout_s spec = spec.timeout_s
+
+let method_spec_mcp_exposed spec = spec.mcp_exposed
+
+let method_spec_of_name name =
+  List.find_opt (fun spec -> String.equal spec.name name) all_method_specs
+
+let method_spec_of_id id =
+  List.find_opt (fun spec -> spec.id = id) all_method_specs
+
+let mcp_exposed_method_specs =
+  List.filter method_spec_mcp_exposed all_method_specs
+
+let mcp_control_method_names =
+  List.map method_spec_name mcp_exposed_method_specs
+
 let dispatch (bot : Bot.t) method_ params =
   try
-    match method_ with
-    | "health" -> handle_health bot
-    | "list_projects" -> handle_list_projects bot
-    | "list_sessions" -> handle_list_sessions bot
-    | "import_project" -> handle_import_project bot params
-    | "list_claude_sessions" -> handle_list_claude_sessions bot params
-    | "list_codex_sessions" -> handle_list_codex_sessions bot params
-    | "list_gemini_sessions" -> handle_list_gemini_sessions bot params
-    | "start_session" -> handle_start_session bot params
-    | "resume_session" -> handle_resume_session bot params
-    | "stop_session" -> handle_stop_session bot params
-    | "send_message" -> handle_send_message bot params
-    | "default_agent" -> handle_default_agent bot params
-    | "rescue_agent" -> handle_rescue_agent bot params
-    | "get_agent_config" -> handle_get_agent_config bot params
-    | "set_model" -> handle_set_model bot params
-    | "set_effort" -> handle_set_effort bot params
-    | "set_goal" -> handle_set_goal bot params
-    | "start_login_flow" -> handle_start_login_flow bot params
-    | "restart" -> handle_restart bot
-    | "rename_thread" -> handle_rename_thread bot params
-    | "cleanup_channels" -> handle_cleanup_channels bot
-    | "refresh_projects" -> handle_refresh_projects bot
-    | _ -> error_response (Printf.sprintf "Unknown method: %s" method_)
+    match method_spec_of_name method_ with
+    | Some spec -> spec.handler bot params
+    | None -> error_response (Printf.sprintf "Unknown method: %s" method_)
   with exn ->
     raise_if_cancelled exn;
     Logs.warn (fun m -> m "control_api: handler error: %s" (Printexc.to_string exn));

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -1323,57 +1323,62 @@ let handle_cleanup_channels (bot : Bot.t) =
 
 (* ── Router ────────────────────────────────────────────────────── *)
 
-let method_spec ?(mcp_exposed=true) ?(timeout_s=60) ~id ~mutability ~handler () =
+let method_spec ?(timeout_s=60) ~id ~mutability ~mcp_exposed ~handler () =
   { id; name = string_of_method_id id; mutability; mcp_exposed; timeout_s;
     handler }
 
 let all_method_specs = [
   method_spec ~id:Health_id ~mutability:Read_only ~mcp_exposed:false
     ~handler:(fun bot _params -> handle_health bot) ();
-  method_spec ~id:List_projects_id ~mutability:Read_only
+  method_spec ~id:List_projects_id ~mutability:Read_only ~mcp_exposed:true
     ~handler:(fun bot _params -> handle_list_projects bot) ();
-  method_spec ~id:List_sessions_id ~mutability:Read_only
+  method_spec ~id:List_sessions_id ~mutability:Read_only ~mcp_exposed:true
     ~handler:(fun bot _params -> handle_list_sessions bot) ();
-  method_spec ~id:Import_project_id ~mutability:Mutates_projects
+  method_spec ~id:Import_project_id ~mutability:Mutates_projects ~mcp_exposed:true
     ~timeout_s:300
     ~handler:(fun bot params -> handle_import_project bot params) ();
   method_spec ~id:List_claude_sessions_id ~mutability:Read_only
+    ~mcp_exposed:true
     ~handler:(fun bot params -> handle_list_claude_sessions bot params) ();
   method_spec ~id:List_codex_sessions_id ~mutability:Read_only
+    ~mcp_exposed:true
     ~handler:(fun bot params -> handle_list_codex_sessions bot params) ();
   method_spec ~id:List_gemini_sessions_id ~mutability:Read_only
+    ~mcp_exposed:true
     ~handler:(fun bot params -> handle_list_gemini_sessions bot params) ();
-  method_spec ~id:Start_session_id ~mutability:Mutates_session
+  method_spec ~id:Start_session_id ~mutability:Mutates_session ~mcp_exposed:true
     ~timeout_s:120
     ~handler:(fun bot params -> handle_start_session bot params) ();
-  method_spec ~id:Resume_session_id ~mutability:Mutates_session
+  method_spec ~id:Resume_session_id ~mutability:Mutates_session ~mcp_exposed:true
     ~timeout_s:120
     ~handler:(fun bot params -> handle_resume_session bot params) ();
-  method_spec ~id:Stop_session_id ~mutability:Mutates_session
+  method_spec ~id:Stop_session_id ~mutability:Mutates_session ~mcp_exposed:true
     ~handler:(fun bot params -> handle_stop_session bot params) ();
-  method_spec ~id:Send_message_id ~mutability:Mutates_session
+  method_spec ~id:Send_message_id ~mutability:Mutates_session ~mcp_exposed:true
     ~handler:(fun bot params -> handle_send_message bot params) ();
-  method_spec ~id:Default_agent_id ~mutability:Mutates_runtime
+  method_spec ~id:Default_agent_id ~mutability:Mutates_runtime ~mcp_exposed:true
     ~handler:(fun bot params -> handle_default_agent bot params) ();
-  method_spec ~id:Rescue_agent_id ~mutability:Mutates_runtime
+  method_spec ~id:Rescue_agent_id ~mutability:Mutates_runtime ~mcp_exposed:true
     ~handler:(fun bot params -> handle_rescue_agent bot params) ();
-  method_spec ~id:Get_agent_config_id ~mutability:Read_only
+  method_spec ~id:Get_agent_config_id ~mutability:Read_only ~mcp_exposed:true
     ~handler:(fun bot params -> handle_get_agent_config bot params) ();
-  method_spec ~id:Set_model_id ~mutability:Mutates_session
+  method_spec ~id:Set_model_id ~mutability:Mutates_session ~mcp_exposed:true
     ~handler:(fun bot params -> handle_set_model bot params) ();
-  method_spec ~id:Set_effort_id ~mutability:Mutates_session
+  method_spec ~id:Set_effort_id ~mutability:Mutates_session ~mcp_exposed:true
     ~handler:(fun bot params -> handle_set_effort bot params) ();
-  method_spec ~id:Set_goal_id ~mutability:Mutates_session
+  method_spec ~id:Set_goal_id ~mutability:Mutates_session ~mcp_exposed:true
     ~handler:(fun bot params -> handle_set_goal bot params) ();
-  method_spec ~id:Start_login_flow_id ~mutability:Read_only
+  method_spec ~id:Start_login_flow_id ~mutability:Read_only ~mcp_exposed:true
     ~handler:(fun bot params -> handle_start_login_flow bot params) ();
-  method_spec ~id:Restart_id ~mutability:Restarts_process
+  method_spec ~id:Restart_id ~mutability:Restarts_process ~mcp_exposed:true
     ~handler:(fun bot _params -> handle_restart bot) ();
-  method_spec ~id:Rename_thread_id ~mutability:Mutates_discord
+  method_spec ~id:Rename_thread_id ~mutability:Mutates_discord ~mcp_exposed:true
     ~handler:(fun bot params -> handle_rename_thread bot params) ();
   method_spec ~id:Cleanup_channels_id ~mutability:Mutates_discord
+    ~mcp_exposed:true
     ~handler:(fun bot _params -> handle_cleanup_channels bot) ();
   method_spec ~id:Refresh_projects_id ~mutability:Mutates_projects
+    ~mcp_exposed:true
     ~handler:(fun bot _params -> handle_refresh_projects bot) ();
 ]
 

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,5 @@
 (tests
- (names test_command test_formatting test_project test_agent_contracts test_discord_rest test_gateway
+ (names test_command test_control_api test_formatting test_project test_agent_contracts test_discord_rest test_gateway
  test_runtime_settings test_bot_defaults test_session_store test_disk_health test_config
   test_runtime_limits test_stream_interrupt)
  (libraries discord_agents alcotest str unix yojson eio.mock eio_main cohttp-eio

--- a/test/test_control_api.ml
+++ b/test/test_control_api.ml
@@ -13,6 +13,89 @@ let mutability_testable =
 
 let failf fmt = Format.kasprintf (fun message -> Alcotest.fail message) fmt
 
+let repo_file path =
+  let rec search dir =
+    let candidate = Filename.concat dir path in
+    if Sys.file_exists candidate then candidate
+    else
+      let parent = Filename.dirname dir in
+      if String.equal parent dir then
+        failf "could not find %s from %s" path (Sys.getcwd ())
+      else
+        search parent
+  in
+  search (Sys.getcwd ())
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
+    let n = in_channel_length ic in
+    really_input_string ic n)
+
+let collect_matches regexp group text =
+  let rec loop pos acc =
+    match Str.search_forward regexp text pos with
+    | exception Not_found -> List.rev acc
+    | _ ->
+      loop (Str.match_end ())
+        (Str.matched_group group text :: acc)
+  in
+  loop 0 []
+
+let unique_preserving_order values =
+  let seen = Hashtbl.create 32 in
+  values
+  |> List.filter (fun value ->
+    if Hashtbl.mem seen value then false
+    else begin
+      Hashtbl.add seen value ();
+      true
+    end)
+
+let sorted_strings values =
+  List.sort String.compare values
+
+let mcp_server_py =
+  lazy (read_file (repo_file "scripts/mcp-server.py"))
+
+let python_control_methods () =
+  collect_matches
+    (Str.regexp "control_request(\"\\([^\"]+\\)\"")
+    1
+    (Lazy.force mcp_server_py)
+  |> unique_preserving_order
+
+let python_default_timeout_s () =
+  let regexp =
+    Str.regexp "def control_request(method, params=None, timeout=\\([0-9]+\\))"
+  in
+  match Str.search_forward regexp (Lazy.force mcp_server_py) 0 with
+  | exception Not_found -> failf "could not find Python control_request timeout"
+  | _ -> int_of_string (Str.matched_group 1 (Lazy.force mcp_server_py))
+
+let python_explicit_timeouts () =
+  let regexp =
+    Str.regexp "control_request(\"\\([^\"]+\\)\"[^\n]*timeout=\\([0-9]+\\)"
+  in
+  let text = Lazy.force mcp_server_py in
+  let rec loop pos acc =
+    match Str.search_forward regexp text pos with
+    | exception Not_found -> acc
+    | _ ->
+      let method_name = Str.matched_group 1 text in
+      let timeout_s = int_of_string (Str.matched_group 2 text) in
+      let acc =
+        match List.assoc_opt method_name acc with
+        | None -> (method_name, timeout_s) :: acc
+        | Some existing when existing = timeout_s -> acc
+        | Some existing ->
+          failf "conflicting Python timeout for %s: %d and %d"
+            method_name existing timeout_s
+      in
+      loop (Str.match_end ()) acc
+  in
+  loop 0 []
+
 let expected_method_ids = [
   Control_api.Health_id;
   List_projects_id;
@@ -55,15 +138,6 @@ let test_spec_names_are_unique () =
     else
       Hashtbl.add seen name (Control_api.method_spec_id spec))
 
-let test_names_match_method_ids () =
-  Control_api.all_method_specs
-  |> List.iter (fun spec ->
-    let id = Control_api.method_spec_id spec in
-    Alcotest.(check string)
-      (Control_api.string_of_method_id id)
-      (Control_api.string_of_method_id id)
-      (Control_api.method_spec_name spec))
-
 let test_lookup_round_trips () =
   Control_api.all_method_specs
   |> List.iter (fun spec ->
@@ -82,48 +156,56 @@ let test_lookup_round_trips () =
       failf "missing control method spec for %s"
         (Control_api.string_of_method_id id)
     | Some spec ->
-      Alcotest.(check string)
+      Alcotest.(check method_id_testable)
         (Control_api.string_of_method_id id)
-        (Control_api.string_of_method_id id)
-        (Control_api.method_spec_name spec))
+        id
+        (Control_api.method_spec_id spec))
 
-let expected_mcp_control_method_names = [
-  "list_projects";
-  "list_sessions";
-  "import_project";
-  "list_claude_sessions";
-  "list_codex_sessions";
-  "list_gemini_sessions";
-  "start_session";
-  "resume_session";
-  "stop_session";
-  "send_message";
-  "default_agent";
-  "rescue_agent";
-  "get_agent_config";
-  "set_model";
-  "set_effort";
-  "set_goal";
-  "start_login_flow";
-  "restart";
-  "rename_thread";
-  "cleanup_channels";
-  "refresh_projects";
+(* These lists intentionally duplicate the descriptor table. Changing
+   control methods should require a conscious update to the metadata tests. *)
+let expected_mcp_exposed_method_ids = [
+  Control_api.List_projects_id;
+  List_sessions_id;
+  Import_project_id;
+  List_claude_sessions_id;
+  List_codex_sessions_id;
+  List_gemini_sessions_id;
+  Start_session_id;
+  Resume_session_id;
+  Stop_session_id;
+  Send_message_id;
+  Default_agent_id;
+  Rescue_agent_id;
+  Get_agent_config_id;
+  Set_model_id;
+  Set_effort_id;
+  Set_goal_id;
+  Start_login_flow_id;
+  Restart_id;
+  Rename_thread_id;
+  Cleanup_channels_id;
+  Refresh_projects_id;
 ]
 
 let test_mcp_exposure_is_explicit () =
+  let actual =
+    Control_api.mcp_exposed_method_specs
+    |> List.map Control_api.method_spec_id
+  in
+  Alcotest.(check (list method_id_testable))
+    "MCP-exposed method ids"
+    expected_mcp_exposed_method_ids
+    actual;
   Alcotest.(check (list string))
     "MCP-visible control method names"
-    expected_mcp_control_method_names
-    Control_api.mcp_control_method_names;
-  Control_api.all_method_specs
-  |> List.iter (fun spec ->
-    let id = Control_api.method_spec_id spec in
-    let expected = id <> Control_api.Health_id in
-    Alcotest.(check bool)
-      (Control_api.string_of_method_id id)
-      expected
-      (Control_api.method_spec_mcp_exposed spec))
+    (List.map Control_api.string_of_method_id expected_mcp_exposed_method_ids)
+    Control_api.mcp_control_method_names
+
+let test_python_mcp_control_methods_match_descriptors () =
+  Alcotest.(check (list string))
+    "Python MCP control methods"
+    (sorted_strings Control_api.mcp_control_method_names)
+    (sorted_strings (python_control_methods ()))
 
 let expected_timeout_s = function
   | Control_api.Import_project_id -> 300
@@ -138,6 +220,21 @@ let test_timeout_metadata_matches_current_mcp_client () =
     Alcotest.(check int)
       (Control_api.string_of_method_id id)
       (expected_timeout_s id)
+      (Control_api.method_spec_timeout_s spec))
+
+let test_timeout_metadata_matches_python_mcp_client () =
+  let default_timeout_s = python_default_timeout_s () in
+  let explicit_timeouts = python_explicit_timeouts () in
+  Control_api.mcp_exposed_method_specs
+  |> List.iter (fun spec ->
+    let name = Control_api.method_spec_name spec in
+    let expected =
+      Option.value (List.assoc_opt name explicit_timeouts)
+        ~default:default_timeout_s
+    in
+    Alcotest.(check int)
+      name
+      expected
       (Control_api.method_spec_timeout_s spec))
 
 let expected_mutability = function
@@ -180,14 +277,16 @@ let () =
         test_specs_cover_method_ids;
       Alcotest.test_case "spec names are unique" `Quick
         test_spec_names_are_unique;
-      Alcotest.test_case "names match method ids" `Quick
-        test_names_match_method_ids;
       Alcotest.test_case "lookup round trips" `Quick
         test_lookup_round_trips;
       Alcotest.test_case "MCP exposure is explicit" `Quick
         test_mcp_exposure_is_explicit;
-      Alcotest.test_case "timeouts match current MCP client" `Quick
+      Alcotest.test_case "Python MCP methods match descriptors" `Quick
+        test_python_mcp_control_methods_match_descriptors;
+      Alcotest.test_case "timeouts match expected snapshot" `Quick
         test_timeout_metadata_matches_current_mcp_client;
+      Alcotest.test_case "timeouts match Python MCP client" `Quick
+        test_timeout_metadata_matches_python_mcp_client;
       Alcotest.test_case "mutability metadata is stable" `Quick
         test_mutability_metadata_is_stable;
     ]);

--- a/test/test_control_api.ml
+++ b/test/test_control_api.ml
@@ -1,0 +1,194 @@
+module Control_api = Discord_agents.Control_api
+
+let method_id_testable =
+  Alcotest.testable
+    (fun fmt id -> Format.fprintf fmt "%s" (Control_api.string_of_method_id id))
+    ( = )
+
+let mutability_testable =
+  Alcotest.testable
+    (fun fmt mutability ->
+      Format.fprintf fmt "%s" (Control_api.string_of_mutability mutability))
+    ( = )
+
+let failf fmt = Format.kasprintf (fun message -> Alcotest.fail message) fmt
+
+let expected_method_ids = [
+  Control_api.Health_id;
+  List_projects_id;
+  List_sessions_id;
+  Import_project_id;
+  List_claude_sessions_id;
+  List_codex_sessions_id;
+  List_gemini_sessions_id;
+  Start_session_id;
+  Resume_session_id;
+  Stop_session_id;
+  Send_message_id;
+  Default_agent_id;
+  Rescue_agent_id;
+  Get_agent_config_id;
+  Set_model_id;
+  Set_effort_id;
+  Set_goal_id;
+  Start_login_flow_id;
+  Restart_id;
+  Rename_thread_id;
+  Cleanup_channels_id;
+  Refresh_projects_id;
+]
+
+let test_specs_cover_method_ids () =
+  let actual = List.map Control_api.method_spec_id Control_api.all_method_specs in
+  Alcotest.(check (list method_id_testable))
+    "control method specs cover expected ids"
+    expected_method_ids
+    actual
+
+let test_spec_names_are_unique () =
+  let seen = Hashtbl.create 32 in
+  Control_api.all_method_specs
+  |> List.iter (fun spec ->
+    let name = Control_api.method_spec_name spec in
+    if Hashtbl.mem seen name then
+      failf "duplicate control method name in specs: %s" name
+    else
+      Hashtbl.add seen name (Control_api.method_spec_id spec))
+
+let test_names_match_method_ids () =
+  Control_api.all_method_specs
+  |> List.iter (fun spec ->
+    let id = Control_api.method_spec_id spec in
+    Alcotest.(check string)
+      (Control_api.string_of_method_id id)
+      (Control_api.string_of_method_id id)
+      (Control_api.method_spec_name spec))
+
+let test_lookup_round_trips () =
+  Control_api.all_method_specs
+  |> List.iter (fun spec ->
+    let name = Control_api.method_spec_name spec in
+    match Control_api.method_spec_of_name name with
+    | None -> failf "missing control method lookup for %s" name
+    | Some found ->
+      Alcotest.(check method_id_testable)
+        name
+        (Control_api.method_spec_id spec)
+        (Control_api.method_spec_id found));
+  expected_method_ids
+  |> List.iter (fun id ->
+    match Control_api.method_spec_of_id id with
+    | None ->
+      failf "missing control method spec for %s"
+        (Control_api.string_of_method_id id)
+    | Some spec ->
+      Alcotest.(check string)
+        (Control_api.string_of_method_id id)
+        (Control_api.string_of_method_id id)
+        (Control_api.method_spec_name spec))
+
+let expected_mcp_control_method_names = [
+  "list_projects";
+  "list_sessions";
+  "import_project";
+  "list_claude_sessions";
+  "list_codex_sessions";
+  "list_gemini_sessions";
+  "start_session";
+  "resume_session";
+  "stop_session";
+  "send_message";
+  "default_agent";
+  "rescue_agent";
+  "get_agent_config";
+  "set_model";
+  "set_effort";
+  "set_goal";
+  "start_login_flow";
+  "restart";
+  "rename_thread";
+  "cleanup_channels";
+  "refresh_projects";
+]
+
+let test_mcp_exposure_is_explicit () =
+  Alcotest.(check (list string))
+    "MCP-visible control method names"
+    expected_mcp_control_method_names
+    Control_api.mcp_control_method_names;
+  Control_api.all_method_specs
+  |> List.iter (fun spec ->
+    let id = Control_api.method_spec_id spec in
+    let expected = id <> Control_api.Health_id in
+    Alcotest.(check bool)
+      (Control_api.string_of_method_id id)
+      expected
+      (Control_api.method_spec_mcp_exposed spec))
+
+let expected_timeout_s = function
+  | Control_api.Import_project_id -> 300
+  | Start_session_id
+  | Resume_session_id -> 120
+  | _ -> 60
+
+let test_timeout_metadata_matches_current_mcp_client () =
+  Control_api.all_method_specs
+  |> List.iter (fun spec ->
+    let id = Control_api.method_spec_id spec in
+    Alcotest.(check int)
+      (Control_api.string_of_method_id id)
+      (expected_timeout_s id)
+      (Control_api.method_spec_timeout_s spec))
+
+let expected_mutability = function
+  | Control_api.Health_id
+  | List_projects_id
+  | List_sessions_id
+  | List_claude_sessions_id
+  | List_codex_sessions_id
+  | List_gemini_sessions_id
+  | Get_agent_config_id
+  | Start_login_flow_id -> Control_api.Read_only
+  | Start_session_id
+  | Resume_session_id
+  | Stop_session_id
+  | Send_message_id
+  | Set_model_id
+  | Set_effort_id
+  | Set_goal_id -> Mutates_session
+  | Default_agent_id
+  | Rescue_agent_id -> Mutates_runtime
+  | Import_project_id
+  | Refresh_projects_id -> Mutates_projects
+  | Rename_thread_id
+  | Cleanup_channels_id -> Mutates_discord
+  | Restart_id -> Restarts_process
+
+let test_mutability_metadata_is_stable () =
+  Control_api.all_method_specs
+  |> List.iter (fun spec ->
+    let id = Control_api.method_spec_id spec in
+    Alcotest.(check mutability_testable)
+      (Control_api.string_of_method_id id)
+      (expected_mutability id)
+      (Control_api.method_spec_mutability spec))
+
+let () =
+  Alcotest.run "control_api" [
+    ("metadata", [
+      Alcotest.test_case "specs cover method ids" `Quick
+        test_specs_cover_method_ids;
+      Alcotest.test_case "spec names are unique" `Quick
+        test_spec_names_are_unique;
+      Alcotest.test_case "names match method ids" `Quick
+        test_names_match_method_ids;
+      Alcotest.test_case "lookup round trips" `Quick
+        test_lookup_round_trips;
+      Alcotest.test_case "MCP exposure is explicit" `Quick
+        test_mcp_exposure_is_explicit;
+      Alcotest.test_case "timeouts match current MCP client" `Quick
+        test_timeout_metadata_matches_current_mcp_client;
+      Alcotest.test_case "mutability metadata is stable" `Quick
+        test_mutability_metadata_is_stable;
+    ]);
+  ]


### PR DESCRIPTION
## Summary

Refactors the Control API router from a hand-written string match into typed method descriptors. The existing handler bodies stay in place, but dispatch now flows through a descriptor table with method IDs, method names, MCP exposure flags, timeout metadata, and mutability metadata.

This is the first macro-refactor slice toward moving the MCP/control contract into typed OCaml ownership before replacing the Python MCP shim.

## Validation

- `nix develop --command dune exec ./test/test_control_api.exe`
- `nix develop --command dune runtest`
- `git diff --cached --check`

## Notes

The Python MCP server is intentionally unchanged in this PR. The new `Control_api.mcp_control_method_names` and timeout metadata are scaffolding for the follow-up MCP descriptor/runtime slice.