### PR TITLE
Port list_sessions MCP call to OCaml

### DIFF
--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -321,10 +321,11 @@ let handle_list_projects (bot : Bot.t) =
 let handle_list_sessions (bot : Bot.t) =
   let entries = Session_store.bindings bot.sessions in
   let sessions = List.map (fun (_tid, (s : Session_store.session)) ->
-    (* single_line on project_name: an MCP client formats this back
-       into Discord markdown bullets (scripts/mcp-server.py:234), so
-       a literal newline in a project name would split the bullet
-       just like it did for session summaries before 25d3546. *)
+    (* single_line on project_name: MCP clients format this back into
+       Discord markdown bullets (scripts/mcp-server.py list_sessions and
+       Mcp_formatter.session_line), so a literal newline in a project name
+       would split the bullet just like it did for session summaries before
+       25d3546. *)
     `Assoc [
       ("project_name", `String (Resource.single_line s.project_name));
       ("agent_kind", `String (Config.string_of_agent_kind s.agent_kind));

--- a/lib/mcp_formatter.ml
+++ b/lib/mcp_formatter.ml
@@ -11,20 +11,19 @@ let string_field object_name name fields =
       Printf.sprintf "%s.%s must be a string" object_name name
     )
 
+let int_error object_name name =
+  Error (
+    Printf.sprintf "%s.%s must be an in-range integer" object_name name
+  )
+
 let int_field object_name name fields =
   match field name fields with
   | Some (`Int value) -> Ok value
   | Some (`Intlit value) ->
     (match int_of_string_opt value with
      | Some value -> Ok value
-     | None ->
-       Error (
-         Printf.sprintf "%s.%s must be an integer" object_name name
-       ))
-  | _ ->
-    Error (
-      Printf.sprintf "%s.%s must be an integer" object_name name
-    )
+     | None -> int_error object_name name)
+  | _ -> int_error object_name name
 
 let bool_field_default default name fields =
   match field name fields with
@@ -111,6 +110,8 @@ let session_line = function
 
 let format_list_sessions response =
   format_response
+    (* Python treats explicit null sessions as empty because list_sessions
+       guards with [if not sessions]; list_projects intentionally does not. *)
     ~null_list_is_empty:true
     ~field_name:"sessions"
     ~empty_message:"No active sessions."

--- a/lib/mcp_formatter.ml
+++ b/lib/mcp_formatter.ml
@@ -11,10 +11,52 @@ let string_field object_name name fields =
       Printf.sprintf "%s.%s must be a string" object_name name
     )
 
+let int_field object_name name fields =
+  match field name fields with
+  | Some (`Int value) -> Ok value
+  | _ ->
+    Error (
+      Printf.sprintf "%s.%s must be an integer" object_name name
+    )
+
 let bool_field_default default name fields =
   match field name fields with
   | Some (`Bool value) -> value
   | _ -> default
+
+let list_field name fields =
+  match field name fields with
+  | None -> Ok []
+  | Some (`List values) -> Ok values
+  | Some _ ->
+    Error (
+      Printf.sprintf "Control API %s field must be an array" name
+    )
+
+let format_lines ~field_name ~empty_message ~line_of_item fields =
+  match list_field field_name fields with
+  | Error _ as error -> error
+  | Ok [] -> Ok empty_message
+  | Ok items ->
+    items
+    |> List.mapi line_of_item
+    |> List.fold_left (fun acc line ->
+      match acc, line with
+      | (Error _ as error), _ -> error
+      | _, (Error _ as error) -> error
+      | Ok lines, Ok line -> Ok (line :: lines))
+      (Ok [])
+    |> Result.map (fun lines ->
+      lines |> List.rev |> String.concat "\n")
+
+let format_response ~field_name ~empty_message ~line_of_item = function
+  | `Assoc fields ->
+    (match field "error" fields with
+     | Some (`String message) -> Error message
+     | Some _ -> Error "Control API error field must be a string"
+     | None ->
+       format_lines ~field_name ~empty_message ~line_of_item fields)
+  | _ -> Error "Control API response must be an object"
 
 let project_line index = function
   | `Assoc fields ->
@@ -29,30 +71,31 @@ let project_line index = function
      | Error message, _ | _, Error message -> Error message)
   | _ -> Error "project entry must be an object"
 
-let format_list_projects = function
+let format_list_projects response =
+  format_response
+    ~field_name:"projects"
+    ~empty_message:"No projects found."
+    ~line_of_item:project_line
+    response
+
+let session_line _index = function
   | `Assoc fields ->
-    (match field "error" fields with
-     | Some (`String message) -> Error message
-     | Some _ -> Error "Control API error field must be a string"
-     | None ->
-       let projects =
-         match field "projects" fields with
-         | None -> Ok []
-         | Some (`List projects) -> Ok projects
-         | Some _ -> Error "Control API projects field must be an array"
-       in
-       (match projects with
-        | Error _ as error -> error
-        | Ok [] -> Ok "No projects found."
-        | Ok projects ->
-          projects
-          |> List.mapi project_line
-          |> List.fold_left (fun acc line ->
-            match acc, line with
-            | (Error _ as error), _ -> error
-            | _, (Error _ as error) -> error
-            | Ok lines, Ok line -> Ok (line :: lines))
-            (Ok [])
-          |> Result.map (fun lines ->
-            lines |> List.rev |> String.concat "\n")))
-  | _ -> Error "Control API response must be an object"
+    (match string_field "session" "project_name" fields,
+           string_field "session" "agent_kind" fields,
+           int_field "session" "message_count" fields,
+           string_field "session" "thread_id" fields with
+     | Ok project_name, Ok agent_kind, Ok message_count, Ok thread_id ->
+       Ok (Printf.sprintf "- **%s** / %s — %d messages (thread: <#%s>)"
+             project_name agent_kind message_count thread_id)
+     | Error message, _, _, _
+     | _, Error message, _, _
+     | _, _, Error message, _
+     | _, _, _, Error message -> Error message)
+  | _ -> Error "session entry must be an object"
+
+let format_list_sessions response =
+  format_response
+    ~field_name:"sessions"
+    ~empty_message:"No active sessions."
+    ~line_of_item:session_line
+    response

--- a/lib/mcp_formatter.ml
+++ b/lib/mcp_formatter.ml
@@ -14,6 +14,13 @@ let string_field object_name name fields =
 let int_field object_name name fields =
   match field name fields with
   | Some (`Int value) -> Ok value
+  | Some (`Intlit value) ->
+    (match int_of_string_opt value with
+     | Some value -> Ok value
+     | None ->
+       Error (
+         Printf.sprintf "%s.%s must be an integer" object_name name
+       ))
   | _ ->
     Error (
       Printf.sprintf "%s.%s must be an integer" object_name name
@@ -24,38 +31,44 @@ let bool_field_default default name fields =
   | Some (`Bool value) -> value
   | _ -> default
 
-let list_field name fields =
+let list_field ?(null_is_empty=false) name fields =
   match field name fields with
   | None -> Ok []
+  | Some `Null when null_is_empty -> Ok []
   | Some (`List values) -> Ok values
   | Some _ ->
     Error (
       Printf.sprintf "Control API %s field must be an array" name
     )
 
-let format_lines ~field_name ~empty_message ~line_of_item fields =
-  match list_field field_name fields with
-  | Error _ as error -> error
-  | Ok [] -> Ok empty_message
-  | Ok items ->
-    items
-    |> List.mapi line_of_item
-    |> List.fold_left (fun acc line ->
-      match acc, line with
-      | (Error _ as error), _ -> error
-      | _, (Error _ as error) -> error
-      | Ok lines, Ok line -> Ok (line :: lines))
-      (Ok [])
-    |> Result.map (fun lines ->
-      lines |> List.rev |> String.concat "\n")
+let finish_lines ~empty_message lines =
+  match lines with
+  | [] -> Ok empty_message
+  | lines -> Ok (lines |> List.rev |> String.concat "\n")
 
-let format_response ~field_name ~empty_message ~line_of_item = function
+let format_lines ?(null_list_is_empty=false)
+    ~field_name ~empty_message ~line_of_item fields =
+  match list_field ~null_is_empty:null_list_is_empty field_name fields with
+  | Error _ as error -> error
+  | Ok items ->
+    let rec loop index lines = function
+      | [] -> finish_lines ~empty_message lines
+      | item :: rest ->
+        match line_of_item index item with
+        | Error _ as error -> error
+        | Ok line -> loop (index + 1) (line :: lines) rest
+    in
+    loop 0 [] items
+
+let format_response ?(null_list_is_empty=false)
+    ~field_name ~empty_message ~line_of_item = function
   | `Assoc fields ->
     (match field "error" fields with
      | Some (`String message) -> Error message
      | Some _ -> Error "Control API error field must be a string"
      | None ->
-       format_lines ~field_name ~empty_message ~line_of_item fields)
+       format_lines ~null_list_is_empty
+         ~field_name ~empty_message ~line_of_item fields)
   | _ -> Error "Control API response must be an object"
 
 let project_line index = function
@@ -78,7 +91,10 @@ let format_list_projects response =
     ~line_of_item:project_line
     response
 
-let session_line _index = function
+(* [Control_api.handle_list_sessions] applies [Resource.single_line] to
+   [project_name] before this formatter interpolates it into a Discord
+   markdown bullet. *)
+let session_line = function
   | `Assoc fields ->
     (match string_field "session" "project_name" fields,
            string_field "session" "agent_kind" fields,
@@ -95,7 +111,8 @@ let session_line _index = function
 
 let format_list_sessions response =
   format_response
+    ~null_list_is_empty:true
     ~field_name:"sessions"
     ~empty_message:"No active sessions."
-    ~line_of_item:session_line
+    ~line_of_item:(fun _index -> session_line)
     response

--- a/lib/mcp_formatter.ml
+++ b/lib/mcp_formatter.ml
@@ -11,7 +11,12 @@ let string_field object_name name fields =
       Printf.sprintf "%s.%s must be a string" object_name name
     )
 
-let int_error object_name name =
+let int_type_error object_name name =
+  Error (
+    Printf.sprintf "%s.%s must be an integer" object_name name
+  )
+
+let int_range_error object_name name =
   Error (
     Printf.sprintf "%s.%s must be an in-range integer" object_name name
   )
@@ -22,8 +27,8 @@ let int_field object_name name fields =
   | Some (`Intlit value) ->
     (match int_of_string_opt value with
      | Some value -> Ok value
-     | None -> int_error object_name name)
-  | _ -> int_error object_name name
+     | None -> int_range_error object_name name)
+  | _ -> int_type_error object_name name
 
 let bool_field_default default name fields =
   match field name fields with
@@ -76,6 +81,8 @@ let project_line index = function
            string_field "project" "path" fields with
      | Ok name, Ok path ->
        let bare_suffix =
+         (* Control_api emits a bool here; malformed non-bools fail closed
+            instead of inheriting Python's broad truthiness. *)
          if bool_field_default false "is_bare" fields then " [bare]" else ""
        in
        Ok (Printf.sprintf "%d. **%s** — `%s`%s"

--- a/lib/mcp_handler.ml
+++ b/lib/mcp_handler.ml
@@ -7,12 +7,23 @@ let unsupported_tool name =
       name
   )
 
-let handle_list_projects control_client =
-  match Control_client.request_method control_client Control_api.List_projects_id with
+let request_and_format control_client method_id formatter =
+  match Control_client.request_method control_client method_id with
   | Error _ as error -> error
-  | Ok response -> Mcp_formatter.format_list_projects response
+  | Ok response -> formatter response
+
+let handle_list_projects control_client =
+  request_and_format control_client
+    Control_api.List_projects_id
+    Mcp_formatter.format_list_projects
+
+let handle_list_sessions control_client =
+  request_and_format control_client
+    Control_api.List_sessions_id
+    Mcp_formatter.format_list_sessions
 
 let handle_tool_call ~control_client (call : Mcp_server.tool_call) =
   match call.name with
   | "list_projects" -> handle_list_projects control_client
+  | "list_sessions" -> handle_list_sessions control_client
   | name -> unsupported_tool name

--- a/test/test_mcp_handler.ml
+++ b/test/test_mcp_handler.ml
@@ -142,6 +142,45 @@ let test_format_list_projects_control_error () =
     (Mcp_formatter.format_list_projects
        (`Assoc [("error", `String "Bot is not running.")]))
 
+let test_format_list_projects_malformed_response () =
+  let check label expected response =
+    Alcotest.(check (result string string))
+      label
+      expected
+      (Mcp_formatter.format_list_projects response)
+  in
+  check "response object"
+    (Error "Control API response must be an object")
+    `Null;
+  check "error string"
+    (Error "Control API error field must be a string")
+    (`Assoc [("error", `Bool true)]);
+  check "projects array"
+    (Error "Control API projects field must be an array")
+    (`Assoc [("projects", `String "bad")]);
+  check "projects null"
+    (Error "Control API projects field must be an array")
+    (`Assoc [("projects", `Null)]);
+  check "project object"
+    (Error "project entry must be an object")
+    (`Assoc [("projects", `List [`String "bad"])]);
+  check "project name"
+    (Error "project.name must be a string")
+    (`Assoc [("projects", `List [
+      `Assoc [
+        ("name", `Bool true);
+        ("path", `String "/tmp/repo");
+      ];
+    ])]);
+  check "project path"
+    (Error "project.path must be a string")
+    (`Assoc [("projects", `List [
+      `Assoc [
+        ("name", `String "repo");
+        ("path", `Bool true);
+      ];
+    ])])
+
 let test_format_list_sessions_matches_python () =
   check_list_sessions_parity "empty" (list_sessions_response []);
   check_list_sessions_parity "sessions"
@@ -204,7 +243,7 @@ let test_format_list_sessions_malformed_response () =
       ];
     ])]);
   check "message count"
-    (Error "session.message_count must be an integer")
+    (Error "session.message_count must be an in-range integer")
     (`Assoc [("sessions", `List [
       `Assoc [
         ("project_name", `String "repo");
@@ -214,7 +253,7 @@ let test_format_list_sessions_malformed_response () =
       ];
     ])]);
   check "invalid int literal"
-    (Error "session.message_count must be an integer")
+    (Error "session.message_count must be an in-range integer")
     (`Assoc [("sessions", `List [
       `Assoc [
         ("project_name", `String "repo");
@@ -533,6 +572,8 @@ let () =
         test_format_list_projects_matches_python;
       Alcotest.test_case "list_projects control error" `Quick
         test_format_list_projects_control_error;
+      Alcotest.test_case "list_projects malformed response" `Quick
+        test_format_list_projects_malformed_response;
       Alcotest.test_case "list_sessions matches Python" `Quick
         test_format_list_sessions_matches_python;
       Alcotest.test_case "list_sessions control error" `Quick

--- a/test/test_mcp_handler.ml
+++ b/test/test_mcp_handler.ml
@@ -89,7 +89,10 @@ let list_projects_response projects =
     ("projects", `List projects);
   ]
 
-let session ?(session_id="session-1") project_name agent_kind message_count thread_id =
+let session ?(session_id="session-1")
+    ~project_name ~agent_kind ~message_count ~thread_id () =
+  (* session_id is deliberately present and ignored by the formatter: the
+     MCP output must tolerate extra fields from the control API. *)
   `Assoc [
     ("project_name", `String project_name);
     ("agent_kind", `String agent_kind);
@@ -143,9 +146,14 @@ let test_format_list_sessions_matches_python () =
   check_list_sessions_parity "empty" (list_sessions_response []);
   check_list_sessions_parity "sessions"
     (list_sessions_response [
-      session "alpha" "claude" 3 "111";
-      session ~session_id:"session-2" "beta" "codex" 0 "222";
+      session ~project_name:"alpha" ~agent_kind:"claude"
+        ~message_count:3 ~thread_id:"111" ();
+      session ~session_id:"session-2"
+        ~project_name:"beta" ~agent_kind:"codex"
+        ~message_count:0 ~thread_id:"222" ();
     ]);
+  check_list_sessions_parity "null sessions"
+    (`Assoc [("ok", `Bool true); ("sessions", `Null)]);
   check_list_sessions_parity "missing sessions"
     (`Assoc [("ok", `Bool true)])
 
@@ -155,6 +163,86 @@ let test_format_list_sessions_control_error () =
     (Error "Bot is not running.")
     (Mcp_formatter.format_list_sessions
        (`Assoc [("error", `String "Bot is not running.")]))
+
+let test_format_list_sessions_malformed_response () =
+  let check label expected response =
+    Alcotest.(check (result string string))
+      label
+      expected
+      (Mcp_formatter.format_list_sessions response)
+  in
+  check "response object"
+    (Error "Control API response must be an object")
+    `Null;
+  check "error string"
+    (Error "Control API error field must be a string")
+    (`Assoc [("error", `Bool true)]);
+  check "sessions array"
+    (Error "Control API sessions field must be an array")
+    (`Assoc [("sessions", `String "bad")]);
+  check "session object"
+    (Error "session entry must be an object")
+    (`Assoc [("sessions", `List [`String "bad"])]);
+  check "project name"
+    (Error "session.project_name must be a string")
+    (`Assoc [("sessions", `List [
+      `Assoc [
+        ("project_name", `Bool true);
+        ("agent_kind", `String "claude");
+        ("message_count", `Int 1);
+        ("thread_id", `String "123");
+      ];
+    ])]);
+  check "agent kind"
+    (Error "session.agent_kind must be a string")
+    (`Assoc [("sessions", `List [
+      `Assoc [
+        ("project_name", `String "repo");
+        ("agent_kind", `Bool true);
+        ("message_count", `Int 1);
+        ("thread_id", `String "123");
+      ];
+    ])]);
+  check "message count"
+    (Error "session.message_count must be an integer")
+    (`Assoc [("sessions", `List [
+      `Assoc [
+        ("project_name", `String "repo");
+        ("agent_kind", `String "claude");
+        ("message_count", `String "1");
+        ("thread_id", `String "123");
+      ];
+    ])]);
+  check "invalid int literal"
+    (Error "session.message_count must be an integer")
+    (`Assoc [("sessions", `List [
+      `Assoc [
+        ("project_name", `String "repo");
+        ("agent_kind", `String "claude");
+        ("message_count", `Intlit "not-an-int");
+        ("thread_id", `String "123");
+      ];
+    ])]);
+  check "thread id"
+    (Error "session.thread_id must be a string")
+    (`Assoc [("sessions", `List [
+      `Assoc [
+        ("project_name", `String "repo");
+        ("agent_kind", `String "claude");
+        ("message_count", `Int 1);
+        ("thread_id", `Int 123);
+      ];
+    ])]);
+  check "int literal"
+    (Ok "- **repo** / claude — 42 messages (thread: <#123>)")
+    (`Assoc [("sessions", `List [
+      `Assoc [
+        ("project_name", `String "repo");
+        ("agent_kind", `String "claude");
+        ("message_count", `Intlit "42");
+        ("thread_id", `String "123");
+      ];
+    ])])
 
 let test_handler_list_projects_requests_control_api () =
   let calls = ref [] in
@@ -182,7 +270,10 @@ let test_handler_list_projects_requests_control_api () =
 let test_handler_list_sessions_requests_control_api () =
   let calls = ref [] in
   let response =
-    list_sessions_response [session "repo" "gemini" 12 "123"]
+    list_sessions_response [
+      session ~project_name:"repo" ~agent_kind:"gemini"
+        ~message_count:12 ~thread_id:"123" ();
+    ]
   in
   let control_client =
     Control_client.make ~request:(fun request ->
@@ -280,7 +371,10 @@ let test_server_wraps_list_projects_control_error () =
 let test_server_wraps_list_sessions_result () =
   let control_client =
     Control_client.make ~request:(fun _request ->
-      Ok (list_sessions_response [session "alpha" "claude" 7 "987"]))
+      Ok (list_sessions_response [
+        session ~project_name:"alpha" ~agent_kind:"claude"
+          ~message_count:7 ~thread_id:"987" ();
+      ]))
   in
   let line =
     {|{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"list_sessions"}}|}
@@ -443,6 +537,8 @@ let () =
         test_format_list_sessions_matches_python;
       Alcotest.test_case "list_sessions control error" `Quick
         test_format_list_sessions_control_error;
+      Alcotest.test_case "list_sessions malformed response" `Quick
+        test_format_list_sessions_malformed_response;
     ]);
     ("handler", [
       Alcotest.test_case "list_projects requests control API" `Quick

--- a/test/test_mcp_handler.ml
+++ b/test/test_mcp_handler.ml
@@ -179,6 +179,15 @@ let test_format_list_projects_malformed_response () =
         ("name", `String "repo");
         ("path", `Bool true);
       ];
+    ])]);
+  check "non-bool is_bare"
+    (Ok "1. **repo** — `/tmp/repo`")
+    (`Assoc [("projects", `List [
+      `Assoc [
+        ("name", `String "repo");
+        ("path", `String "/tmp/repo");
+        ("is_bare", `String "yes");
+      ];
     ])])
 
 let test_format_list_sessions_matches_python () =
@@ -243,7 +252,7 @@ let test_format_list_sessions_malformed_response () =
       ];
     ])]);
   check "message count"
-    (Error "session.message_count must be an in-range integer")
+    (Error "session.message_count must be an integer")
     (`Assoc [("sessions", `List [
       `Assoc [
         ("project_name", `String "repo");
@@ -258,7 +267,7 @@ let test_format_list_sessions_malformed_response () =
       `Assoc [
         ("project_name", `String "repo");
         ("agent_kind", `String "claude");
-        ("message_count", `Intlit "not-an-int");
+        ("message_count", `Intlit "999999999999999999999999999999");
         ("thread_id", `String "123");
       ];
     ])]);

--- a/test/test_mcp_handler.ml
+++ b/test/test_mcp_handler.ml
@@ -51,7 +51,7 @@ let read_process_output command =
   | Unix.WSIGNALED n -> failf "command signaled %d: %s" n command
   | Unix.WSTOPPED n -> failf "command stopped %d: %s" n command
 
-let python_list_projects_output response =
+let python_tool_output tool_name response =
   let script = repo_file "scripts/mcp-server.py" in
   let program =
     "import json, runpy, sys; "
@@ -59,15 +59,22 @@ let python_list_projects_output response =
     ^ "response = json.loads(sys.argv[2]); "
     ^ "ns['handle_tool_call'].__globals__['control_request'] = "
     ^ "lambda method, params=None, timeout=60: response; "
-    ^ "sys.stdout.write(ns['handle_tool_call']('list_projects', {}))"
+    ^ "sys.stdout.write(ns['handle_tool_call'](sys.argv[3], {}))"
   in
   let command =
-    Printf.sprintf "python3 -c %s %s %s"
+    Printf.sprintf "python3 -c %s %s %s %s"
       (Filename.quote program)
       (Filename.quote script)
       (Filename.quote (Yojson.Safe.to_string response))
+      (Filename.quote tool_name)
   in
   read_process_output command
+
+let python_list_projects_output response =
+  python_tool_output "list_projects" response
+
+let python_list_sessions_output response =
+  python_tool_output "list_sessions" response
 
 let project ?(is_bare=false) name path =
   `Assoc [
@@ -82,10 +89,34 @@ let list_projects_response projects =
     ("projects", `List projects);
   ]
 
+let session ?(session_id="session-1") project_name agent_kind message_count thread_id =
+  `Assoc [
+    ("project_name", `String project_name);
+    ("agent_kind", `String agent_kind);
+    ("message_count", `Int message_count);
+    ("thread_id", `String thread_id);
+    ("session_id", `String session_id);
+  ]
+
+let list_sessions_response sessions =
+  `Assoc [
+    ("ok", `Bool true);
+    ("sessions", `List sessions);
+  ]
+
 let check_list_projects_parity label response =
   let expected = python_list_projects_output response in
   let actual =
     match Mcp_formatter.format_list_projects response with
+    | Ok text -> text
+    | Error message -> failf "%s: formatter error: %s" label message
+  in
+  Alcotest.(check string) label expected actual
+
+let check_list_sessions_parity label response =
+  let expected = python_list_sessions_output response in
+  let actual =
+    match Mcp_formatter.format_list_sessions response with
     | Ok text -> text
     | Error message -> failf "%s: formatter error: %s" label message
   in
@@ -108,6 +139,23 @@ let test_format_list_projects_control_error () =
     (Mcp_formatter.format_list_projects
        (`Assoc [("error", `String "Bot is not running.")]))
 
+let test_format_list_sessions_matches_python () =
+  check_list_sessions_parity "empty" (list_sessions_response []);
+  check_list_sessions_parity "sessions"
+    (list_sessions_response [
+      session "alpha" "claude" 3 "111";
+      session ~session_id:"session-2" "beta" "codex" 0 "222";
+    ]);
+  check_list_sessions_parity "missing sessions"
+    (`Assoc [("ok", `Bool true)])
+
+let test_format_list_sessions_control_error () =
+  Alcotest.(check (result string string))
+    "control error"
+    (Error "Bot is not running.")
+    (Mcp_formatter.format_list_sessions
+       (`Assoc [("error", `String "Bot is not running.")]))
+
 let test_handler_list_projects_requests_control_api () =
   let calls = ref [] in
   let response =
@@ -126,6 +174,29 @@ let test_handler_list_projects_requests_control_api () =
   match !calls with
   | [request] ->
     Alcotest.(check string) "method" "list_projects" request.method_name;
+    Alcotest.(check int) "timeout" 60 request.timeout_s;
+    Alcotest.(check bool) "params omitted" true
+      (Option.is_none request.params)
+  | calls -> failf "expected one control request, got %d" (List.length calls)
+
+let test_handler_list_sessions_requests_control_api () =
+  let calls = ref [] in
+  let response =
+    list_sessions_response [session "repo" "gemini" 12 "123"]
+  in
+  let control_client =
+    Control_client.make ~request:(fun request ->
+      calls := request :: !calls;
+      Ok response)
+  in
+  let call = { Mcp_server.name = "list_sessions"; arguments = `Assoc [] } in
+  Alcotest.(check (result string string))
+    "handler output"
+    (Ok "- **repo** / gemini — 12 messages (thread: <#123>)")
+    (Mcp_handler.handle_tool_call ~control_client call);
+  match !calls with
+  | [request] ->
+    Alcotest.(check string) "method" "list_sessions" request.method_name;
     Alcotest.(check int) "timeout" 60 request.timeout_s;
     Alcotest.(check bool) "params omitted" true
       (Option.is_none request.params)
@@ -205,6 +276,38 @@ let test_server_wraps_list_projects_control_error () =
   | Some actual, Some expected ->
     check_json "MCP error response" expected actual
   | _ -> failf "expected MCP error response"
+
+let test_server_wraps_list_sessions_result () =
+  let control_client =
+    Control_client.make ~request:(fun _request ->
+      Ok (list_sessions_response [session "alpha" "claude" 7 "987"]))
+  in
+  let line =
+    {|{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"list_sessions"}}|}
+  in
+  let actual =
+    Mcp_server.handle_line
+      ~handle_tool_call:(Mcp_handler.handle_tool_call ~control_client)
+      line
+  in
+  let expected =
+    Some (`Assoc [
+      ("jsonrpc", `String "2.0");
+      ("id", `Int 10);
+      ("result", `Assoc [
+        ("content", `List [
+          `Assoc [
+            ("type", `String "text");
+            ("text",
+             `String "- **alpha** / claude — 7 messages (thread: <#987>)");
+          ];
+        ]);
+      ]);
+    ])
+  in
+  match actual, expected with
+  | Some actual, Some expected -> check_json "MCP response" expected actual
+  | _ -> failf "expected MCP response"
 
 let temp_dir_counter = ref 0
 
@@ -336,16 +439,24 @@ let () =
         test_format_list_projects_matches_python;
       Alcotest.test_case "list_projects control error" `Quick
         test_format_list_projects_control_error;
+      Alcotest.test_case "list_sessions matches Python" `Quick
+        test_format_list_sessions_matches_python;
+      Alcotest.test_case "list_sessions control error" `Quick
+        test_format_list_sessions_control_error;
     ]);
     ("handler", [
       Alcotest.test_case "list_projects requests control API" `Quick
         test_handler_list_projects_requests_control_api;
+      Alcotest.test_case "list_sessions requests control API" `Quick
+        test_handler_list_sessions_requests_control_api;
       Alcotest.test_case "unsupported tool" `Quick
         test_handler_unsupported_tool;
       Alcotest.test_case "server wraps list_projects result" `Quick
         test_server_wraps_list_projects_result;
       Alcotest.test_case "server wraps list_projects control error" `Quick
         test_server_wraps_list_projects_control_error;
+      Alcotest.test_case "server wraps list_sessions result" `Quick
+        test_server_wraps_list_sessions_result;
     ]);
     ("control client", [
       Alcotest.test_case "unix roundtrip" `Quick


### PR DESCRIPTION
## Summary

- port the private OCaml MCP `list_sessions` tool call through `Mcp_handler`
- factor shared MCP response/list formatting for read-only list tools
- add `list_sessions` formatter parity against `scripts/mcp-server.py`
- add handler dispatch and MCP response-envelope tests for the new tool

## Validation

- `nix develop --command dune exec ./test/test_mcp_handler.exe`
- `nix develop --command dune runtest`
- `nix build`
- `git diff --check`
- private MCP stdio smoke: `tools/call` for `list_sessions` returned the live session list through the OCaml executable

## Notes

The public Python MCP runtime remains unchanged. This continues the private OCaml MCP migration by adding a second read-only tool behind the existing descriptor/control-client boundary.
