### PR TITLE
Add typed MCP tool descriptors

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
             ocamlformat
           ] ++ deps ++ [
             pkgs.gmp
+            pkgs.python3
           ];
 
           shellHook = ''
@@ -51,6 +52,7 @@
           version = "0.1.0";
           src = ./.;
           buildInputs = deps;
+          nativeCheckInputs = [ pkgs.python3 ];
         };
       });
 }

--- a/lib/discord_agents.ml
+++ b/lib/discord_agents.ml
@@ -18,6 +18,7 @@ module Command = Command
 module Claude_sessions = Claude_sessions
 module Codex_sessions = Codex_sessions
 module Gemini_sessions = Gemini_sessions
+module Mcp_tool = Mcp_tool
 module Session = Session
 module Websocket = Websocket
 module Bot = Bot

--- a/lib/mcp_tool.ml
+++ b/lib/mcp_tool.ml
@@ -1,0 +1,306 @@
+(** MCP tool descriptors for the discord-agents control surface.
+
+    The Python MCP shim is still the runtime entrypoint. This module is
+    the typed OCaml source of truth we can migrate that runtime toward. *)
+
+type id =
+  | Start_session
+  | List_projects
+  | Import_project
+  | List_sessions
+  | Send_message
+  | Stop_session
+  | List_claude_sessions
+  | List_codex_sessions
+  | List_gemini_sessions
+  | Default_agent
+  | Rescue_agent
+  | Get_agent_config
+  | Set_model
+  | Set_effort
+  | Set_goal
+  | Start_login_flow
+  | Resume_session
+  | Restart_bot
+  | Rename_thread
+  | Cleanup_channels
+  | Refresh_projects
+
+type spec = {
+  id : id;
+  name : string;
+  description : string;
+  input_schema : Yojson.Safe.t;
+  control_method : Control_api.method_id;
+}
+
+let string_of_id = function
+  | Start_session -> "start_session"
+  | List_projects -> "list_projects"
+  | Import_project -> "import_project"
+  | List_sessions -> "list_sessions"
+  | Send_message -> "send_message"
+  | Stop_session -> "stop_session"
+  | List_claude_sessions -> "list_claude_sessions"
+  | List_codex_sessions -> "list_codex_sessions"
+  | List_gemini_sessions -> "list_gemini_sessions"
+  | Default_agent -> "default_agent"
+  | Rescue_agent -> "rescue_agent"
+  | Get_agent_config -> "get_agent_config"
+  | Set_model -> "set_model"
+  | Set_effort -> "set_effort"
+  | Set_goal -> "set_goal"
+  | Start_login_flow -> "start_login_flow"
+  | Resume_session -> "resume_session"
+  | Restart_bot -> "restart_bot"
+  | Rename_thread -> "rename_thread"
+  | Cleanup_channels -> "cleanup_channels"
+  | Refresh_projects -> "refresh_projects"
+
+let string_type = `String "string"
+
+let integer_type = `String "integer"
+
+let boolean_type = `String "boolean"
+
+let null_type = `String "null"
+
+let string_list_json values =
+  `List (List.map (fun value -> `String value) values)
+
+let field key value fields =
+  match value with
+  | None -> fields
+  | Some value -> (key, value) :: fields
+
+let property ?description ?enum ?max_length ?minimum ?maximum ?default
+    ~type_ () =
+  `Assoc (
+    [("type", type_)]
+    |> field "description" (Option.map (fun s -> `String s) description)
+    |> field "enum" (Option.map string_list_json enum)
+    |> field "maxLength" (Option.map (fun n -> `Int n) max_length)
+    |> field "minimum" (Option.map (fun n -> `Int n) minimum)
+    |> field "maximum" (Option.map (fun n -> `Int n) maximum)
+    |> field "default" default
+    |> List.rev
+  )
+
+let object_schema ?(required=[]) properties =
+  `Assoc (
+    [
+      ("type", `String "object");
+      ("properties", `Assoc properties);
+    ] @
+    if required = [] then [] else [("required", string_list_json required)]
+  )
+
+let no_args_schema =
+  object_schema []
+
+let agent_enum =
+  ["claude"; "codex"; "gemini"]
+
+let session_id_property description =
+  property ~type_:string_type ~description ()
+
+let hours_property =
+  property ~type_:integer_type
+    ~description:"How many hours back to search"
+    ~default:(`Int 24) ()
+
+let spec ~id ~description ~input_schema ~control_method =
+  { id; name = string_of_id id; description; input_schema; control_method }
+
+let all_specs = [
+  spec ~id:Start_session
+    ~description:"Start a new agent session for a project (claude, codex, or gemini). Creates a Discord thread and git worktree. Returns the thread info."
+    ~control_method:Control_api.Start_session_id
+    ~input_schema:(object_schema ~required:["project"] [
+      ("project", property ~type_:string_type
+        ~description:"Project name, number from the list, or a prefix/substring to fuzzy match" ());
+      ("agent", property ~type_:string_type
+        ~description:"Agent type: claude, codex, or gemini. If omitted, uses the bot's current effective top-level agent (default agent unless a rescue agent is active under disk pressure)."
+        ~enum:agent_enum ());
+      ("thread_name", property ~type_:string_type
+        ~description:"Short descriptive name for the thread (max 80 chars). If omitted, uses a default name."
+        ~max_length:80 ());
+      ("initial_prompt", property ~type_:string_type
+        ~description:"First message to send to the new agent. Posted visibly in the thread, then the agent starts working on it immediately \u{2014} the user does not need to send a follow-up. Keep it concise: describe the goal and any key context, not step-by-step instructions. Capped at 1900 *bytes* on the server (UTF-8 codepoint-aware truncation, so multi-byte characters can shorten the effective char count); the maxLength below is the worst case (all-ASCII)."
+        ~max_length:1900 ());
+    ]);
+  spec ~id:List_projects
+    ~description:"List all discovered projects that can have agent sessions started on them."
+    ~control_method:Control_api.List_projects_id
+    ~input_schema:no_args_schema;
+  spec ~id:Import_project
+    ~description:"Clone a GitHub HTTPS or SSH URL into the bot's project registry, create its Discord project channel, and make the channel session-ready. Reuses local git credentials; no token is accepted."
+    ~control_method:Control_api.Import_project_id
+    ~input_schema:(object_schema ~required:["url"] [
+      ("url", property ~type_:string_type
+        ~description:"GitHub repository URL, e.g. https://github.com/owner/repo.git or git@github.com:owner/repo.git" ());
+      ("name", property ~type_:string_type
+        ~description:"Optional local project directory name under the configured base directory. Defaults to the GitHub repository name."
+        ~max_length:100 ());
+    ]);
+  spec ~id:List_sessions
+    ~description:"List active bot sessions (Discord threads with agent sessions attached)."
+    ~control_method:Control_api.List_sessions_id
+    ~input_schema:no_args_schema;
+  spec ~id:Send_message
+    ~description:"Send a visible user-style message to another active session thread, then route it through the same handler as a Discord user message. Use list_sessions to find thread IDs. The message is queued if the target session is busy. Do not send command-looking messages. If replying to an inter-agent message, pass its remaining_hops value so loops terminate."
+    ~control_method:Control_api.Send_message_id
+    ~input_schema:(object_schema ~required:["thread_id"; "message"] [
+      ("thread_id", session_id_property
+        "Discord thread ID of the destination active session");
+      ("message", property ~type_:string_type
+        ~description:"Plain message text to send. Must not start with ! and must fit in one Discord message. The bot enforces a 1600-byte cap, so non-ASCII text may allow fewer characters."
+        ~max_length:1600 ());
+      ("source_thread_id", property ~type_:string_type
+        ~description:"Optional claimed Discord thread ID of the sending session, if known. This is displayed as an untrusted claimed source until caller context is wired in." ());
+      ("remaining_hops", property ~type_:integer_type
+        ~description:"Loop guard. Defaults to 3 for a new chain. If replying to an inter-agent message, pass the remaining_hops value shown in that message."
+        ~minimum:1 ~maximum:5 ~default:(`Int 3) ());
+    ]);
+  spec ~id:Stop_session
+    ~description:"Stop an active bot session by Discord thread ID. Idle sessions stop immediately; busy sessions terminate the active agent run and then clean up the session."
+    ~control_method:Control_api.Stop_session_id
+    ~input_schema:(object_schema ~required:["thread_id"] [
+      ("thread_id", session_id_property "Discord thread ID of the session to stop");
+    ]);
+  spec ~id:List_claude_sessions
+    ~description:"List recent Claude Code sessions running on this machine (last 24h). Useful for finding sessions to resume."
+    ~control_method:Control_api.List_claude_sessions_id
+    ~input_schema:(object_schema [("hours", hours_property)]);
+  spec ~id:List_codex_sessions
+    ~description:"List recent Codex CLI sessions on this machine (last 24h). Useful for finding sessions to resume."
+    ~control_method:Control_api.List_codex_sessions_id
+    ~input_schema:(object_schema [("hours", hours_property)]);
+  spec ~id:List_gemini_sessions
+    ~description:"List recent Gemini CLI sessions on this machine (last 24h). Useful for finding sessions to resume."
+    ~control_method:Control_api.List_gemini_sessions_id
+    ~input_schema:(object_schema [("hours", hours_property)]);
+  spec ~id:Default_agent
+    ~description:"Show or set the default agent used for new top-level sessions. Existing idle top-level sessions reset to a fresh session immediately; busy ones reset after their queued work finishes."
+    ~control_method:Control_api.Default_agent_id
+    ~input_schema:(object_schema [
+      ("agent", property ~type_:string_type
+        ~description:"Agent type to make the default. Omit to read the current default."
+        ~enum:agent_enum ());
+    ]);
+  spec ~id:Rescue_agent
+    ~description:"Show or set the rescue agent automatically used for new top-level sessions under disk pressure. Use agent=off to disable it."
+    ~control_method:Control_api.Rescue_agent_id
+    ~input_schema:(object_schema [
+      ("agent", property ~type_:string_type
+        ~description:"Agent type to use as the rescue agent, or off to disable rescue mode. Omit to read the current setting."
+        ~enum:(agent_enum @ ["off"]) ());
+    ]);
+  spec ~id:Get_agent_config
+    ~description:"Show the per-session agent configuration for a Discord thread: current values, every supported config value, a single-command briefing, and login repair hint."
+    ~control_method:Control_api.Get_agent_config_id
+    ~input_schema:(object_schema ~required:["thread_id"] [
+      ("thread_id", session_id_property "Discord thread ID of the session");
+    ]);
+  spec ~id:Set_model
+    ~description:"Set or clear the model override for an existing Discord agent session. Pass model explicitly; use model=default or an empty/null value to clear."
+    ~control_method:Control_api.Set_model_id
+    ~input_schema:(object_schema ~required:["thread_id"; "model"] [
+      ("thread_id", session_id_property "Discord thread ID of the session");
+      ("model", property ~type_:(`List [string_type; null_type])
+        ~description:"Model name to pass to the agent CLI, or default/null to clear" ());
+    ]);
+  spec ~id:Set_effort
+    ~description:"Set or clear the reasoning effort override for an existing Discord agent session. Pass effort explicitly. Use get_agent_config for the selected thread's supported values; set_effort validates against that thread's agent."
+    ~control_method:Control_api.Set_effort_id
+    ~input_schema:(object_schema ~required:["thread_id"; "effort"] [
+      ("thread_id", session_id_property "Discord thread ID of the session");
+      ("effort", property ~type_:(`List [string_type; null_type])
+        ~description:"Reasoning effort value for the thread's agent, or default/null to clear" ());
+    ]);
+  spec ~id:Set_goal
+    ~description:"Set, update, or clear a persisted Codex session goal. With current codex exec integration this is injected as prompt context; native Codex /goal requires app-server."
+    ~control_method:Control_api.Set_goal_id
+    ~input_schema:(object_schema ~required:["thread_id"] [
+      ("thread_id", session_id_property "Discord thread ID of the session");
+      ("objective", property ~type_:(`List [string_type; null_type])
+        ~description:"Goal objective, max 4000 bytes. Required for a new goal; omit to update status/token_budget on an existing goal." ());
+      ("status", property ~type_:string_type
+        ~description:"Goal status"
+        ~enum:["active"; "paused"; "blocked"; "usageLimited"; "budgetLimited"; "complete"] ());
+      ("token_budget", property ~type_:(`List [integer_type; null_type])
+        ~description:"Optional positive token budget" ());
+      ("clear", property ~type_:boolean_type
+        ~description:"Clear the stored goal" ());
+    ]);
+  spec ~id:Start_login_flow
+    ~description:"Return the local command needed to repair login for an agent or session. The bot does not run OAuth itself."
+    ~control_method:Control_api.Start_login_flow_id
+    ~input_schema:(object_schema [
+      ("thread_id", session_id_property "Discord thread ID whose agent needs login");
+      ("agent", property ~type_:string_type
+        ~description:"Agent kind when no thread_id is supplied"
+        ~enum:agent_enum ());
+    ]);
+  spec ~id:Resume_session
+    ~description:"Resume an existing Claude, Codex, or Gemini session in a new Discord thread. Use list_claude_sessions / list_codex_sessions / list_gemini_sessions to find a session ID. With kind unspecified, the bot tries the current effective top-level agent first, then the others."
+    ~control_method:Control_api.Resume_session_id
+    ~input_schema:(object_schema ~required:["session_id"] [
+      ("session_id", property ~type_:string_type
+        ~description:"Session ID or prefix (at least 8 characters)" ());
+      ("kind", property ~type_:string_type
+        ~description:"Which session store to search. Omit to try the current effective top-level agent first, then the others."
+        ~enum:agent_enum ());
+    ]);
+  spec ~id:Restart_bot
+    ~description:"Rebuild the discord-agents bot from source and restart it. Use after code changes."
+    ~control_method:Control_api.Restart_id
+    ~input_schema:no_args_schema;
+  spec ~id:Rename_thread
+    ~description:"Rename a Discord thread. Use from the control channel to rename any thread by ID, or specify the thread_id of the thread to rename."
+    ~control_method:Control_api.Rename_thread_id
+    ~input_schema:(object_schema ~required:["thread_id"; "name"] [
+      ("thread_id", property ~type_:string_type
+        ~description:"Discord thread ID (snowflake) to rename" ());
+      ("name", property ~type_:string_type
+        ~description:"New name for the thread (max 100 characters)" ());
+    ]);
+  spec ~id:Cleanup_channels
+    ~description:"Delete stale Discord channels that don't match any current project."
+    ~control_method:Control_api.Cleanup_channels_id
+    ~input_schema:no_args_schema;
+  spec ~id:Refresh_projects
+    ~description:"Re-scan for new projects without restarting the bot. Use when a new project has been added to the base directories."
+    ~control_method:Control_api.Refresh_projects_id
+    ~input_schema:no_args_schema;
+]
+
+let spec_id spec = spec.id
+
+let tool_name spec = spec.name
+
+let description spec = spec.description
+
+let input_schema spec = spec.input_schema
+
+let control_method spec = spec.control_method
+
+let control_method_name spec =
+  Control_api.string_of_method_id spec.control_method
+
+let control_method_timeout_s spec =
+  match Control_api.method_spec_of_id spec.control_method with
+  | Some method_spec -> Control_api.method_spec_timeout_s method_spec
+  | None ->
+    invalid_arg
+      (Printf.sprintf "missing control method for MCP tool %s" spec.name)
+
+let json_of_spec spec =
+  `Assoc [
+    ("name", `String spec.name);
+    ("description", `String spec.description);
+    ("inputSchema", spec.input_schema);
+  ]
+
+let tool_definitions_json =
+  `List (List.map json_of_spec all_specs)

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,7 @@
 (tests
- (names test_command test_control_api test_formatting test_project test_agent_contracts test_discord_rest test_gateway
+ (names test_command test_control_api test_mcp_tool test_formatting test_project test_agent_contracts test_discord_rest test_gateway
  test_runtime_settings test_bot_defaults test_session_store test_disk_health test_config
   test_runtime_limits test_stream_interrupt)
+ (deps ../scripts/mcp-server.py)
  (libraries discord_agents alcotest str unix yojson eio.mock eio_main cohttp-eio
   uri mirage-crypto-rng.unix))

--- a/test/test_mcp_tool.ml
+++ b/test/test_mcp_tool.ml
@@ -26,6 +26,18 @@ let repo_file path =
   in
   search (Sys.getcwd ())
 
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
+    let n = in_channel_length ic in
+    really_input_string ic n)
+
+let mcp_server_path =
+  lazy (repo_file "scripts/mcp-server.py")
+
+let mcp_server_py =
+  lazy (read_file (Lazy.force mcp_server_path))
+
 let read_process_output command =
   let ic = Unix.open_process_in command in
   let buf = Buffer.create 4096 in
@@ -42,7 +54,6 @@ let read_process_output command =
   | Unix.WSTOPPED n -> failf "command stopped %d: %s" n command
 
 let python_tools_json () =
-  let script = repo_file "scripts/mcp-server.py" in
   let program =
     "import json, runpy, sys; "
     ^ "ns = runpy.run_path(sys.argv[1]); "
@@ -51,10 +62,50 @@ let python_tools_json () =
   let command =
     Printf.sprintf "python3 -c %s %s"
       (Filename.quote program)
-      (Filename.quote script)
+      (Filename.quote (Lazy.force mcp_server_path))
   in
   read_process_output command
   |> Yojson.Safe.from_string
+
+let python_default_timeout_s =
+  lazy (
+  let regexp =
+    Str.regexp "def control_request(method, params=None, timeout=\\([0-9]+\\))"
+  in
+  match Str.search_forward regexp (Lazy.force mcp_server_py) 0 with
+  | exception Not_found -> failf "could not find Python control_request timeout"
+  | _ -> int_of_string (Str.matched_group 1 (Lazy.force mcp_server_py))
+  )
+
+let python_explicit_timeouts =
+  lazy (
+  let regexp =
+    Str.regexp "control_request(\"\\([^\"]+\\)\"[^\n]*timeout=\\([0-9]+\\)"
+  in
+  let text = Lazy.force mcp_server_py in
+  let rec loop pos acc =
+    match Str.search_forward regexp text pos with
+    | exception Not_found -> acc
+    | _ ->
+      let method_name = Str.matched_group 1 text in
+      let timeout_s = int_of_string (Str.matched_group 2 text) in
+      let acc =
+        match List.assoc_opt method_name acc with
+        | None -> (method_name, timeout_s) :: acc
+        | Some existing when existing = timeout_s -> acc
+        | Some existing ->
+          failf "conflicting Python timeout for %s: %d and %d"
+            method_name existing timeout_s
+      in
+      loop (Str.match_end ()) acc
+  in
+  loop 0 []
+  )
+
+let python_timeout_s method_name =
+  Option.value
+    (List.assoc_opt method_name (Lazy.force python_explicit_timeouts))
+    ~default:(Lazy.force python_default_timeout_s)
 
 let rec canonical_json = function
   | `Assoc fields ->
@@ -185,7 +236,7 @@ let test_tool_control_methods_match_control_metadata () =
     | Some method_spec ->
       Alcotest.(check int)
         (Mcp_tool.tool_name spec)
-        (Control_api.method_spec_timeout_s method_spec)
+        (python_timeout_s (Control_api.method_spec_name method_spec))
         (Mcp_tool.control_method_timeout_s spec));
   let tool_control_names =
     Mcp_tool.all_specs

--- a/test/test_mcp_tool.ml
+++ b/test/test_mcp_tool.ml
@@ -1,0 +1,217 @@
+module Control_api = Discord_agents.Control_api
+module Mcp_tool = Discord_agents.Mcp_tool
+
+let failf fmt = Format.kasprintf (fun message -> Alcotest.fail message) fmt
+
+let tool_id_testable =
+  Alcotest.testable
+    (fun fmt id -> Format.fprintf fmt "%s" (Mcp_tool.string_of_id id))
+    ( = )
+
+let method_id_testable =
+  Alcotest.testable
+    (fun fmt id -> Format.fprintf fmt "%s" (Control_api.string_of_method_id id))
+    ( = )
+
+let repo_file path =
+  let rec search dir =
+    let candidate = Filename.concat dir path in
+    if Sys.file_exists candidate then candidate
+    else
+      let parent = Filename.dirname dir in
+      if String.equal parent dir then
+        failf "could not find %s from %s" path (Sys.getcwd ())
+      else
+        search parent
+  in
+  search (Sys.getcwd ())
+
+let read_process_output command =
+  let ic = Unix.open_process_in command in
+  let buf = Buffer.create 4096 in
+  (try
+     while true do
+       Buffer.add_string buf (input_line ic);
+       Buffer.add_char buf '\n'
+     done
+   with End_of_file -> ());
+  match Unix.close_process_in ic with
+  | Unix.WEXITED 0 -> Buffer.contents buf
+  | Unix.WEXITED n -> failf "command exited %d: %s" n command
+  | Unix.WSIGNALED n -> failf "command signaled %d: %s" n command
+  | Unix.WSTOPPED n -> failf "command stopped %d: %s" n command
+
+let python_tools_json () =
+  let script = repo_file "scripts/mcp-server.py" in
+  let program =
+    "import json, runpy, sys; "
+    ^ "ns = runpy.run_path(sys.argv[1]); "
+    ^ "print(json.dumps(ns['TOOLS'], sort_keys=True))"
+  in
+  let command =
+    Printf.sprintf "python3 -c %s %s"
+      (Filename.quote program)
+      (Filename.quote script)
+  in
+  read_process_output command
+  |> Yojson.Safe.from_string
+
+let rec canonical_json = function
+  | `Assoc fields ->
+    fields
+    |> List.map (fun (key, value) -> key, canonical_json value)
+    |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+    |> fun fields -> `Assoc fields
+  | `List values -> `List (List.map canonical_json values)
+  | other -> other
+
+let json_string json =
+  Yojson.Safe.to_string (canonical_json json)
+
+let check_json label expected actual =
+  Alcotest.(check string) label (json_string expected) (json_string actual)
+
+let unique values =
+  let seen = Hashtbl.create 32 in
+  values
+  |> List.filter (fun value ->
+    if Hashtbl.mem seen value then false
+    else begin
+      Hashtbl.add seen value ();
+      true
+    end)
+
+let sorted_strings values =
+  List.sort String.compare values
+
+let expected_tool_ids = [
+  Mcp_tool.Start_session;
+  List_projects;
+  Import_project;
+  List_sessions;
+  Send_message;
+  Stop_session;
+  List_claude_sessions;
+  List_codex_sessions;
+  List_gemini_sessions;
+  Default_agent;
+  Rescue_agent;
+  Get_agent_config;
+  Set_model;
+  Set_effort;
+  Set_goal;
+  Start_login_flow;
+  Resume_session;
+  Restart_bot;
+  Rename_thread;
+  Cleanup_channels;
+  Refresh_projects;
+]
+
+let test_specs_cover_tool_ids () =
+  let actual = List.map Mcp_tool.spec_id Mcp_tool.all_specs in
+  Alcotest.(check (list tool_id_testable))
+    "MCP tool specs cover expected ids"
+    expected_tool_ids
+    actual
+
+let test_tool_names_are_unique () =
+  let seen = Hashtbl.create 32 in
+  Mcp_tool.all_specs
+  |> List.iter (fun spec ->
+    let name = Mcp_tool.tool_name spec in
+    if Hashtbl.mem seen name then
+      failf "duplicate MCP tool name in specs: %s" name
+    else
+      Hashtbl.add seen name (Mcp_tool.spec_id spec))
+
+let test_tool_definitions_match_python () =
+  check_json
+    "MCP tool definitions"
+    (python_tools_json ())
+    Mcp_tool.tool_definitions_json
+
+let test_control_methods_are_exposed () =
+  let tool_methods =
+    Mcp_tool.all_specs
+    |> List.map Mcp_tool.control_method
+  in
+  Alcotest.(check (list string))
+    "MCP tools cover exposed control methods"
+    (Control_api.mcp_control_method_names |> sorted_strings)
+    (tool_methods
+     |> List.map Control_api.string_of_method_id
+     |> sorted_strings);
+  let missing =
+    tool_methods
+    |> List.filter (fun id ->
+      match Control_api.method_spec_of_id id with
+      | Some spec -> not (Control_api.method_spec_mcp_exposed spec)
+      | None -> true)
+  in
+  Alcotest.(check (list method_id_testable))
+    "all tool control methods are MCP-exposed"
+    []
+    missing
+
+let test_tool_names_match_python_order () =
+  let python_names =
+    match python_tools_json () with
+    | `List tools ->
+      tools
+      |> List.map (function
+        | `Assoc fields ->
+          (match List.assoc_opt "name" fields with
+           | Some (`String name) -> name
+           | _ -> failf "Python tool without string name")
+        | _ -> failf "Python tool entry is not an object")
+    | _ -> failf "Python TOOLS is not a list"
+  in
+  let ocaml_names = List.map Mcp_tool.tool_name Mcp_tool.all_specs in
+  Alcotest.(check (list string))
+    "MCP tool names"
+    python_names
+    ocaml_names
+
+let test_tool_control_methods_match_control_metadata () =
+  Mcp_tool.all_specs
+  |> List.iter (fun spec ->
+    let control_method = Mcp_tool.control_method spec in
+    match Control_api.method_spec_of_id control_method with
+    | None ->
+      failf "missing control method %s for tool %s"
+        (Control_api.string_of_method_id control_method)
+        (Mcp_tool.tool_name spec)
+    | Some method_spec ->
+      Alcotest.(check int)
+        (Mcp_tool.tool_name spec)
+        (Control_api.method_spec_timeout_s method_spec)
+        (Mcp_tool.control_method_timeout_s spec));
+  let tool_control_names =
+    Mcp_tool.all_specs
+    |> List.map Mcp_tool.control_method_name
+    |> unique
+    |> sorted_strings
+  in
+  Alcotest.(check (list string))
+    "control method names"
+    (sorted_strings Control_api.mcp_control_method_names)
+    tool_control_names
+
+let () =
+  Alcotest.run "mcp_tool" [
+    ("metadata", [
+      Alcotest.test_case "specs cover tool ids" `Quick
+        test_specs_cover_tool_ids;
+      Alcotest.test_case "tool names are unique" `Quick
+        test_tool_names_are_unique;
+      Alcotest.test_case "tool definitions match Python" `Quick
+        test_tool_definitions_match_python;
+      Alcotest.test_case "tool names match Python order" `Quick
+        test_tool_names_match_python_order;
+      Alcotest.test_case "control methods are exposed" `Quick
+        test_control_methods_are_exposed;
+      Alcotest.test_case "tool control methods match control metadata"
+        `Quick test_tool_control_methods_match_control_metadata;
+    ]);
+  ]


### PR DESCRIPTION
## Summary

Adds an OCaml `Mcp_tool` descriptor module for the current MCP tool contract while leaving the Python MCP runtime unchanged.

The descriptors now encode:

- MCP tool ids and public tool names
- tool descriptions and input schemas
- the typed `Control_api.method_id` each tool forwards to
- timeout lookup through the Control API method metadata
- rendered MCP `tools/list` JSON

This is the next macro-refactor step toward replacing `scripts/mcp-server.py` with an OCaml stdio MCP executable. It establishes an OCaml-owned tool contract first, with drift tests against the Python shim.

## Validation

- `nix develop --command dune exec ./test/test_mcp_tool.exe`
- `nix develop --command dune runtest`
- `git diff --cached --check`

## Notes

The Python MCP server still handles runtime `tools/call` behavior in this PR. The new test imports `scripts/mcp-server.py` with Python, reads `TOOLS`, and compares canonical JSON to `Mcp_tool.tool_definitions_json`.