### PR TITLE
Port recent-session MCP tools to OCaml

### DIFF
--- a/lib/mcp_formatter.ml
+++ b/lib/mcp_formatter.ml
@@ -30,6 +30,20 @@ let int_field object_name name fields =
      | None -> int_range_error object_name name)
   | _ -> int_type_error object_name name
 
+let int_field_default default object_name name fields =
+  match field name fields with
+  | None -> Ok default
+  | Some _ -> int_field object_name name fields
+
+let string_field_default default object_name name fields =
+  match field name fields with
+  | None -> Ok default
+  | Some (`String value) -> Ok value
+  | _ ->
+    Error (
+      Printf.sprintf "%s.%s must be a string" object_name name
+    )
+
 let bool_field_default default name fields =
   match field name fields with
   | Some (`Bool value) -> value
@@ -45,18 +59,18 @@ let list_field ?(null_is_empty=false) name fields =
       Printf.sprintf "Control API %s field must be an array" name
     )
 
-let finish_lines ~empty_message lines =
+let finish_lines ?(footer="") ~empty_message lines =
   match lines with
   | [] -> Ok empty_message
-  | lines -> Ok (lines |> List.rev |> String.concat "\n")
+  | lines -> Ok ((lines |> List.rev |> String.concat "\n") ^ footer)
 
-let format_lines ?(null_list_is_empty=false)
+let format_lines ?(null_list_is_empty=false) ?(footer="")
     ~field_name ~empty_message ~line_of_item fields =
   match list_field ~null_is_empty:null_list_is_empty field_name fields with
   | Error _ as error -> error
   | Ok items ->
     let rec loop index lines = function
-      | [] -> finish_lines ~empty_message lines
+      | [] -> finish_lines ~footer ~empty_message lines
       | item :: rest ->
         match line_of_item index item with
         | Error _ as error -> error
@@ -64,7 +78,7 @@ let format_lines ?(null_list_is_empty=false)
     in
     loop 0 [] items
 
-let format_response ?(null_list_is_empty=false)
+let format_response ?(null_list_is_empty=false) ?(footer="")
     ~field_name ~empty_message ~line_of_item = function
   | `Assoc fields ->
     (match field "error" fields with
@@ -72,7 +86,7 @@ let format_response ?(null_list_is_empty=false)
      | Some _ -> Error "Control API error field must be a string"
      | None ->
        format_lines ~null_list_is_empty
-         ~field_name ~empty_message ~line_of_item fields)
+         ~footer ~field_name ~empty_message ~line_of_item fields)
   | _ -> Error "Control API response must be an object"
 
 let project_line index = function
@@ -123,4 +137,78 @@ let format_list_sessions response =
     ~field_name:"sessions"
     ~empty_message:"No active sessions."
     ~line_of_item:(fun _index -> session_line)
+    response
+
+let age_minutes_text age_minutes =
+  if age_minutes < 60 then
+    Printf.sprintf "%dm ago" age_minutes
+  else
+    Printf.sprintf "%dh ago" (age_minutes / 60)
+
+let recent_working_dir fields =
+  match field "working_dir" fields with
+  | None | Some `Null -> Ok "(unknown project)"
+  | Some (`String "") -> Ok "(unknown project)"
+  | Some (`String value) -> Ok value
+  | Some _ -> Error "recent_session.working_dir must be a string"
+
+let claude_recent_session_line = function
+  | `Assoc fields ->
+    (match string_field "recent_session" "session_id_short" fields,
+           int_field_default 0 "recent_session" "age_minutes" fields,
+           string_field_default "(no summary)"
+             "recent_session" "summary" fields with
+     | Ok session_id_short, Ok age_minutes, Ok summary ->
+       Ok (Printf.sprintf "- `%s` %s — %s"
+             session_id_short (age_minutes_text age_minutes) summary)
+     | Error message, _, _
+     | _, Error message, _
+     | _, _, Error message -> Error message)
+  | _ -> Error "recent_session entry must be an object"
+
+let cli_recent_session_line = function
+  | `Assoc fields ->
+    (match string_field "recent_session" "session_id_short" fields,
+           int_field_default 0 "recent_session" "age_minutes" fields,
+           recent_working_dir fields,
+           string_field_default "(no summary)"
+             "recent_session" "summary" fields with
+     | Ok session_id_short, Ok age_minutes, Ok working_dir, Ok summary ->
+       Ok (Printf.sprintf "- `%s` %s — %s — %s"
+             session_id_short (age_minutes_text age_minutes)
+             working_dir summary)
+     | Error message, _, _, _
+     | _, Error message, _, _
+     | _, _, Error message, _
+     | _, _, _, Error message -> Error message)
+  | _ -> Error "recent_session entry must be an object"
+
+let format_recent_sessions ~empty_message ~footer ~line_of_item response =
+  format_response
+    ~null_list_is_empty:true
+    ~footer
+    ~field_name:"sessions"
+    ~empty_message
+    ~line_of_item:(fun _index item -> line_of_item item)
+    response
+
+let format_list_claude_sessions response =
+  format_recent_sessions
+    ~empty_message:"No recent Claude sessions found."
+    ~footer:"\n\nUse resume_session with a session ID prefix to attach."
+    ~line_of_item:claude_recent_session_line
+    response
+
+let format_list_codex_sessions response =
+  format_recent_sessions
+    ~empty_message:"No recent Codex sessions found."
+    ~footer:"\n\nUse resume_session with kind=codex to attach."
+    ~line_of_item:cli_recent_session_line
+    response
+
+let format_list_gemini_sessions response =
+  format_recent_sessions
+    ~empty_message:"No recent Gemini sessions found."
+    ~footer:"\n\nUse resume_session with kind=gemini to attach."
+    ~line_of_item:cli_recent_session_line
     response

--- a/lib/mcp_formatter.ml
+++ b/lib/mcp_formatter.ml
@@ -175,23 +175,27 @@ let recent_working_dir fields =
    empty messages are the only other difference.
 
    Null policy inside a session object is deliberately split, because
-   the two fields are not alike: [working_dir] null is reachable and
+   the fields are not alike: [working_dir] null is reachable and
    meaningful (Python's [or] makes it "(unknown project)", so we match),
-   while a null [session_id_short] or [summary] is malformed — Python
-   interpolates the literal "None" there, and we fail closed instead.
-   Both are pinned by tests.
+   while a null [session_id_short], [summary] or [age_minutes] is
+   malformed — Python interpolates the literal "None" for the first two
+   and raises TypeError on the third ([None < 60]), where we return a
+   field-specific error for all three. Each case is pinned by a test.
 
-   [working_dir] and [summary] are forced single-line before
-   interpolation: [summary] arrives normalized from the discoverers, but
-   [working_dir] does not (Control_api emits [s.working_dir] verbatim,
-   and Codex reads it straight out of a rollout file). A literal newline
-   there would land the rest of the entry at column 0, where Discord
-   parses it as a sibling bullet — a forged entry the calling agent
-   cannot tell from a real one and may feed back to [resume_session].
-   [Bot.format_recent_sessions] sanitizes the Discord-side listing for
-   exactly this reason; Python does not, so this is a deliberate
-   divergence for pathological input only. [session_id_short] is
-   [Resource.short_id] output (lowercase hex) and needs no scrubbing. *)
+   Every interpolated string field is forced single-line first. A
+   literal newline in any of them lands the rest of the entry at column
+   0, where Discord parses it as a sibling bullet — a forged entry the
+   calling agent cannot tell from a real one and may feed back to
+   [resume_session]. [summary] already arrives normalized from the
+   discoverers and [session_id_short] is usually an 8-char hex prefix,
+   but neither is guaranteed: [Resource.short_id] is a [String.sub] that
+   validates nothing, and all three fields have the same provenance —
+   Codex reads [session_id] and [cwd] out of the same rollout record,
+   Claude takes its id from a filename. So scrub all three rather than
+   rest the invariant on the shape of upstream data.
+   [Bot.format_session_listing] (lib/bot.ml) does the same for the
+   Discord-side listing. Python does not, so this is a deliberate
+   divergence, visible only for pathological input. *)
 let recent_session_line ~with_working_dir = function
   | `Assoc fields ->
     let working_dir =
@@ -206,6 +210,7 @@ let recent_session_line ~with_working_dir = function
            string_field_default "(no summary)"
              "recent_session" "summary" fields with
      | Ok session_id_short, Ok age_minutes, Ok working_dir, Ok summary ->
+       let session_id_short = Resource.single_line session_id_short in
        let age = age_minutes_text age_minutes in
        let summary = Resource.single_line summary in
        Ok (

--- a/lib/mcp_formatter.ml
+++ b/lib/mcp_formatter.ml
@@ -193,9 +193,11 @@ let recent_working_dir fields =
    Codex reads [session_id] and [cwd] out of the same rollout record,
    Claude takes its id from a filename. So scrub all three rather than
    rest the invariant on the shape of upstream data.
-   [Bot.format_session_listing] (lib/bot.ml) does the same for the
-   Discord-side listing. Python does not, so this is a deliberate
-   divergence, visible only for pathological input. *)
+   [Bot.format_session_listing] (lib/bot.ml:1512) scrubs the working dir
+   and summary of the Discord-side listing for the same reason, but not
+   its session id — issue #103 tracks closing that half. Python does not
+   scrub at all, so this is a deliberate divergence, visible only for
+   pathological input. *)
 let recent_session_line ~with_working_dir = function
   | `Assoc fields ->
     let working_dir =

--- a/lib/mcp_formatter.ml
+++ b/lib/mcp_formatter.ml
@@ -59,18 +59,26 @@ let list_field ?(null_is_empty=false) name fields =
       Printf.sprintf "Control API %s field must be an array" name
     )
 
-let finish_lines ?(footer="") ~empty_message lines =
+(* The blank line between body and footer belongs to the joiner, not to
+   the footer string: a caller that passed a footer without its own
+   leading "\n\n" would otherwise silently glue it onto the last
+   bullet. [footer] is the footer text alone. *)
+let finish_lines ?footer ~empty_message lines =
   match lines with
   | [] -> Ok empty_message
-  | lines -> Ok ((lines |> List.rev |> String.concat "\n") ^ footer)
+  | lines ->
+    let body = lines |> List.rev |> String.concat "\n" in
+    (match footer with
+     | None -> Ok body
+     | Some footer -> Ok (body ^ "\n\n" ^ footer))
 
-let format_lines ?(null_list_is_empty=false) ?(footer="")
+let format_lines ?(null_list_is_empty=false) ?footer
     ~field_name ~empty_message ~line_of_item fields =
   match list_field ~null_is_empty:null_list_is_empty field_name fields with
   | Error _ as error -> error
   | Ok items ->
     let rec loop index lines = function
-      | [] -> finish_lines ~footer ~empty_message lines
+      | [] -> finish_lines ?footer ~empty_message lines
       | item :: rest ->
         match line_of_item index item with
         | Error _ as error -> error
@@ -78,7 +86,7 @@ let format_lines ?(null_list_is_empty=false) ?(footer="")
     in
     loop 0 [] items
 
-let format_response ?(null_list_is_empty=false) ?(footer="")
+let format_response ?(null_list_is_empty=false) ?footer
     ~field_name ~empty_message ~line_of_item = function
   | `Assoc fields ->
     (match field "error" fields with
@@ -86,7 +94,7 @@ let format_response ?(null_list_is_empty=false) ?(footer="")
      | Some _ -> Error "Control API error field must be a string"
      | None ->
        format_lines ~null_list_is_empty
-         ~footer ~field_name ~empty_message ~line_of_item fields)
+         ?footer ~field_name ~empty_message ~line_of_item fields)
   | _ -> Error "Control API response must be an object"
 
 let project_line index = function
@@ -139,12 +147,22 @@ let format_list_sessions response =
     ~line_of_item:(fun _index -> session_line)
     response
 
+(* Negative ages don't occur (Control_api derives them from mtime), and
+   the [< 60] guard keeps them out of the division if they ever do —
+   which matters, because OCaml's [/] truncates toward zero while
+   Python's [//] floors: [-70] renders "-70m ago" through the guard on
+   both sides, but "-1h ago" here against "-2h ago" in Python if the
+   guard is ever loosened. *)
 let age_minutes_text age_minutes =
   if age_minutes < 60 then
     Printf.sprintf "%dm ago" age_minutes
   else
     Printf.sprintf "%dh ago" (age_minutes / 60)
 
+(* Mirrors Python's [s.get("working_dir", "") or "(unknown project)"]:
+   absent, null and empty all fall back. A non-string fails closed
+   instead of inheriting Python's [str()] rendering — the same call the
+   [project_line] [is_bare] handling makes above. *)
 let recent_working_dir fields =
   match field "working_dir" fields with
   | None | Some `Null -> Ok "(unknown project)"
@@ -152,63 +170,84 @@ let recent_working_dir fields =
   | Some (`String value) -> Ok value
   | Some _ -> Error "recent_session.working_dir must be a string"
 
-let claude_recent_session_line = function
-  | `Assoc fields ->
-    (match string_field "recent_session" "session_id_short" fields,
-           int_field_default 0 "recent_session" "age_minutes" fields,
-           string_field_default "(no summary)"
-             "recent_session" "summary" fields with
-     | Ok session_id_short, Ok age_minutes, Ok summary ->
-       Ok (Printf.sprintf "- `%s` %s — %s"
-             session_id_short (age_minutes_text age_minutes) summary)
-     | Error message, _, _
-     | _, Error message, _
-     | _, _, Error message -> Error message)
-  | _ -> Error "recent_session entry must be an object"
+(* One line shape for all three agents: Claude's listing omits the
+   working_dir segment, Codex's and Gemini's carry it. Their footers and
+   empty messages are the only other difference.
 
-let cli_recent_session_line = function
+   Null policy inside a session object is deliberately split, because
+   the two fields are not alike: [working_dir] null is reachable and
+   meaningful (Python's [or] makes it "(unknown project)", so we match),
+   while a null [session_id_short] or [summary] is malformed — Python
+   interpolates the literal "None" there, and we fail closed instead.
+   Both are pinned by tests.
+
+   [working_dir] and [summary] are forced single-line before
+   interpolation: [summary] arrives normalized from the discoverers, but
+   [working_dir] does not (Control_api emits [s.working_dir] verbatim,
+   and Codex reads it straight out of a rollout file). A literal newline
+   there would land the rest of the entry at column 0, where Discord
+   parses it as a sibling bullet — a forged entry the calling agent
+   cannot tell from a real one and may feed back to [resume_session].
+   [Bot.format_recent_sessions] sanitizes the Discord-side listing for
+   exactly this reason; Python does not, so this is a deliberate
+   divergence for pathological input only. [session_id_short] is
+   [Resource.short_id] output (lowercase hex) and needs no scrubbing. *)
+let recent_session_line ~with_working_dir = function
   | `Assoc fields ->
+    let working_dir =
+      (* Claude's listing never renders working_dir, so it must not
+         validate it either: failing closed on an unrendered field would
+         reject a listing Python renders fine. *)
+      if with_working_dir then recent_working_dir fields else Ok ""
+    in
     (match string_field "recent_session" "session_id_short" fields,
            int_field_default 0 "recent_session" "age_minutes" fields,
-           recent_working_dir fields,
+           working_dir,
            string_field_default "(no summary)"
              "recent_session" "summary" fields with
      | Ok session_id_short, Ok age_minutes, Ok working_dir, Ok summary ->
-       Ok (Printf.sprintf "- `%s` %s — %s — %s"
-             session_id_short (age_minutes_text age_minutes)
-             working_dir summary)
+       let age = age_minutes_text age_minutes in
+       let summary = Resource.single_line summary in
+       Ok (
+         if with_working_dir then
+           Printf.sprintf "- `%s` %s — %s — %s"
+             session_id_short age (Resource.single_line working_dir) summary
+         else
+           Printf.sprintf "- `%s` %s — %s" session_id_short age summary
+       )
      | Error message, _, _, _
      | _, Error message, _, _
      | _, _, Error message, _
      | _, _, _, Error message -> Error message)
   | _ -> Error "recent_session entry must be an object"
 
-let format_recent_sessions ~empty_message ~footer ~line_of_item response =
+let format_recent_sessions ~empty_message ~footer ~with_working_dir response =
   format_response
     ~null_list_is_empty:true
     ~footer
     ~field_name:"sessions"
     ~empty_message
-    ~line_of_item:(fun _index item -> line_of_item item)
+    ~line_of_item:(fun _index item ->
+      recent_session_line ~with_working_dir item)
     response
 
 let format_list_claude_sessions response =
   format_recent_sessions
     ~empty_message:"No recent Claude sessions found."
-    ~footer:"\n\nUse resume_session with a session ID prefix to attach."
-    ~line_of_item:claude_recent_session_line
+    ~footer:"Use resume_session with a session ID prefix to attach."
+    ~with_working_dir:false
     response
 
 let format_list_codex_sessions response =
   format_recent_sessions
     ~empty_message:"No recent Codex sessions found."
-    ~footer:"\n\nUse resume_session with kind=codex to attach."
-    ~line_of_item:cli_recent_session_line
+    ~footer:"Use resume_session with kind=codex to attach."
+    ~with_working_dir:true
     response
 
 let format_list_gemini_sessions response =
   format_recent_sessions
     ~empty_message:"No recent Gemini sessions found."
-    ~footer:"\n\nUse resume_session with kind=gemini to attach."
-    ~line_of_item:cli_recent_session_line
+    ~footer:"Use resume_session with kind=gemini to attach."
+    ~with_working_dir:true
     response

--- a/lib/mcp_handler.ml
+++ b/lib/mcp_handler.ml
@@ -7,8 +7,8 @@ let unsupported_tool name =
       name
   )
 
-let request_and_format control_client method_id formatter =
-  match Control_client.request_method control_client method_id with
+let request_and_format ?params control_client method_id formatter =
+  match Control_client.request_method ?params control_client method_id with
   | Error _ as error -> error
   | Ok response -> formatter response
 
@@ -22,8 +22,29 @@ let handle_list_sessions control_client =
     Control_api.List_sessions_id
     Mcp_formatter.format_list_sessions
 
+let handle_list_claude_sessions control_client params =
+  request_and_format ~params control_client
+    Control_api.List_claude_sessions_id
+    Mcp_formatter.format_list_claude_sessions
+
+let handle_list_codex_sessions control_client params =
+  request_and_format ~params control_client
+    Control_api.List_codex_sessions_id
+    Mcp_formatter.format_list_codex_sessions
+
+let handle_list_gemini_sessions control_client params =
+  request_and_format ~params control_client
+    Control_api.List_gemini_sessions_id
+    Mcp_formatter.format_list_gemini_sessions
+
 let handle_tool_call ~control_client (call : Mcp_server.tool_call) =
   match call.name with
   | "list_projects" -> handle_list_projects control_client
   | "list_sessions" -> handle_list_sessions control_client
+  | "list_claude_sessions" ->
+    handle_list_claude_sessions control_client call.arguments
+  | "list_codex_sessions" ->
+    handle_list_codex_sessions control_client call.arguments
+  | "list_gemini_sessions" ->
+    handle_list_gemini_sessions control_client call.arguments
   | name -> unsupported_tool name

--- a/lib/mcp_handler.ml
+++ b/lib/mcp_handler.ml
@@ -22,6 +22,12 @@ let handle_list_sessions control_client =
     Control_api.List_sessions_id
     Mcp_formatter.format_list_sessions
 
+(* Wire-format note: Python's [control_request] drops falsy params, so a
+   no-argument call goes out with no "params" key at all, while we always
+   forward the arguments object — [{}] for the common no-argument case.
+   [Control_api.hours_param] maps absent, empty and non-integer alike to
+   the 24h default, so the two are equivalent; pinned by
+   test_control_api's hours_param cases. *)
 let handle_list_claude_sessions control_client params =
   request_and_format ~params control_client
     Control_api.List_claude_sessions_id

--- a/test/test_control_api.ml
+++ b/test/test_control_api.ml
@@ -270,8 +270,27 @@ let test_mutability_metadata_is_stable () =
       (expected_mutability id)
       (Control_api.method_spec_mutability spec))
 
+(* The OCaml MCP handler forwards an empty params object for a
+   no-argument recent-session call, where Python's control_request omits
+   "params" entirely. Both must land on the same 24h default, or the two
+   MCP implementations would disagree on the most common call there is. *)
+let test_hours_param_defaults () =
+  Alcotest.(check int) "absent params" 24 (Control_api.hours_param None);
+  Alcotest.(check int) "empty params" 24
+    (Control_api.hours_param (Some (`Assoc [])));
+  Alcotest.(check int) "explicit hours" 6
+    (Control_api.hours_param (Some (`Assoc [("hours", `Int 6)])));
+  Alcotest.(check int) "non-integer hours" 24
+    (Control_api.hours_param (Some (`Assoc [("hours", `String "6")])));
+  Alcotest.(check int) "non-object params" 24
+    (Control_api.hours_param (Some (`List [])))
+
 let () =
   Alcotest.run "control_api" [
+    ("params", [
+      Alcotest.test_case "hours_param defaults" `Quick
+        test_hours_param_defaults;
+    ]);
     ("metadata", [
       Alcotest.test_case "specs cover method ids" `Quick
         test_specs_cover_method_ids;

--- a/test/test_mcp_handler.ml
+++ b/test/test_mcp_handler.ml
@@ -72,6 +72,32 @@ let python_tool_output ?(arguments=`Assoc []) tool_name response =
   in
   read_process_output command
 
+(* True when the Python handler raises rather than returning text — the
+   oracle's behavior for inputs where it has no defined output, which we
+   answer with a field-specific error instead. *)
+let python_tool_call_fails ?(arguments=`Assoc []) tool_name response =
+  let script = repo_file "scripts/mcp-server.py" in
+  let program =
+    "import json, runpy, sys; "
+    ^ "ns = runpy.run_path(sys.argv[1]); "
+    ^ "response = json.loads(sys.argv[2]); "
+    ^ "arguments = json.loads(sys.argv[4]); "
+    ^ "ns['handle_tool_call'].__globals__['control_request'] = "
+    ^ "lambda method, params=None, timeout=60: response; "
+    ^ "sys.stdout.write(ns['handle_tool_call'](sys.argv[3], arguments))"
+  in
+  let command =
+    Printf.sprintf "python3 -c %s %s %s %s %s 2>/dev/null"
+      (Filename.quote program)
+      (Filename.quote script)
+      (Filename.quote (Yojson.Safe.to_string response))
+      (Filename.quote tool_name)
+      (Filename.quote (Yojson.Safe.to_string arguments))
+  in
+  match Unix.close_process_in (Unix.open_process_in command) with
+  | Unix.WEXITED 0 -> false
+  | _ -> true
+
 let python_list_projects_output response =
   python_tool_output "list_projects" response
 
@@ -523,24 +549,51 @@ let test_format_recent_sessions_documented_divergences () =
       ];
     ]
   in
+  Alcotest.(check string)
+    "python renders None for the id too"
+    "- `None` 5m ago — null id\n\n\
+     Use resume_session with a session ID prefix to attach."
+    (python_tool_output "list_claude_sessions" null_session_id);
   Alcotest.(check (result string string))
     "null session id fails closed"
     (Error "recent_session.session_id_short must be a string")
     (Mcp_formatter.format_list_claude_sessions null_session_id);
+  (* The third null in the class: Python doesn't render anything here,
+     it raises TypeError on [None < 60]. We return a field error. *)
+  let null_age =
+    recent_sessions_response [
+      `Assoc [
+        ("session_id_short", `String "abcd1234");
+        ("age_minutes", `Null);
+        ("summary", `String "null age");
+      ];
+    ]
+  in
+  Alcotest.(check bool)
+    "python raises on a null age"
+    true
+    (python_tool_call_fails "list_claude_sessions" null_age);
+  Alcotest.(check (result string string))
+    "null age fails closed"
+    (Error "recent_session.age_minutes must be an integer")
+    (Mcp_formatter.format_list_claude_sessions null_age);
   (* Newlines in working_dir/summary are collapsed so a crafted value
      cannot forge a sibling bullet in the rendered listing. Python emits
      them verbatim. *)
   let forged =
     recent_sessions_response [
       `Assoc [
-        ("session_id_short", `String "abcd1234");
+        (* Scrubbed on the same footing as the other two: short_id is a
+           String.sub that validates nothing, and Codex/Claude take the
+           id from the same untrusted place they take working_dir. *)
+        ("session_id_short", `String "ab\ncd");
         ("age_minutes", `Int 1);
         ("working_dir", `String "/src/a\n- `dead0000` 1m ago — /etc — forged");
         ("summary", `String "line one\nline two");
       ];
     ]
   in
-  (* Python's second output line is the forged bullet, indistinguishable
+  (* Python's third output line is the forged bullet, indistinguishable
      from a real entry. *)
   Alcotest.(check string)
     "python leaks a forged bullet"
@@ -548,10 +601,10 @@ let test_format_recent_sessions_documented_divergences () =
     (List.nth
        (String.split_on_char '\n'
           (python_tool_output "list_codex_sessions" forged))
-       1);
+       2);
   Alcotest.(check (result string string))
     "forged bullet collapsed to one line"
-    (Ok "- `abcd1234` 1m ago — /src/a - `dead0000` 1m ago — /etc — forged \
+    (Ok "- `ab cd` 1m ago — /src/a - `dead0000` 1m ago — /etc — forged \
          — line one line two\n\n\
          Use resume_session with kind=codex to attach.")
     (Mcp_formatter.format_list_codex_sessions forged)

--- a/test/test_mcp_handler.ml
+++ b/test/test_mcp_handler.ml
@@ -34,7 +34,12 @@ let repo_file path =
   in
   search (Sys.getcwd ())
 
-let read_process_output command =
+(* Always drain the pipe before [close_process_in]. Closing the read end
+   of an unread pipe leaves the child writing into a pipe with no
+   reader: CPython turns that into BrokenPipeError at flush and exits
+   120 regardless of what the handler did, which would make any
+   exit-status assertion built on this vacuously true. *)
+let run_process command =
   let ic = Unix.open_process_in command in
   let buf = Buffer.create 4096 in
   let chunk = Bytes.create 4096 in
@@ -45,58 +50,61 @@ let read_process_output command =
        | n -> Buffer.add_subbytes buf chunk 0 n
      done
    with End_of_file -> ());
-  match Unix.close_process_in ic with
-  | Unix.WEXITED 0 -> Buffer.contents buf
-  | Unix.WEXITED n -> failf "command exited %d: %s" n command
-  | Unix.WSIGNALED n -> failf "command signaled %d: %s" n command
-  | Unix.WSTOPPED n -> failf "command stopped %d: %s" n command
+  (Unix.close_process_in ic, Buffer.contents buf)
+
+let read_process_output command =
+  match run_process command with
+  | Unix.WEXITED 0, output -> output
+  | Unix.WEXITED n, output ->
+    failf "command exited %d: %s\n%s" n command output
+  | Unix.WSIGNALED n, _ -> failf "command signaled %d: %s" n command
+  | Unix.WSTOPPED n, _ -> failf "command stopped %d: %s" n command
+
+(* Run the Python MCP handler against a canned control-API response.
+   [merge_stderr] keeps the traceback for callers asserting on failure;
+   parity callers leave it off so a traceback can't be mistaken for
+   handler output. *)
+let python_tool_command ?(arguments=`Assoc []) ?(merge_stderr=false)
+    tool_name response =
+  let script = repo_file "scripts/mcp-server.py" in
+  let program =
+    "import json, runpy, sys; "
+    ^ "ns = runpy.run_path(sys.argv[1]); "
+    ^ "response = json.loads(sys.argv[2]); "
+    ^ "arguments = json.loads(sys.argv[4]); "
+    ^ "ns['handle_tool_call'].__globals__['control_request'] = "
+    ^ "lambda method, params=None, timeout=60: response; "
+    ^ "sys.stdout.write(ns['handle_tool_call'](sys.argv[3], arguments))"
+  in
+  Printf.sprintf "python3 -c %s %s %s %s %s%s"
+    (Filename.quote program)
+    (Filename.quote script)
+    (Filename.quote (Yojson.Safe.to_string response))
+    (Filename.quote tool_name)
+    (Filename.quote (Yojson.Safe.to_string arguments))
+    (if merge_stderr then " 2>&1" else "")
 
 let python_tool_output ?(arguments=`Assoc []) tool_name response =
-  let script = repo_file "scripts/mcp-server.py" in
-  let program =
-    "import json, runpy, sys; "
-    ^ "ns = runpy.run_path(sys.argv[1]); "
-    ^ "response = json.loads(sys.argv[2]); "
-    ^ "arguments = json.loads(sys.argv[4]); "
-    ^ "ns['handle_tool_call'].__globals__['control_request'] = "
-    ^ "lambda method, params=None, timeout=60: response; "
-    ^ "sys.stdout.write(ns['handle_tool_call'](sys.argv[3], arguments))"
-  in
-  let command =
-    Printf.sprintf "python3 -c %s %s %s %s %s"
-      (Filename.quote program)
-      (Filename.quote script)
-      (Filename.quote (Yojson.Safe.to_string response))
-      (Filename.quote tool_name)
-      (Filename.quote (Yojson.Safe.to_string arguments))
-  in
-  read_process_output command
+  read_process_output (python_tool_command ~arguments tool_name response)
 
-(* True when the Python handler raises rather than returning text — the
-   oracle's behavior for inputs where it has no defined output, which we
-   answer with a field-specific error instead. *)
-let python_tool_call_fails ?(arguments=`Assoc []) tool_name response =
-  let script = repo_file "scripts/mcp-server.py" in
-  let program =
-    "import json, runpy, sys; "
-    ^ "ns = runpy.run_path(sys.argv[1]); "
-    ^ "response = json.loads(sys.argv[2]); "
-    ^ "arguments = json.loads(sys.argv[4]); "
-    ^ "ns['handle_tool_call'].__globals__['control_request'] = "
-    ^ "lambda method, params=None, timeout=60: response; "
-    ^ "sys.stdout.write(ns['handle_tool_call'](sys.argv[3], arguments))"
-  in
-  let command =
-    Printf.sprintf "python3 -c %s %s %s %s %s 2>/dev/null"
-      (Filename.quote program)
-      (Filename.quote script)
-      (Filename.quote (Yojson.Safe.to_string response))
-      (Filename.quote tool_name)
-      (Filename.quote (Yojson.Safe.to_string arguments))
-  in
-  match Unix.close_process_in (Unix.open_process_in command) with
-  | Unix.WEXITED 0 -> false
-  | _ -> true
+(* [Some traceback] when the Python handler raises instead of returning
+   text — the oracle's behavior for inputs where it has no defined
+   output, which we answer with a field-specific error instead.
+   [None] when it exits cleanly. *)
+let python_tool_call_failure ?(arguments=`Assoc []) tool_name response =
+  match
+    run_process
+      (python_tool_command ~arguments ~merge_stderr:true tool_name response)
+  with
+  | Unix.WEXITED 0, _ -> None
+  | _, output -> Some output
+
+let contains_substring haystack needle =
+  let n = String.length needle and h = String.length haystack in
+  n = 0 ||
+  (let rec loop i = i + n <= h && (String.sub haystack i n = needle
+                                   || loop (i + 1)) in
+   loop 0)
 
 let python_list_projects_output response =
   python_tool_output "list_projects" response
@@ -569,10 +577,24 @@ let test_format_recent_sessions_documented_divergences () =
       ];
     ]
   in
+  (* Guard against a vacuous oracle check: the same probe must report a
+     clean exit for a response Python handles, or "python raises here"
+     below would hold for every input and pin nothing. *)
   Alcotest.(check bool)
-    "python raises on a null age"
+    "probe reports success for a well-formed response"
     true
-    (python_tool_call_fails "list_claude_sessions" null_age);
+    (Option.is_none
+       (python_tool_call_failure "list_claude_sessions"
+          (recent_sessions_response [
+            recent_session ~age_minutes:5 ~summary:"fine" "abcd1234";
+          ])));
+  (match python_tool_call_failure "list_claude_sessions" null_age with
+   | None -> failf "expected the Python handler to raise on a null age"
+   | Some traceback ->
+     Alcotest.(check bool)
+       "python raises TypeError on a null age"
+       true
+       (contains_substring traceback "TypeError"));
   Alcotest.(check (result string string))
     "null age fails closed"
     (Error "recent_session.age_minutes must be an integer")

--- a/test/test_mcp_handler.ml
+++ b/test/test_mcp_handler.ml
@@ -51,22 +51,24 @@ let read_process_output command =
   | Unix.WSIGNALED n -> failf "command signaled %d: %s" n command
   | Unix.WSTOPPED n -> failf "command stopped %d: %s" n command
 
-let python_tool_output tool_name response =
+let python_tool_output ?(arguments=`Assoc []) tool_name response =
   let script = repo_file "scripts/mcp-server.py" in
   let program =
     "import json, runpy, sys; "
     ^ "ns = runpy.run_path(sys.argv[1]); "
     ^ "response = json.loads(sys.argv[2]); "
+    ^ "arguments = json.loads(sys.argv[4]); "
     ^ "ns['handle_tool_call'].__globals__['control_request'] = "
     ^ "lambda method, params=None, timeout=60: response; "
-    ^ "sys.stdout.write(ns['handle_tool_call'](sys.argv[3], {}))"
+    ^ "sys.stdout.write(ns['handle_tool_call'](sys.argv[3], arguments))"
   in
   let command =
-    Printf.sprintf "python3 -c %s %s %s %s"
+    Printf.sprintf "python3 -c %s %s %s %s %s"
       (Filename.quote program)
       (Filename.quote script)
       (Filename.quote (Yojson.Safe.to_string response))
       (Filename.quote tool_name)
+      (Filename.quote (Yojson.Safe.to_string arguments))
   in
   read_process_output command
 
@@ -107,6 +109,27 @@ let list_sessions_response sessions =
     ("sessions", `List sessions);
   ]
 
+let recent_session ?(session_id="session-1") ?working_dir
+    ?(summary="recent work") ?(age_minutes=17) session_id_short =
+  let fields = [
+    ("session_id", `String session_id);
+    ("session_id_short", `String session_id_short);
+    ("summary", `String summary);
+    ("age_minutes", `Int age_minutes);
+  ] in
+  let fields =
+    match working_dir with
+    | None -> fields
+    | Some working_dir -> ("working_dir", `String working_dir) :: fields
+  in
+  `Assoc (List.rev fields)
+
+let recent_sessions_response sessions =
+  `Assoc [
+    ("ok", `Bool true);
+    ("sessions", `List sessions);
+  ]
+
 let check_list_projects_parity label response =
   let expected = python_list_projects_output response in
   let actual =
@@ -120,6 +143,15 @@ let check_list_sessions_parity label response =
   let expected = python_list_sessions_output response in
   let actual =
     match Mcp_formatter.format_list_sessions response with
+    | Ok text -> text
+    | Error message -> failf "%s: formatter error: %s" label message
+  in
+  Alcotest.(check string) label expected actual
+
+let check_recent_sessions_parity label tool_name formatter response =
+  let expected = python_tool_output tool_name response in
+  let actual =
+    match formatter response with
     | Ok text -> text
     | Error message -> failf "%s: formatter error: %s" label message
   in
@@ -292,6 +324,138 @@ let test_format_list_sessions_malformed_response () =
       ];
     ])])
 
+let test_format_recent_sessions_matches_python () =
+  check_recent_sessions_parity "claude empty"
+    "list_claude_sessions"
+    Mcp_formatter.format_list_claude_sessions
+    (recent_sessions_response []);
+  check_recent_sessions_parity "claude sessions"
+    "list_claude_sessions"
+    Mcp_formatter.format_list_claude_sessions
+    (recent_sessions_response [
+      recent_session ~age_minutes:12 ~summary:"fixed tests" "abcd1234";
+      recent_session ~age_minutes:125 ~summary:"wrote plan" "efgh5678";
+    ]);
+  check_recent_sessions_parity "claude missing summary"
+    "list_claude_sessions"
+    Mcp_formatter.format_list_claude_sessions
+    (recent_sessions_response [
+      `Assoc [
+        ("session_id_short", `String "abcd1234");
+        ("age_minutes", `Int 3);
+      ];
+    ]);
+  check_recent_sessions_parity "codex sessions"
+    "list_codex_sessions"
+    Mcp_formatter.format_list_codex_sessions
+    (recent_sessions_response [
+      recent_session ~working_dir:"/src/alpha"
+        ~age_minutes:59 ~summary:"ported tool" "abcd1234";
+      recent_session ~working_dir:"/src/beta"
+        ~age_minutes:60 ~summary:"reviewed output" "efgh5678";
+    ]);
+  check_recent_sessions_parity "codex unknown project"
+    "list_codex_sessions"
+    Mcp_formatter.format_list_codex_sessions
+    (recent_sessions_response [
+      recent_session ~working_dir:"" ~age_minutes:1 "abcd1234";
+      `Assoc [
+        ("session_id_short", `String "efgh5678");
+        ("age_minutes", `Int 2);
+        ("summary", `String "missing wd");
+      ];
+    ]);
+  check_recent_sessions_parity "gemini sessions"
+    "list_gemini_sessions"
+    Mcp_formatter.format_list_gemini_sessions
+    (recent_sessions_response [
+      recent_session ~working_dir:"/src/gamma"
+        ~age_minutes:240 ~summary:"added MCP support" "abcd1234";
+    ]);
+  check_recent_sessions_parity "null sessions"
+    "list_gemini_sessions"
+    Mcp_formatter.format_list_gemini_sessions
+    (`Assoc [("ok", `Bool true); ("sessions", `Null)]);
+  check_recent_sessions_parity "missing sessions"
+    "list_codex_sessions"
+    Mcp_formatter.format_list_codex_sessions
+    (`Assoc [("ok", `Bool true)])
+
+let test_format_recent_sessions_control_error () =
+  Alcotest.(check (result string string))
+    "control error"
+    (Error "Bot is not running.")
+    (Mcp_formatter.format_list_claude_sessions
+       (`Assoc [("error", `String "Bot is not running.")]))
+
+let test_format_recent_sessions_malformed_response () =
+  let check label expected formatter response =
+    Alcotest.(check (result string string))
+      label
+      expected
+      (formatter response)
+  in
+  check "response object"
+    (Error "Control API response must be an object")
+    Mcp_formatter.format_list_claude_sessions
+    `Null;
+  check "error string"
+    (Error "Control API error field must be a string")
+    Mcp_formatter.format_list_claude_sessions
+    (`Assoc [("error", `Bool true)]);
+  check "sessions array"
+    (Error "Control API sessions field must be an array")
+    Mcp_formatter.format_list_claude_sessions
+    (`Assoc [("sessions", `String "bad")]);
+  check "session object"
+    (Error "recent_session entry must be an object")
+    Mcp_formatter.format_list_claude_sessions
+    (`Assoc [("sessions", `List [`String "bad"])]);
+  check "session id short"
+    (Error "recent_session.session_id_short must be a string")
+    Mcp_formatter.format_list_claude_sessions
+    (`Assoc [("sessions", `List [
+      `Assoc [
+        ("session_id_short", `Bool true);
+      ];
+    ])]);
+  check "age minutes"
+    (Error "recent_session.age_minutes must be an integer")
+    Mcp_formatter.format_list_claude_sessions
+    (`Assoc [("sessions", `List [
+      `Assoc [
+        ("session_id_short", `String "abcd1234");
+        ("age_minutes", `String "1");
+      ];
+    ])]);
+  check "invalid age literal"
+    (Error "recent_session.age_minutes must be an in-range integer")
+    Mcp_formatter.format_list_claude_sessions
+    (`Assoc [("sessions", `List [
+      `Assoc [
+        ("session_id_short", `String "abcd1234");
+        ("age_minutes", `Intlit "999999999999999999999999999999");
+      ];
+    ])]);
+  check "summary"
+    (Error "recent_session.summary must be a string")
+    Mcp_formatter.format_list_claude_sessions
+    (`Assoc [("sessions", `List [
+      `Assoc [
+        ("session_id_short", `String "abcd1234");
+        ("summary", `Bool true);
+      ];
+    ])]);
+  check "working dir"
+    (Error "recent_session.working_dir must be a string")
+    Mcp_formatter.format_list_codex_sessions
+    (`Assoc [("sessions", `List [
+      `Assoc [
+        ("session_id_short", `String "abcd1234");
+        ("working_dir", `Bool true);
+      ];
+    ])])
+
 let test_handler_list_projects_requests_control_api () =
   let calls = ref [] in
   let response =
@@ -340,6 +504,54 @@ let test_handler_list_sessions_requests_control_api () =
     Alcotest.(check bool) "params omitted" true
       (Option.is_none request.params)
   | calls -> failf "expected one control request, got %d" (List.length calls)
+
+let check_recent_handler_requests_control_api
+    ~tool_name ~method_name ~response ~expected_output =
+  let calls = ref [] in
+  let arguments = `Assoc [("hours", `Int 6)] in
+  let control_client =
+    Control_client.make ~request:(fun request ->
+      calls := request :: !calls;
+      Ok response)
+  in
+  let call = { Mcp_server.name = tool_name; arguments } in
+  Alcotest.(check (result string string))
+    "handler output"
+    (Ok expected_output)
+    (Mcp_handler.handle_tool_call ~control_client call);
+  match !calls with
+  | [request] ->
+    Alcotest.(check string) "method" method_name request.method_name;
+    Alcotest.(check int) "timeout" 60 request.timeout_s;
+    (match request.params with
+     | Some params -> check_json "params" arguments params
+     | None -> failf "expected params")
+  | calls -> failf "expected one control request, got %d" (List.length calls)
+
+let test_handler_recent_sessions_request_control_api () =
+  check_recent_handler_requests_control_api
+    ~tool_name:"list_claude_sessions"
+    ~method_name:"list_claude_sessions"
+    ~response:(recent_sessions_response [
+      recent_session ~age_minutes:61 ~summary:"tracked bug" "abcd1234";
+    ])
+    ~expected_output:"- `abcd1234` 1h ago — tracked bug\n\nUse resume_session with a session ID prefix to attach.";
+  check_recent_handler_requests_control_api
+    ~tool_name:"list_codex_sessions"
+    ~method_name:"list_codex_sessions"
+    ~response:(recent_sessions_response [
+      recent_session ~working_dir:"/src/repo"
+        ~age_minutes:4 ~summary:"fixed test" "abcd1234";
+    ])
+    ~expected_output:"- `abcd1234` 4m ago — /src/repo — fixed test\n\nUse resume_session with kind=codex to attach.";
+  check_recent_handler_requests_control_api
+    ~tool_name:"list_gemini_sessions"
+    ~method_name:"list_gemini_sessions"
+    ~response:(recent_sessions_response [
+      recent_session ~working_dir:"/src/repo"
+        ~age_minutes:120 ~summary:"checked stack" "abcd1234";
+    ])
+    ~expected_output:"- `abcd1234` 2h ago — /src/repo — checked stack\n\nUse resume_session with kind=gemini to attach."
 
 let test_handler_unsupported_tool () =
   let control_client =
@@ -442,6 +654,41 @@ let test_server_wraps_list_sessions_result () =
             ("type", `String "text");
             ("text",
              `String "- **alpha** / claude — 7 messages (thread: <#987>)");
+          ];
+        ]);
+      ]);
+    ])
+  in
+  match actual, expected with
+  | Some actual, Some expected -> check_json "MCP response" expected actual
+  | _ -> failf "expected MCP response"
+
+let test_server_wraps_recent_sessions_result () =
+  let control_client =
+    Control_client.make ~request:(fun _request ->
+      Ok (recent_sessions_response [
+        recent_session ~working_dir:"/src/alpha"
+          ~age_minutes:7 ~summary:"ported recent sessions" "abcd1234";
+      ]))
+  in
+  let line =
+    {|{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"list_codex_sessions","arguments":{"hours":2}}}|}
+  in
+  let actual =
+    Mcp_server.handle_line
+      ~handle_tool_call:(Mcp_handler.handle_tool_call ~control_client)
+      line
+  in
+  let expected =
+    Some (`Assoc [
+      ("jsonrpc", `String "2.0");
+      ("id", `Int 11);
+      ("result", `Assoc [
+        ("content", `List [
+          `Assoc [
+            ("type", `String "text");
+            ("text",
+             `String "- `abcd1234` 7m ago — /src/alpha — ported recent sessions\n\nUse resume_session with kind=codex to attach.");
           ];
         ]);
       ]);
@@ -589,12 +836,20 @@ let () =
         test_format_list_sessions_control_error;
       Alcotest.test_case "list_sessions malformed response" `Quick
         test_format_list_sessions_malformed_response;
+      Alcotest.test_case "recent sessions match Python" `Quick
+        test_format_recent_sessions_matches_python;
+      Alcotest.test_case "recent sessions control error" `Quick
+        test_format_recent_sessions_control_error;
+      Alcotest.test_case "recent sessions malformed response" `Quick
+        test_format_recent_sessions_malformed_response;
     ]);
     ("handler", [
       Alcotest.test_case "list_projects requests control API" `Quick
         test_handler_list_projects_requests_control_api;
       Alcotest.test_case "list_sessions requests control API" `Quick
         test_handler_list_sessions_requests_control_api;
+      Alcotest.test_case "recent sessions request control API" `Quick
+        test_handler_recent_sessions_request_control_api;
       Alcotest.test_case "unsupported tool" `Quick
         test_handler_unsupported_tool;
       Alcotest.test_case "server wraps list_projects result" `Quick
@@ -603,6 +858,8 @@ let () =
         test_server_wraps_list_projects_control_error;
       Alcotest.test_case "server wraps list_sessions result" `Quick
         test_server_wraps_list_sessions_result;
+      Alcotest.test_case "server wraps recent sessions result" `Quick
+        test_server_wraps_recent_sessions_result;
     ]);
     ("control client", [
       Alcotest.test_case "unix roundtrip" `Quick

--- a/test/test_mcp_handler.ml
+++ b/test/test_mcp_handler.ml
@@ -365,6 +365,41 @@ let test_format_recent_sessions_matches_python () =
         ("summary", `String "missing wd");
       ];
     ]);
+  (* age_minutes absent: both sides default to 0 and render "0m ago". *)
+  check_recent_sessions_parity "claude missing age"
+    "list_claude_sessions"
+    Mcp_formatter.format_list_claude_sessions
+    (recent_sessions_response [
+      `Assoc [
+        ("session_id_short", `String "abcd1234");
+        ("summary", `String "no age field");
+      ];
+    ]);
+  (* working_dir null: Python's [or] falls back, so do we. *)
+  check_recent_sessions_parity "codex null working dir"
+    "list_codex_sessions"
+    Mcp_formatter.format_list_codex_sessions
+    (recent_sessions_response [
+      `Assoc [
+        ("session_id_short", `String "abcd1234");
+        ("age_minutes", `Int 7);
+        ("working_dir", `Null);
+        ("summary", `String "null wd");
+      ];
+    ]);
+  (* Claude's listing ignores working_dir entirely, so a malformed one
+     must not fail the listing the way it does for Codex/Gemini. *)
+  check_recent_sessions_parity "claude ignores working dir"
+    "list_claude_sessions"
+    Mcp_formatter.format_list_claude_sessions
+    (recent_sessions_response [
+      `Assoc [
+        ("session_id_short", `String "abcd1234");
+        ("age_minutes", `Int 8);
+        ("working_dir", `Bool true);
+        ("summary", `String "unrendered wd");
+      ];
+    ]);
   check_recent_sessions_parity "gemini sessions"
     "list_gemini_sessions"
     Mcp_formatter.format_list_gemini_sessions
@@ -455,6 +490,71 @@ let test_format_recent_sessions_malformed_response () =
         ("working_dir", `Bool true);
       ];
     ])])
+
+(* Two places where we deliberately do not match Python. Both assert the
+   Python side too, so the divergence stays visible if the oracle ever
+   changes underneath us. *)
+let test_format_recent_sessions_documented_divergences () =
+  let null_summary =
+    recent_sessions_response [
+      `Assoc [
+        ("session_id_short", `String "abcd1234");
+        ("age_minutes", `Int 5);
+        ("summary", `Null);
+      ];
+    ]
+  in
+  (* Python interpolates the literal "None" for a null summary. *)
+  Alcotest.(check string)
+    "python renders None"
+    "- `abcd1234` 5m ago — None\n\n\
+     Use resume_session with a session ID prefix to attach."
+    (python_tool_output "list_claude_sessions" null_summary);
+  Alcotest.(check (result string string))
+    "null summary fails closed"
+    (Error "recent_session.summary must be a string")
+    (Mcp_formatter.format_list_claude_sessions null_summary);
+  let null_session_id =
+    recent_sessions_response [
+      `Assoc [
+        ("session_id_short", `Null);
+        ("age_minutes", `Int 5);
+        ("summary", `String "null id");
+      ];
+    ]
+  in
+  Alcotest.(check (result string string))
+    "null session id fails closed"
+    (Error "recent_session.session_id_short must be a string")
+    (Mcp_formatter.format_list_claude_sessions null_session_id);
+  (* Newlines in working_dir/summary are collapsed so a crafted value
+     cannot forge a sibling bullet in the rendered listing. Python emits
+     them verbatim. *)
+  let forged =
+    recent_sessions_response [
+      `Assoc [
+        ("session_id_short", `String "abcd1234");
+        ("age_minutes", `Int 1);
+        ("working_dir", `String "/src/a\n- `dead0000` 1m ago — /etc — forged");
+        ("summary", `String "line one\nline two");
+      ];
+    ]
+  in
+  (* Python's second output line is the forged bullet, indistinguishable
+     from a real entry. *)
+  Alcotest.(check string)
+    "python leaks a forged bullet"
+    "- `dead0000` 1m ago — /etc — forged — line one"
+    (List.nth
+       (String.split_on_char '\n'
+          (python_tool_output "list_codex_sessions" forged))
+       1);
+  Alcotest.(check (result string string))
+    "forged bullet collapsed to one line"
+    (Ok "- `abcd1234` 1m ago — /src/a - `dead0000` 1m ago — /etc — forged \
+         — line one line two\n\n\
+         Use resume_session with kind=codex to attach.")
+    (Mcp_formatter.format_list_codex_sessions forged)
 
 let test_handler_list_projects_requests_control_api () =
   let calls = ref [] in
@@ -552,6 +652,33 @@ let test_handler_recent_sessions_request_control_api () =
         ~age_minutes:120 ~summary:"checked stack" "abcd1234";
     ])
     ~expected_output:"- `abcd1234` 2h ago — /src/repo — checked stack\n\nUse resume_session with kind=gemini to attach."
+
+(* The no-argument call is the common case, and the one place our wire
+   format differs from Python's: we forward an empty params object where
+   [control_request] omits "params" entirely. [Control_api.hours_param]
+   collapses both to the 24h default (pinned in test_control_api). *)
+let test_handler_recent_sessions_empty_arguments () =
+  let calls = ref [] in
+  let control_client =
+    Control_client.make ~request:(fun request ->
+      calls := request :: !calls;
+      Ok (recent_sessions_response []))
+  in
+  let call =
+    { Mcp_server.name = "list_codex_sessions"; arguments = `Assoc [] }
+  in
+  Alcotest.(check (result string string))
+    "handler output"
+    (Ok "No recent Codex sessions found.")
+    (Mcp_handler.handle_tool_call ~control_client call);
+  match !calls with
+  | [request] ->
+    Alcotest.(check string) "method"
+      "list_codex_sessions" request.method_name;
+    (match request.params with
+     | Some params -> check_json "params" (`Assoc []) params
+     | None -> failf "expected params")
+  | calls -> failf "expected one control request, got %d" (List.length calls)
 
 let test_handler_unsupported_tool () =
   let control_client =
@@ -842,6 +969,8 @@ let () =
         test_format_recent_sessions_control_error;
       Alcotest.test_case "recent sessions malformed response" `Quick
         test_format_recent_sessions_malformed_response;
+      Alcotest.test_case "recent sessions documented divergences" `Quick
+        test_format_recent_sessions_documented_divergences;
     ]);
     ("handler", [
       Alcotest.test_case "list_projects requests control API" `Quick
@@ -850,6 +979,8 @@ let () =
         test_handler_list_sessions_requests_control_api;
       Alcotest.test_case "recent sessions request control API" `Quick
         test_handler_recent_sessions_request_control_api;
+      Alcotest.test_case "recent sessions empty arguments" `Quick
+        test_handler_recent_sessions_empty_arguments;
       Alcotest.test_case "unsupported tool" `Quick
         test_handler_unsupported_tool;
       Alcotest.test_case "server wraps list_projects result" `Quick


### PR DESCRIPTION
## Summary
- wire list_claude_sessions, list_codex_sessions, and list_gemini_sessions through the OCaml MCP handler
- add typed recent-session formatting with Python parity coverage
- prove arguments are forwarded to the Control API and MCP response wrapping still works

## Tests
- nix develop --command dune exec ./test/test_mcp_handler.exe
- nix develop --command dune runtest
- nix build
- git diff --check

Stack: 1/5 for the MCP Python-to-OCaml port.