### PR TITLE
Add OCaml MCP stdio skeleton

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -6,6 +6,4 @@
 
 (executable
  (name mcp_server)
- (public_name discord-agents-mcp-ocaml)
- (package discord_agents)
  (libraries discord_agents yojson))

--- a/bin/dune
+++ b/bin/dune
@@ -3,3 +3,9 @@
  (public_name discord-agents)
  (package discord_agents)
  (libraries discord_agents eio_main logs logs.fmt fmt fmt.tty))
+
+(executable
+ (name mcp_server)
+ (public_name discord-agents-mcp-ocaml)
+ (package discord_agents)
+ (libraries discord_agents yojson))

--- a/bin/mcp_server.ml
+++ b/bin/mcp_server.ml
@@ -1,0 +1,21 @@
+let handle_tool_call (call : Discord_agents.Mcp_server.tool_call) =
+  Error (
+    Printf.sprintf
+      "OCaml MCP tools/call is not wired yet for tool: %s"
+      call.name
+  )
+
+let write_response json =
+  print_endline (Yojson.Safe.to_string json);
+  flush stdout
+
+let () =
+  try
+    while true do
+      match input_line stdin with
+      | line ->
+        (match Discord_agents.Mcp_server.handle_line ~handle_tool_call line with
+         | None -> ()
+         | Some response -> write_response response)
+    done
+  with End_of_file -> ()

--- a/lib/discord_agents.ml
+++ b/lib/discord_agents.ml
@@ -19,6 +19,7 @@ module Claude_sessions = Claude_sessions
 module Codex_sessions = Codex_sessions
 module Gemini_sessions = Gemini_sessions
 module Mcp_tool = Mcp_tool
+module Mcp_server = Mcp_server
 module Session = Session
 module Websocket = Websocket
 module Bot = Bot

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -11,11 +11,15 @@ type tool_call = {
 
 type tool_handler = tool_call -> (string, string) result
 
+type request_id =
+  | Request of Yojson.Safe.t
+  | Notification
+
 let protocol_version = "2024-11-05"
 
 let server_name = "discord-agents-mcp"
 
-let server_version = "0.3.0"
+let server_version = "0.2.0"
 
 let raise_if_fatal exn =
   match exn with
@@ -34,8 +38,8 @@ let string_field name fields =
 
 let id_field fields =
   match field "id" fields with
-  | Some id -> id
-  | None -> `Null
+  | Some id -> Request id
+  | None -> Notification
 
 let response ~id ~result =
   `Assoc [
@@ -53,6 +57,16 @@ let error ~id ~code ~message =
       ("message", `String message);
     ]);
   ]
+
+let maybe_response ~id ~result =
+  match id with
+  | Notification -> None
+  | Request id -> Some (response ~id ~result)
+
+let maybe_error ~id ~code ~message =
+  match id with
+  | Notification -> None
+  | Request id -> Some (error ~id ~code ~message)
 
 let initialize_result =
   `Assoc [
@@ -81,45 +95,54 @@ let tool_response ?(is_error=false) text =
 let tools_list_result =
   `Assoc [("tools", Mcp_tool.tool_definitions_json)]
 
-let call_tool handle_tool_call fields =
-  let params =
-    match field "params" fields with
-    | Some (`Assoc params) -> params
-    | _ -> []
-  in
-  let arguments =
-    match field "arguments" params with
-    | Some arguments -> arguments
-    | None -> `Assoc []
-  in
-  let call = {
-    name = string_field "name" params;
-    arguments;
-  } in
-  try
-    match handle_tool_call call with
-    | Ok text -> tool_response text
-    | Error message -> tool_response ~is_error:true message
-  with exn ->
-    raise_if_fatal exn;
-    tool_response ~is_error:true (Printf.sprintf "Error: %s" (Printexc.to_string exn))
+let invalid_params message =
+  Error message
+
+let call_tool (handle_tool_call : tool_handler) fields =
+  match field "params" fields with
+  | None -> invalid_params "tools/call params must be an object"
+  | Some (`Assoc params) ->
+    (match field "name" params with
+     | Some (`String name) when name <> "" ->
+       let arguments =
+         match field "arguments" params with
+         | None -> Ok (`Assoc [])
+         | Some (`Assoc _ as arguments) -> Ok arguments
+         | Some _ -> invalid_params "tools/call params.arguments must be an object"
+       in
+       (match arguments with
+        | Error _ as error -> error
+        | Ok arguments ->
+          let call = { name; arguments } in
+          Ok (
+            try
+              match handle_tool_call call with
+              | Ok text -> tool_response text
+              | Error message -> tool_response ~is_error:true message
+            with exn ->
+              raise_if_fatal exn;
+              tool_response ~is_error:true
+                (Printf.sprintf "Error: %s" (Printexc.to_string exn))
+          ))
+     | _ -> invalid_params "tools/call params.name must be a non-empty string")
+  | Some _ -> invalid_params "tools/call params must be an object"
 
 let handle_json ~handle_tool_call = function
   | `Assoc fields ->
     let id = id_field fields in
     (match string_field "method" fields with
-     | "initialize" -> Some (response ~id ~result:initialize_result)
+     | "initialize" -> maybe_response ~id ~result:initialize_result
      | "notifications/initialized" -> None
-     | "tools/list" -> Some (response ~id ~result:tools_list_result)
+     | "tools/list" -> maybe_response ~id ~result:tools_list_result
      | "tools/call" ->
-       Some (response ~id ~result:(call_tool handle_tool_call fields))
-     | "ping" -> Some (response ~id ~result:(`Assoc []))
+       (match call_tool handle_tool_call fields with
+        | Ok result -> maybe_response ~id ~result
+        | Error message -> maybe_error ~id ~code:(-32602) ~message)
+     | "ping" -> maybe_response ~id ~result:(`Assoc [])
      | method_name ->
-       if field "id" fields = None then None
-       else
-         Some (error ~id ~code:(-32601)
-                 ~message:(Printf.sprintf "Unknown method: %s" method_name)))
-  | _ -> None
+       maybe_error ~id ~code:(-32601)
+         ~message:(Printf.sprintf "Unknown method: %s" method_name))
+  | _ -> Some (error ~id:`Null ~code:(-32600) ~message:"Invalid Request")
 
 let handle_line ~handle_tool_call line =
   match String.trim line with
@@ -127,4 +150,5 @@ let handle_line ~handle_tool_call line =
   | trimmed ->
     match Yojson.Safe.from_string trimmed with
     | json -> handle_json ~handle_tool_call json
-    | exception Yojson.Json_error _ -> None
+    | exception Yojson.Json_error _ ->
+      Some (error ~id:`Null ~code:(-32700) ~message:"Parse error")

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -1,0 +1,130 @@
+(** Minimal MCP JSON-RPC protocol handling.
+
+    The Python MCP server remains the runtime entrypoint for tool calls while
+    formatting is ported. This module owns the protocol surface that can be
+    tested against the typed OCaml tool descriptors. *)
+
+type tool_call = {
+  name : string;
+  arguments : Yojson.Safe.t;
+}
+
+type tool_handler = tool_call -> (string, string) result
+
+let protocol_version = "2024-11-05"
+
+let server_name = "discord-agents-mcp"
+
+let server_version = "0.3.0"
+
+let raise_if_fatal exn =
+  match exn with
+  | Out_of_memory
+  | Stack_overflow
+  | Sys.Break -> raise exn
+  | _ -> ()
+
+let field name fields =
+  List.assoc_opt name fields
+
+let string_field name fields =
+  match field name fields with
+  | Some (`String value) -> value
+  | _ -> ""
+
+let id_field fields =
+  match field "id" fields with
+  | Some id -> id
+  | None -> `Null
+
+let response ~id ~result =
+  `Assoc [
+    ("jsonrpc", `String "2.0");
+    ("id", id);
+    ("result", result);
+  ]
+
+let error ~id ~code ~message =
+  `Assoc [
+    ("jsonrpc", `String "2.0");
+    ("id", id);
+    ("error", `Assoc [
+      ("code", `Int code);
+      ("message", `String message);
+    ]);
+  ]
+
+let initialize_result =
+  `Assoc [
+    ("protocolVersion", `String protocol_version);
+    ("capabilities", `Assoc [("tools", `Assoc [])]);
+    ("serverInfo", `Assoc [
+      ("name", `String server_name);
+      ("version", `String server_version);
+    ]);
+  ]
+
+let text_content text =
+  `List [
+    `Assoc [
+      ("type", `String "text");
+      ("text", `String text);
+    ];
+  ]
+
+let tool_response ?(is_error=false) text =
+  let fields = [("content", text_content text)] in
+  `Assoc (
+    if is_error then fields @ [("isError", `Bool true)] else fields
+  )
+
+let tools_list_result =
+  `Assoc [("tools", Mcp_tool.tool_definitions_json)]
+
+let call_tool handle_tool_call fields =
+  let params =
+    match field "params" fields with
+    | Some (`Assoc params) -> params
+    | _ -> []
+  in
+  let arguments =
+    match field "arguments" params with
+    | Some arguments -> arguments
+    | None -> `Assoc []
+  in
+  let call = {
+    name = string_field "name" params;
+    arguments;
+  } in
+  try
+    match handle_tool_call call with
+    | Ok text -> tool_response text
+    | Error message -> tool_response ~is_error:true message
+  with exn ->
+    raise_if_fatal exn;
+    tool_response ~is_error:true (Printf.sprintf "Error: %s" (Printexc.to_string exn))
+
+let handle_json ~handle_tool_call = function
+  | `Assoc fields ->
+    let id = id_field fields in
+    (match string_field "method" fields with
+     | "initialize" -> Some (response ~id ~result:initialize_result)
+     | "notifications/initialized" -> None
+     | "tools/list" -> Some (response ~id ~result:tools_list_result)
+     | "tools/call" ->
+       Some (response ~id ~result:(call_tool handle_tool_call fields))
+     | "ping" -> Some (response ~id ~result:(`Assoc []))
+     | method_name ->
+       if field "id" fields = None then None
+       else
+         Some (error ~id ~code:(-32601)
+                 ~message:(Printf.sprintf "Unknown method: %s" method_name)))
+  | _ -> None
+
+let handle_line ~handle_tool_call line =
+  match String.trim line with
+  | "" -> None
+  | trimmed ->
+    match Yojson.Safe.from_string trimmed with
+    | json -> handle_json ~handle_tool_call json
+    | exception Yojson.Json_error _ -> None

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -19,6 +19,8 @@ let protocol_version = "2024-11-05"
 
 let server_name = "discord-agents-mcp"
 
+(* Keep aligned with scripts/mcp-server.py while Python remains the runtime
+   MCP entrypoint. *)
 let server_version = "0.2.0"
 
 let raise_if_fatal exn =
@@ -107,6 +109,7 @@ let call_tool (handle_tool_call : tool_handler) fields =
        let arguments =
          match field "arguments" params with
          | None -> Ok (`Assoc [])
+         | Some `Null -> Ok (`Assoc [])
          | Some (`Assoc _ as arguments) -> Ok arguments
          | Some _ -> invalid_params "tools/call params.arguments must be an object"
        in

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,5 @@
 (tests
- (names test_command test_control_api test_mcp_tool test_formatting test_project test_agent_contracts test_discord_rest test_gateway
+ (names test_command test_control_api test_mcp_tool test_mcp_server test_formatting test_project test_agent_contracts test_discord_rest test_gateway
  test_runtime_settings test_bot_defaults test_session_store test_disk_health test_config
   test_runtime_limits test_stream_interrupt)
  (deps ../scripts/mcp-server.py)

--- a/test/test_mcp_server.ml
+++ b/test/test_mcp_server.ml
@@ -133,6 +133,21 @@ let test_tools_call_defaults_arguments () =
   | calls ->
     failf "expected one handler call, got %d" (List.length calls)
 
+let test_tools_call_treats_null_arguments_as_absent () =
+  handler_calls := [];
+  let handler =
+    recording_handler (Ok "listed")
+  in
+  expect_response "tools/call null args" ~handler
+    {|{"jsonrpc":"2.0","id":41,"method":"tools/call","params":{"name":"list_projects","arguments":null}}|}
+    (response ~id:(`Int 41) ~result:(text_result "listed"));
+  match !handler_calls with
+  | [{ Mcp_server.name; arguments }] ->
+    Alcotest.(check string) "tool name" "list_projects" name;
+    check_json "arguments" (`Assoc []) arguments
+  | calls ->
+    failf "expected one handler call, got %d" (List.length calls)
+
 let test_tools_call_error_result () =
   let handler _call = Error "not yet" in
   expect_response "tools/call error" ~handler
@@ -197,6 +212,8 @@ let () =
         test_tools_call_invokes_handler;
       Alcotest.test_case "tools/call defaults arguments" `Quick
         test_tools_call_defaults_arguments;
+      Alcotest.test_case "tools/call null arguments" `Quick
+        test_tools_call_treats_null_arguments_as_absent;
       Alcotest.test_case "tools/call error result" `Quick
         test_tools_call_error_result;
       Alcotest.test_case "tools/call rejects missing params" `Quick

--- a/test/test_mcp_server.ml
+++ b/test/test_mcp_server.ml
@@ -1,0 +1,170 @@
+module Mcp_server = Discord_agents.Mcp_server
+module Mcp_tool = Discord_agents.Mcp_tool
+
+let failf fmt = Format.kasprintf (fun message -> Alcotest.fail message) fmt
+
+let rec canonical_json = function
+  | `Assoc fields ->
+    fields
+    |> List.map (fun (key, value) -> key, canonical_json value)
+    |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+    |> fun fields -> `Assoc fields
+  | `List values -> `List (List.map canonical_json values)
+  | other -> other
+
+let json_string json =
+  Yojson.Safe.to_string (canonical_json json)
+
+let check_json label expected actual =
+  Alcotest.(check string) label (json_string expected) (json_string actual)
+
+let response ~id ~result =
+  `Assoc [
+    ("jsonrpc", `String "2.0");
+    ("id", id);
+    ("result", result);
+  ]
+
+let text_result ?(is_error=false) text =
+  let fields = [
+    ("content", `List [
+      `Assoc [
+        ("type", `String "text");
+        ("text", `String text);
+      ];
+    ]);
+  ] in
+  `Assoc (if is_error then fields @ [("isError", `Bool true)] else fields)
+
+let handler_calls = ref []
+
+let recording_handler result call =
+  handler_calls := call :: !handler_calls;
+  result
+
+let handle_line ?(handler=recording_handler (Ok "handled")) line =
+  Mcp_server.handle_line ~handle_tool_call:handler line
+
+let expect_response label ?handler line expected =
+  match handle_line ?handler line with
+  | None -> failf "%s: expected a response" label
+  | Some actual -> check_json label expected actual
+
+let expect_no_response label line =
+  match handle_line line with
+  | None -> ()
+  | Some actual ->
+    failf "%s: expected no response, got %s"
+      label (Yojson.Safe.to_string actual)
+
+let test_initialize () =
+  expect_response "initialize"
+    {|{"jsonrpc":"2.0","id":1,"method":"initialize"}|}
+    (response ~id:(`Int 1) ~result:Mcp_server.initialize_result)
+
+let test_notifications_initialized_is_ignored () =
+  expect_no_response "initialized notification"
+    {|{"jsonrpc":"2.0","method":"notifications/initialized"}|}
+
+let test_tools_list_uses_typed_descriptors () =
+  expect_response "tools/list"
+    {|{"jsonrpc":"2.0","id":"tools","method":"tools/list"}|}
+    (response ~id:(`String "tools")
+       ~result:(`Assoc [("tools", Mcp_tool.tool_definitions_json)]))
+
+let test_ping () =
+  expect_response "ping"
+    {|{"jsonrpc":"2.0","id":2,"method":"ping"}|}
+    (response ~id:(`Int 2) ~result:(`Assoc []))
+
+let test_tools_call_invokes_handler () =
+  handler_calls := [];
+  let handler =
+    recording_handler (Ok "sent")
+  in
+  expect_response "tools/call" ~handler
+    {|{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"send_message","arguments":{"thread_id":"123","message":"hello"}}}|}
+    (response ~id:(`Int 3) ~result:(text_result "sent"));
+  match !handler_calls with
+  | [{ Mcp_server.name; arguments }] ->
+    Alcotest.(check string) "tool name" "send_message" name;
+    check_json "arguments"
+      (`Assoc [
+        ("thread_id", `String "123");
+        ("message", `String "hello");
+      ])
+      arguments
+  | calls ->
+    failf "expected one handler call, got %d" (List.length calls)
+
+let test_tools_call_defaults_arguments () =
+  handler_calls := [];
+  let handler =
+    recording_handler (Ok "listed")
+  in
+  expect_response "tools/call default args" ~handler
+    {|{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"list_projects"}}|}
+    (response ~id:(`Int 4) ~result:(text_result "listed"));
+  match !handler_calls with
+  | [{ Mcp_server.name; arguments }] ->
+    Alcotest.(check string) "tool name" "list_projects" name;
+    check_json "arguments" (`Assoc []) arguments
+  | calls ->
+    failf "expected one handler call, got %d" (List.length calls)
+
+let test_tools_call_error_result () =
+  let handler _call = Error "not yet" in
+  expect_response "tools/call error" ~handler
+    {|{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"x"}}|}
+    (response ~id:(`Int 5) ~result:(text_result ~is_error:true "not yet"))
+
+let test_tools_call_exception_becomes_tool_error () =
+  let handler _call = failwith "boom" in
+  expect_response "tools/call exception" ~handler
+    {|{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"x"}}|}
+    (response ~id:(`Int 6)
+       ~result:(text_result ~is_error:true "Error: Failure(\"boom\")"))
+
+let test_unknown_request_returns_jsonrpc_error () =
+  expect_response "unknown request"
+    {|{"jsonrpc":"2.0","id":7,"method":"missing"}|}
+    (`Assoc [
+      ("jsonrpc", `String "2.0");
+      ("id", `Int 7);
+      ("error", `Assoc [
+        ("code", `Int (-32601));
+        ("message", `String "Unknown method: missing");
+      ]);
+    ])
+
+let test_unknown_notification_is_ignored () =
+  expect_no_response "unknown notification"
+    {|{"jsonrpc":"2.0","method":"missing"}|}
+
+let test_invalid_json_is_ignored () =
+  expect_no_response "invalid json" "{"
+
+let () =
+  Alcotest.run "mcp_server" [
+    ("protocol", [
+      Alcotest.test_case "initialize" `Quick test_initialize;
+      Alcotest.test_case "initialized notification" `Quick
+        test_notifications_initialized_is_ignored;
+      Alcotest.test_case "tools/list descriptors" `Quick
+        test_tools_list_uses_typed_descriptors;
+      Alcotest.test_case "ping" `Quick test_ping;
+      Alcotest.test_case "tools/call invokes handler" `Quick
+        test_tools_call_invokes_handler;
+      Alcotest.test_case "tools/call defaults arguments" `Quick
+        test_tools_call_defaults_arguments;
+      Alcotest.test_case "tools/call error result" `Quick
+        test_tools_call_error_result;
+      Alcotest.test_case "tools/call exception" `Quick
+        test_tools_call_exception_becomes_tool_error;
+      Alcotest.test_case "unknown request" `Quick
+        test_unknown_request_returns_jsonrpc_error;
+      Alcotest.test_case "unknown notification" `Quick
+        test_unknown_notification_is_ignored;
+      Alcotest.test_case "invalid json" `Quick test_invalid_json_is_ignored;
+    ]);
+  ]

--- a/test/test_mcp_server.ml
+++ b/test/test_mcp_server.ml
@@ -25,6 +25,16 @@ let response ~id ~result =
     ("result", result);
   ]
 
+let error_response ~id ~code ~message =
+  `Assoc [
+    ("jsonrpc", `String "2.0");
+    ("id", id);
+    ("error", `Assoc [
+      ("code", `Int code);
+      ("message", `String message);
+    ]);
+  ]
+
 let text_result ?(is_error=false) text =
   let fields = [
     ("content", `List [
@@ -59,8 +69,15 @@ let expect_no_response label line =
 
 let test_initialize () =
   expect_response "initialize"
-    {|{"jsonrpc":"2.0","id":1,"method":"initialize"}|}
-    (response ~id:(`Int 1) ~result:Mcp_server.initialize_result)
+    {|{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"0.1"}}}|}
+    (response ~id:(`Int 1) ~result:(`Assoc [
+      ("protocolVersion", `String "2024-11-05");
+      ("capabilities", `Assoc [("tools", `Assoc [])]);
+      ("serverInfo", `Assoc [
+        ("name", `String "discord-agents-mcp");
+        ("version", `String "0.2.0");
+      ]);
+    ]))
 
 let test_notifications_initialized_is_ignored () =
   expect_no_response "initialized notification"
@@ -71,6 +88,10 @@ let test_tools_list_uses_typed_descriptors () =
     {|{"jsonrpc":"2.0","id":"tools","method":"tools/list"}|}
     (response ~id:(`String "tools")
        ~result:(`Assoc [("tools", Mcp_tool.tool_definitions_json)]))
+
+let test_tools_list_notification_is_ignored () =
+  expect_no_response "tools/list notification"
+    {|{"jsonrpc":"2.0","method":"tools/list"}|}
 
 let test_ping () =
   expect_response "ping"
@@ -118,6 +139,24 @@ let test_tools_call_error_result () =
     {|{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"x"}}|}
     (response ~id:(`Int 5) ~result:(text_result ~is_error:true "not yet"))
 
+let test_tools_call_rejects_missing_params () =
+  expect_response "tools/call missing params"
+    {|{"jsonrpc":"2.0","id":50,"method":"tools/call"}|}
+    (error_response ~id:(`Int 50) ~code:(-32602)
+       ~message:"tools/call params must be an object")
+
+let test_tools_call_rejects_missing_name () =
+  expect_response "tools/call missing name"
+    {|{"jsonrpc":"2.0","id":51,"method":"tools/call","params":{"arguments":{}}}|}
+    (error_response ~id:(`Int 51) ~code:(-32602)
+       ~message:"tools/call params.name must be a non-empty string")
+
+let test_tools_call_rejects_non_object_arguments () =
+  expect_response "tools/call non-object arguments"
+    {|{"jsonrpc":"2.0","id":52,"method":"tools/call","params":{"name":"x","arguments":[]}}|}
+    (error_response ~id:(`Int 52) ~code:(-32602)
+       ~message:"tools/call params.arguments must be an object")
+
 let test_tools_call_exception_becomes_tool_error () =
   let handler _call = failwith "boom" in
   expect_response "tools/call exception" ~handler
@@ -128,21 +167,20 @@ let test_tools_call_exception_becomes_tool_error () =
 let test_unknown_request_returns_jsonrpc_error () =
   expect_response "unknown request"
     {|{"jsonrpc":"2.0","id":7,"method":"missing"}|}
-    (`Assoc [
-      ("jsonrpc", `String "2.0");
-      ("id", `Int 7);
-      ("error", `Assoc [
-        ("code", `Int (-32601));
-        ("message", `String "Unknown method: missing");
-      ]);
-    ])
+    (error_response ~id:(`Int 7) ~code:(-32601)
+       ~message:"Unknown method: missing")
 
 let test_unknown_notification_is_ignored () =
   expect_no_response "unknown notification"
     {|{"jsonrpc":"2.0","method":"missing"}|}
 
-let test_invalid_json_is_ignored () =
-  expect_no_response "invalid json" "{"
+let test_invalid_json_returns_parse_error () =
+  expect_response "invalid json" "{"
+    (error_response ~id:`Null ~code:(-32700) ~message:"Parse error")
+
+let test_invalid_request_returns_error () =
+  expect_response "invalid request" "[]"
+    (error_response ~id:`Null ~code:(-32600) ~message:"Invalid Request")
 
 let () =
   Alcotest.run "mcp_server" [
@@ -152,6 +190,8 @@ let () =
         test_notifications_initialized_is_ignored;
       Alcotest.test_case "tools/list descriptors" `Quick
         test_tools_list_uses_typed_descriptors;
+      Alcotest.test_case "tools/list notification" `Quick
+        test_tools_list_notification_is_ignored;
       Alcotest.test_case "ping" `Quick test_ping;
       Alcotest.test_case "tools/call invokes handler" `Quick
         test_tools_call_invokes_handler;
@@ -159,12 +199,21 @@ let () =
         test_tools_call_defaults_arguments;
       Alcotest.test_case "tools/call error result" `Quick
         test_tools_call_error_result;
+      Alcotest.test_case "tools/call rejects missing params" `Quick
+        test_tools_call_rejects_missing_params;
+      Alcotest.test_case "tools/call rejects missing name" `Quick
+        test_tools_call_rejects_missing_name;
+      Alcotest.test_case "tools/call rejects non-object arguments" `Quick
+        test_tools_call_rejects_non_object_arguments;
       Alcotest.test_case "tools/call exception" `Quick
         test_tools_call_exception_becomes_tool_error;
       Alcotest.test_case "unknown request" `Quick
         test_unknown_request_returns_jsonrpc_error;
       Alcotest.test_case "unknown notification" `Quick
         test_unknown_notification_is_ignored;
-      Alcotest.test_case "invalid json" `Quick test_invalid_json_is_ignored;
+      Alcotest.test_case "invalid json" `Quick
+        test_invalid_json_returns_parse_error;
+      Alcotest.test_case "invalid request" `Quick
+        test_invalid_request_returns_error;
     ]);
   ]


### PR DESCRIPTION
## Summary

- add a pure `Mcp_server` JSON-RPC protocol module for initialize, ping, tools/list, tools/call dispatch, and error responses
- add a private OCaml stdio executable skeleton for local development without replacing or installing over the Python MCP runtime
- add protocol tests covering descriptor-backed `tools/list`, injected tool handlers, invalid params, notifications, parse errors, tool errors, unknown requests, and explicit `arguments: null`

## Notes

This is intentionally a bridge slice. The existing Python MCP server remains the runtime entrypoint for real tool calls until response formatting is ported tool-by-tool. The OCaml executable is private until calls are wired.

## Validation

- `nix develop --command dune exec ./test/test_mcp_server.exe`
- `nix develop --command dune build ./bin/mcp_server.exe`
- `git diff --check`
- `nix develop --command dune runtest`
- `nix build`
- direct stdio smoke through `_build/default/bin/mcp_server.exe`
