### PR TITLE
Port session lifecycle MCP tools to OCaml

### DIFF
--- a/lib/mcp_formatter.ml
+++ b/lib/mcp_formatter.ml
@@ -86,17 +86,9 @@ let format_lines ?(null_list_is_empty=false) ?footer
     in
     loop 0 [] items
 
-let format_response ?(null_list_is_empty=false) ?footer
-    ~field_name ~empty_message ~line_of_item = function
-  | `Assoc fields ->
-    (match field "error" fields with
-     | Some (`String message) -> Error message
-     | Some _ -> Error "Control API error field must be a string"
-     | None ->
-       format_lines ~null_list_is_empty
-         ?footer ~field_name ~empty_message ~line_of_item fields)
-  | _ -> Error "Control API response must be an object"
-
+(* Every tool result comes through here: an [error] string short-circuits
+   to Error (Python returns [result["error"]] the same way), anything
+   else is handed to the tool's own renderer. *)
 let format_object ~format_fields = function
   | `Assoc fields ->
     (match field "error" fields with
@@ -104,6 +96,13 @@ let format_object ~format_fields = function
      | Some _ -> Error "Control API error field must be a string"
      | None -> format_fields fields)
   | _ -> Error "Control API response must be an object"
+
+let format_response ?(null_list_is_empty=false) ?footer
+    ~field_name ~empty_message ~line_of_item response =
+  format_object response
+    ~format_fields:(fun fields ->
+      format_lines ~null_list_is_empty
+        ?footer ~field_name ~empty_message ~line_of_item fields)
 
 let project_line index = function
   | `Assoc fields ->
@@ -267,14 +266,28 @@ let format_list_gemini_sessions response =
     ~with_working_dir:true
     response
 
-let string_prefix max_length value =
-  if String.length value <= max_length then value
-  else String.sub value 0 max_length
-
+(* [Config.string_of_agent_kind] is the only real source of [agent_kind],
+   so ASCII case mapping is enough — but Python's [str.capitalize()] is
+   Unicode-aware, so a non-ASCII kind would diverge. The [lowercase]
+   pass is not redundant: it reproduces [capitalize()]'s down-casing of
+   the tail, which turns "CODEX" into "Codex", not "CODEX". *)
 let python_capitalize_ascii value =
   value
   |> String.lowercase_ascii
   |> String.capitalize_ascii
+
+(* The lifecycle tools render into Discord markdown like everything else
+   here, so they inherit [recent_session_line]'s rule: single-line every
+   control-API string before interpolating it. The provenance is the
+   same untrusted set — Control_api builds start_session's project_name
+   and working_dir from project config and worktree paths, resume_session
+   hands back the full on-disk session id, and stop_session's message
+   embeds a project name (lib/control_api.ml). A newline in any of them
+   puts the rest of the reply at column 0 in the calling agent's render,
+   where it reads as a separate statement about a session that doesn't
+   exist. Python scrubs none of this; deliberate divergence, pinned by
+   tests. *)
+let render_string value = Resource.single_line value
 
 let format_start_session response =
   let format_fields fields =
@@ -284,7 +297,8 @@ let format_start_session response =
     | Ok thread_id, Ok working_dir, Ok project_name ->
       Ok (Printf.sprintf
             "Started session for **%s** in <#%s>.\nWorking in: `%s`"
-            project_name thread_id working_dir)
+            (render_string project_name) (render_string thread_id)
+            (render_string working_dir))
     | Error message, _, _
     | _, Error message, _
     | _, _, Error message -> Error message
@@ -297,13 +311,23 @@ let format_resume_session response =
           string_field_default "" "resume_session" "session_id" fields,
           string_field_default "" "resume_session" "agent_kind" fields with
     | Ok thread_id, Ok session_id, Ok agent_kind ->
-      let sid_short = string_prefix 8 session_id in
+      let sid_short =
+        (* Python slices the decoded str, so its [:8] is 8 codepoints.
+           A byte-counting [String.sub] would cut a multibyte id in half
+           and emit a half-encoded character into the JSON-RPC response,
+           which a strict client fails to decode. [sanitize_utf8] covers
+           ids that were already invalid on disk — Codex reads the id
+           out of a rollout record, Claude from a filename. *)
+        Resource.utf8_prefix ~max_chars:8
+          (Resource.sanitize_utf8 (render_string session_id))
+      in
       let kind_label =
         if String.equal agent_kind "" then ""
-        else Printf.sprintf "%s " (python_capitalize_ascii agent_kind)
+        else Printf.sprintf "%s " (python_capitalize_ascii
+                                     (render_string agent_kind))
       in
       Ok (Printf.sprintf "Resumed %ssession `%s` in <#%s>."
-            kind_label sid_short thread_id)
+            kind_label sid_short (render_string thread_id))
     | Error message, _, _
     | _, Error message, _
     | _, _, Error message -> Error message
@@ -318,10 +342,10 @@ let format_send_message response =
     | Ok thread_id, Ok remaining_hops, Ok "posted_not_routed" ->
       Ok (Printf.sprintf
             "Posted message to <#%s>, but the target session disappeared before routing. remaining_hops=%d."
-            thread_id remaining_hops)
+            (render_string thread_id) remaining_hops)
     | Ok thread_id, Ok remaining_hops, Ok _ ->
       Ok (Printf.sprintf "Sent message to <#%s>. remaining_hops=%d."
-            thread_id remaining_hops)
+            (render_string thread_id) remaining_hops)
     | Error message, _, _
     | _, Error message, _
     | _, _, Error message -> Error message
@@ -330,6 +354,10 @@ let format_send_message response =
 
 let format_stop_session response =
   let format_fields fields =
-    string_field_default "Stop requested." "stop_session" "message" fields
+    match
+      string_field_default "Stop requested." "stop_session" "message" fields
+    with
+    | Ok message -> Ok (render_string message)
+    | Error _ as error -> error
   in
   format_object ~format_fields response

--- a/lib/mcp_formatter.ml
+++ b/lib/mcp_formatter.ml
@@ -97,6 +97,14 @@ let format_response ?(null_list_is_empty=false) ?footer
          ?footer ~field_name ~empty_message ~line_of_item fields)
   | _ -> Error "Control API response must be an object"
 
+let format_object ~format_fields = function
+  | `Assoc fields ->
+    (match field "error" fields with
+     | Some (`String message) -> Error message
+     | Some _ -> Error "Control API error field must be a string"
+     | None -> format_fields fields)
+  | _ -> Error "Control API response must be an object"
+
 let project_line index = function
   | `Assoc fields ->
     (match string_field "project" "name" fields,
@@ -258,3 +266,70 @@ let format_list_gemini_sessions response =
     ~footer:"Use resume_session with kind=gemini to attach."
     ~with_working_dir:true
     response
+
+let string_prefix max_length value =
+  if String.length value <= max_length then value
+  else String.sub value 0 max_length
+
+let python_capitalize_ascii value =
+  value
+  |> String.lowercase_ascii
+  |> String.capitalize_ascii
+
+let format_start_session response =
+  let format_fields fields =
+    match string_field_default "" "start_session" "thread_id" fields,
+          string_field_default "" "start_session" "working_dir" fields,
+          string_field_default "" "start_session" "project_name" fields with
+    | Ok thread_id, Ok working_dir, Ok project_name ->
+      Ok (Printf.sprintf
+            "Started session for **%s** in <#%s>.\nWorking in: `%s`"
+            project_name thread_id working_dir)
+    | Error message, _, _
+    | _, Error message, _
+    | _, _, Error message -> Error message
+  in
+  format_object ~format_fields response
+
+let format_resume_session response =
+  let format_fields fields =
+    match string_field_default "" "resume_session" "thread_id" fields,
+          string_field_default "" "resume_session" "session_id" fields,
+          string_field_default "" "resume_session" "agent_kind" fields with
+    | Ok thread_id, Ok session_id, Ok agent_kind ->
+      let sid_short = string_prefix 8 session_id in
+      let kind_label =
+        if String.equal agent_kind "" then ""
+        else Printf.sprintf "%s " (python_capitalize_ascii agent_kind)
+      in
+      Ok (Printf.sprintf "Resumed %ssession `%s` in <#%s>."
+            kind_label sid_short thread_id)
+    | Error message, _, _
+    | _, Error message, _
+    | _, _, Error message -> Error message
+  in
+  format_object ~format_fields response
+
+let format_send_message response =
+  let format_fields fields =
+    match string_field_default "" "send_message" "thread_id" fields,
+          int_field_default 0 "send_message" "remaining_hops" fields,
+          string_field_default "sent" "send_message" "state" fields with
+    | Ok thread_id, Ok remaining_hops, Ok "posted_not_routed" ->
+      Ok (Printf.sprintf
+            "Posted message to <#%s>, but the target session disappeared before routing. remaining_hops=%d."
+            thread_id remaining_hops)
+    | Ok thread_id, Ok remaining_hops, Ok _ ->
+      Ok (Printf.sprintf "Sent message to <#%s>. remaining_hops=%d."
+            thread_id remaining_hops)
+    | Error message, _, _
+    | _, Error message, _
+    | _, _, Error message -> Error message
+  in
+  format_object ~format_fields response
+
+let format_stop_session response =
+  let format_fields fields =
+    string_field_default "Stop requested." "stop_session" "message" fields
+  in
+  format_object ~format_fields response

--- a/lib/mcp_formatter.ml
+++ b/lib/mcp_formatter.ml
@@ -286,8 +286,15 @@ let python_capitalize_ascii value =
    puts the rest of the reply at column 0 in the calling agent's render,
    where it reads as a separate statement about a session that doesn't
    exist. Python scrubs none of this; deliberate divergence, pinned by
-   tests. *)
-let render_string value = Resource.single_line value
+   tests.
+
+   [sanitize_utf8] for the same reason applied field-wide rather than to
+   the session id alone: working dirs are real filesystem paths and can
+   carry non-UTF-8 bytes, Yojson re-emits those verbatim, and the
+   decoder on the other side of the JSON-RPC boundary raises rather than
+   rendering. Identity on valid input, so parity is unaffected. *)
+let render_string value =
+  Resource.sanitize_utf8 (Resource.single_line value)
 
 let format_start_session response =
   let format_fields fields =
@@ -315,11 +322,11 @@ let format_resume_session response =
         (* Python slices the decoded str, so its [:8] is 8 codepoints.
            A byte-counting [String.sub] would cut a multibyte id in half
            and emit a half-encoded character into the JSON-RPC response,
-           which a strict client fails to decode. [sanitize_utf8] covers
-           ids that were already invalid on disk — Codex reads the id
-           out of a rollout record, Claude from a filename. *)
-        Resource.utf8_prefix ~max_chars:8
-          (Resource.sanitize_utf8 (render_string session_id))
+           which a strict client fails to decode. Ids arrive from a
+           rollout record (Codex) or a filename (Claude), so
+           [render_string]'s sanitize pass matters here even more than
+           elsewhere. *)
+        Resource.utf8_prefix ~max_chars:8 (render_string session_id)
       in
       let kind_label =
         if String.equal agent_kind "" then ""

--- a/lib/mcp_handler.ml
+++ b/lib/mcp_handler.ml
@@ -12,6 +12,27 @@ let request_and_format ?params control_client method_id formatter =
   | Error _ as error -> error
   | Ok response -> formatter response
 
+let string_contains text needle =
+  let text_length = String.length text in
+  let needle_length = String.length needle in
+  let rec loop index =
+    if needle_length = 0 then true
+    else if index + needle_length > text_length then false
+    else if String.equal (String.sub text index needle_length) needle then true
+    else loop (index + 1)
+  in
+  loop 0
+
+let response_error_contains fragment = function
+  | `Assoc fields ->
+    (match List.assoc_opt "error" fields with
+     | Some (`String message) ->
+       string_contains
+         (String.lowercase_ascii message)
+         (String.lowercase_ascii fragment)
+     | _ -> false)
+  | _ -> false
+
 let handle_list_projects control_client =
   request_and_format control_client
     Control_api.List_projects_id
@@ -43,14 +64,48 @@ let handle_list_gemini_sessions control_client params =
     Control_api.List_gemini_sessions_id
     Mcp_formatter.format_list_gemini_sessions
 
+let handle_start_session control_client params =
+  let request_start () =
+    Control_client.request_method ~params control_client
+      Control_api.Start_session_id
+  in
+  match request_start () with
+  | Error _ as error -> error
+  | Ok response when response_error_contains "no project matching" response ->
+    ignore (Control_client.request_method control_client
+              Control_api.Refresh_projects_id);
+    (match request_start () with
+     | Error _ as error -> error
+     | Ok response -> Mcp_formatter.format_start_session response)
+  | Ok response -> Mcp_formatter.format_start_session response
+
+let handle_resume_session control_client params =
+  request_and_format ~params control_client
+    Control_api.Resume_session_id
+    Mcp_formatter.format_resume_session
+
+let handle_send_message control_client params =
+  request_and_format ~params control_client
+    Control_api.Send_message_id
+    Mcp_formatter.format_send_message
+
+let handle_stop_session control_client params =
+  request_and_format ~params control_client
+    Control_api.Stop_session_id
+    Mcp_formatter.format_stop_session
+
 let handle_tool_call ~control_client (call : Mcp_server.tool_call) =
   match call.name with
+  | "start_session" -> handle_start_session control_client call.arguments
   | "list_projects" -> handle_list_projects control_client
   | "list_sessions" -> handle_list_sessions control_client
+  | "send_message" -> handle_send_message control_client call.arguments
+  | "stop_session" -> handle_stop_session control_client call.arguments
   | "list_claude_sessions" ->
     handle_list_claude_sessions control_client call.arguments
   | "list_codex_sessions" ->
     handle_list_codex_sessions control_client call.arguments
   | "list_gemini_sessions" ->
     handle_list_gemini_sessions control_client call.arguments
+  | "resume_session" -> handle_resume_session control_client call.arguments
   | name -> unsupported_tool name

--- a/lib/mcp_handler.ml
+++ b/lib/mcp_handler.ml
@@ -12,24 +12,16 @@ let request_and_format ?params control_client method_id formatter =
   | Error _ as error -> error
   | Ok response -> formatter response
 
-let string_contains text needle =
-  let text_length = String.length text in
-  let needle_length = String.length needle in
-  let rec loop index =
-    if needle_length = 0 then true
-    else if index + needle_length > text_length then false
-    else if String.equal (String.sub text index needle_length) needle then true
-    else loop (index + 1)
-  in
-  loop 0
-
+(* Python matches the retry trigger with [in] on a lowercased message
+   (scripts/mcp-server.py), so the comparison is case-insensitive on
+   both sides. *)
 let response_error_contains fragment = function
   | `Assoc fields ->
     (match List.assoc_opt "error" fields with
      | Some (`String message) ->
-       string_contains
-         (String.lowercase_ascii message)
-         (String.lowercase_ascii fragment)
+       Resource.contains_substring
+         ~haystack:(String.lowercase_ascii message)
+         ~needle:(String.lowercase_ascii fragment)
      | _ -> false)
   | _ -> false
 

--- a/lib/resource.ml
+++ b/lib/resource.ml
@@ -268,24 +268,37 @@ let contains_substring ~haystack ~needle =
     character would go straight into the JSON we serialize, where a
     strict decoder on the other side raises rather than renders.
 
-    A malformed lead or lone continuation byte counts as one character,
-    so the walk always advances and the result never exceeds
-    [max_chars] characters. Well-formed input never ends mid-sequence.
-    Use [truncate_utf8] instead when the budget is in bytes. *)
+    A lead byte's declared width is only trusted when the continuation
+    bytes are actually present; anything malformed — lone continuation,
+    truncated sequence, 0xF8..0xFF — advances a single byte and counts
+    as one character. So the walk always advances, the result is never
+    more than [max_chars] characters, and a valid sequence is never cut
+    in half. Use [truncate_utf8] instead when the budget is in bytes. *)
 let utf8_prefix ~max_chars s =
   let length = String.length s in
+  let is_continuation index =
+    index < length && Char.code s.[index] land 0xC0 = 0x80
+  in
   let rec loop pos chars =
     if chars >= max_chars || pos >= length then pos
     else
       let lead = Char.code s.[pos] in
-      let width =
+      let declared =
         if lead < 0x80 then 1
         else if lead < 0xC0 then 1   (* lone continuation byte *)
         else if lead < 0xE0 then 2
         else if lead < 0xF0 then 3
-        else 4
+        else if lead < 0xF8 then 4
+        else 1                       (* 0xF8..0xFF: never a lead *)
       in
-      loop (min length (pos + width)) (chars + 1)
+      let rec complete index =
+        index >= declared || (is_continuation (pos + index)
+                              && complete (index + 1))
+      in
+      (* Without this check "\xE2AB" would swallow two ASCII characters
+         into one, returning more characters than asked for. *)
+      let width = if declared = 1 || complete 1 then declared else 1 in
+      loop (pos + width) (chars + 1)
   in
   String.sub s 0 (loop 0 0)
 

--- a/lib/resource.ml
+++ b/lib/resource.ml
@@ -320,8 +320,14 @@ let utf8_sequence_length s index =
     character by itself — the same accounting [sanitize_utf8] uses when
     it swaps such a byte for U+FFFD. The walk therefore always
     advances, the result is never more than [max_chars] characters, and
-    a valid sequence is never cut in half. Use [truncate_utf8] instead
-    when the budget is in bytes. *)
+    a valid sequence is never cut in half.
+
+    The Python correspondence is exact for valid UTF-8 only. On invalid
+    input CPython's decoder replaces each maximal subpart, so it sees
+    one character in "\xE2\x82" where the per-byte accounting here sees
+    two; sanitize first (as the formatter does) and the question
+    doesn't arise. Use [truncate_utf8] instead when the budget is in
+    bytes. *)
 let utf8_prefix ~max_chars s =
   let length = String.length s in
   let rec loop pos chars =

--- a/lib/resource.ml
+++ b/lib/resource.ml
@@ -262,42 +262,76 @@ let contains_substring ~haystack ~needle =
   in
   loop 0
 
+(** Length in bytes of the UTF-8 sequence starting at [index] in [s],
+    or [None] if no valid sequence starts there.
+
+    Strict per RFC 3629: a lead byte's declared width counts only when
+    its continuation bytes are actually present, and overlong
+    encodings, surrogate halves and codepoints beyond U+10FFFF are
+    rejected — they are exactly what a strict JSON decoder refuses.
+    [None] means "this single byte is garbage"; callers advance by one
+    and decide what to do with it.
+
+    Shared by [sanitize_utf8] and [utf8_prefix] so the two can't drift
+    into disagreeing about what a character is. *)
+let utf8_sequence_length s index =
+  let n = String.length s in
+  let is_cont b = b land 0xC0 = 0x80 in
+  let c = Char.code s.[index] in
+  if c < 0x80 then Some 1
+  else if c < 0xC2 then None  (* lone continuation, or overlong lead *)
+  else if c < 0xE0 then begin
+    if index + 1 < n && is_cont (Char.code s.[index + 1]) then Some 2
+    else None
+  end else if c < 0xF0 then begin
+    if index + 2 < n
+    && is_cont (Char.code s.[index + 1])
+    && is_cont (Char.code s.[index + 2]) then begin
+      let cp = ((c land 0x0F) lsl 12)
+            lor ((Char.code s.[index + 1] land 0x3F) lsl 6)
+            lor (Char.code s.[index + 2] land 0x3F) in
+      if cp < 0x800 then None                        (* overlong *)
+      else if cp >= 0xD800 && cp <= 0xDFFF then None  (* surrogate *)
+      else Some 3
+    end else None
+  end else if c < 0xF5 then begin
+    if index + 3 < n
+    && is_cont (Char.code s.[index + 1])
+    && is_cont (Char.code s.[index + 2])
+    && is_cont (Char.code s.[index + 3]) then begin
+      let cp = ((c land 0x07) lsl 18)
+            lor ((Char.code s.[index + 1] land 0x3F) lsl 12)
+            lor ((Char.code s.[index + 2] land 0x3F) lsl 6)
+            lor (Char.code s.[index + 3] land 0x3F) in
+      if cp < 0x10000 then None            (* overlong *)
+      else if cp > 0x10FFFF then None      (* beyond Unicode *)
+      else Some 4
+    end else None
+  end else None  (* 0xF5..0xFF: not a valid lead byte *)
+
 (** First [max_chars] Unicode codepoints of [s] — what Python's [s[:n]]
     does to a decoded str, as opposed to [String.sub], which counts
     bytes and can cut a multibyte character in half. A half-encoded
     character would go straight into the JSON we serialize, where a
     strict decoder on the other side raises rather than renders.
 
-    A lead byte's declared width is only trusted when the continuation
-    bytes are actually present; anything malformed — lone continuation,
-    truncated sequence, 0xF8..0xFF — advances a single byte and counts
-    as one character. So the walk always advances, the result is never
-    more than [max_chars] characters, and a valid sequence is never cut
-    in half. Use [truncate_utf8] instead when the budget is in bytes. *)
+    Counting follows [utf8_sequence_length], so one valid sequence is
+    one character and every byte that isn't part of one counts as a
+    character by itself — the same accounting [sanitize_utf8] uses when
+    it swaps such a byte for U+FFFD. The walk therefore always
+    advances, the result is never more than [max_chars] characters, and
+    a valid sequence is never cut in half. Use [truncate_utf8] instead
+    when the budget is in bytes. *)
 let utf8_prefix ~max_chars s =
   let length = String.length s in
-  let is_continuation index =
-    index < length && Char.code s.[index] land 0xC0 = 0x80
-  in
   let rec loop pos chars =
     if chars >= max_chars || pos >= length then pos
     else
-      let lead = Char.code s.[pos] in
-      let declared =
-        if lead < 0x80 then 1
-        else if lead < 0xC0 then 1   (* lone continuation byte *)
-        else if lead < 0xE0 then 2
-        else if lead < 0xF0 then 3
-        else if lead < 0xF8 then 4
-        else 1                       (* 0xF8..0xFF: never a lead *)
+      let width =
+        match utf8_sequence_length s pos with
+        | Some width -> width
+        | None -> 1   (* garbage byte: advance one, count one *)
       in
-      let rec complete index =
-        index >= declared || (is_continuation (pos + index)
-                              && complete (index + 1))
-      in
-      (* Without this check "\xE2AB" would swallow two ASCII characters
-         into one, returning more characters than asked for. *)
-      let width = if declared = 1 || complete 1 then declared else 1 in
       loop (pos + width) (chars + 1)
   in
   String.sub s 0 (loop 0 0)
@@ -343,43 +377,9 @@ let sanitize_utf8 s =
   let n = String.length s in
   let buf = Buffer.create n in
   let replacement = "\xEF\xBF\xBD" in
-  let is_cont b = b land 0xC0 = 0x80 in
   let i = ref 0 in
   while !i < n do
-    let c = Char.code s.[!i] in
-    let valid_len =
-      if c < 0x80 then Some 1
-      else if c < 0xC2 then None  (* lone continuation, or overlong lead *)
-      else if c < 0xE0 then begin
-        if !i + 1 < n && is_cont (Char.code s.[!i + 1]) then Some 2
-        else None
-      end else if c < 0xF0 then begin
-        if !i + 2 < n
-        && is_cont (Char.code s.[!i + 1])
-        && is_cont (Char.code s.[!i + 2]) then begin
-          let cp = ((c land 0x0F) lsl 12)
-                lor ((Char.code s.[!i + 1] land 0x3F) lsl 6)
-                lor (Char.code s.[!i + 2] land 0x3F) in
-          if cp < 0x800 then None              (* overlong *)
-          else if cp >= 0xD800 && cp <= 0xDFFF then None  (* surrogate *)
-          else Some 3
-        end else None
-      end else if c < 0xF5 then begin
-        if !i + 3 < n
-        && is_cont (Char.code s.[!i + 1])
-        && is_cont (Char.code s.[!i + 2])
-        && is_cont (Char.code s.[!i + 3]) then begin
-          let cp = ((c land 0x07) lsl 18)
-                lor ((Char.code s.[!i + 1] land 0x3F) lsl 12)
-                lor ((Char.code s.[!i + 2] land 0x3F) lsl 6)
-                lor (Char.code s.[!i + 3] land 0x3F) in
-          if cp < 0x10000 then None            (* overlong *)
-          else if cp > 0x10FFFF then None      (* beyond Unicode *)
-          else Some 4
-        end else None
-      end else None  (* 0xF5..0xFF: not a valid lead byte *)
-    in
-    match valid_len with
+    match utf8_sequence_length s !i with
     | Some k -> Buffer.add_substring buf s !i k; i := !i + k
     | None -> Buffer.add_string buf replacement; incr i
   done;

--- a/lib/resource.ml
+++ b/lib/resource.ml
@@ -246,6 +246,49 @@ let generate_uuid () =
     listing and resume reply uses. Safe on shorter inputs. *)
 let short_id sid = String.sub sid 0 (min 8 (String.length sid))
 
+(** Whether [needle] occurs anywhere in [haystack]. The empty needle is
+    present in everything, matching the substring conventions of both
+    [str.__contains__] and [String.starts_with]. Naive scan: callers
+    match short needles against short strings. *)
+let contains_substring ~haystack ~needle =
+  let haystack_length = String.length haystack in
+  let needle_length = String.length needle in
+  let rec loop index =
+    if needle_length = 0 then true
+    else if index + needle_length > haystack_length then false
+    else if String.equal (String.sub haystack index needle_length) needle then
+      true
+    else loop (index + 1)
+  in
+  loop 0
+
+(** First [max_chars] Unicode codepoints of [s] — what Python's [s[:n]]
+    does to a decoded str, as opposed to [String.sub], which counts
+    bytes and can cut a multibyte character in half. A half-encoded
+    character would go straight into the JSON we serialize, where a
+    strict decoder on the other side raises rather than renders.
+
+    A malformed lead or lone continuation byte counts as one character,
+    so the walk always advances and the result never exceeds
+    [max_chars] characters. Well-formed input never ends mid-sequence.
+    Use [truncate_utf8] instead when the budget is in bytes. *)
+let utf8_prefix ~max_chars s =
+  let length = String.length s in
+  let rec loop pos chars =
+    if chars >= max_chars || pos >= length then pos
+    else
+      let lead = Char.code s.[pos] in
+      let width =
+        if lead < 0x80 then 1
+        else if lead < 0xC0 then 1   (* lone continuation byte *)
+        else if lead < 0xE0 then 2
+        else if lead < 0xF0 then 3
+        else 4
+      in
+      loop (min length (pos + width)) (chars + 1)
+  in
+  String.sub s 0 (loop 0 0)
+
 (** Replace each \n / \r / \t in [s] with a single space. The
     replacement is 1:1 (a run of three newlines becomes three
     spaces, not one) — visually equivalent in Discord and simpler

--- a/test/test_mcp_handler.ml
+++ b/test/test_mcp_handler.ml
@@ -164,6 +164,39 @@ let recent_sessions_response sessions =
     ("sessions", `List sessions);
   ]
 
+let start_session_response ?(thread_id="123") ?(working_dir="/src/repo")
+    ?(project_name="repo") () =
+  `Assoc [
+    ("ok", `Bool true);
+    ("thread_id", `String thread_id);
+    ("working_dir", `String working_dir);
+    ("project_name", `String project_name);
+  ]
+
+let resume_session_response ?(thread_id="123")
+    ?(session_id="abcd1234efgh5678") ?(agent_kind="codex") () =
+  `Assoc [
+    ("ok", `Bool true);
+    ("thread_id", `String thread_id);
+    ("session_id", `String session_id);
+    ("agent_kind", `String agent_kind);
+  ]
+
+let send_message_response ?(thread_id="123") ?(remaining_hops=2)
+    ?(state="sent") () =
+  `Assoc [
+    ("ok", `Bool true);
+    ("thread_id", `String thread_id);
+    ("remaining_hops", `Int remaining_hops);
+    ("state", `String state);
+  ]
+
+let stop_session_response ?(message="Stopped session for repo.") () =
+  `Assoc [
+    ("ok", `Bool true);
+    ("message", `String message);
+  ]
+
 let check_list_projects_parity label response =
   let expected = python_list_projects_output response in
   let actual =
@@ -182,7 +215,7 @@ let check_list_sessions_parity label response =
   in
   Alcotest.(check string) label expected actual
 
-let check_recent_sessions_parity label tool_name formatter response =
+let check_tool_parity label tool_name formatter response =
   let expected = python_tool_output tool_name response in
   let actual =
     match formatter response with
@@ -359,18 +392,18 @@ let test_format_list_sessions_malformed_response () =
     ])])
 
 let test_format_recent_sessions_matches_python () =
-  check_recent_sessions_parity "claude empty"
+  check_tool_parity "claude empty"
     "list_claude_sessions"
     Mcp_formatter.format_list_claude_sessions
     (recent_sessions_response []);
-  check_recent_sessions_parity "claude sessions"
+  check_tool_parity "claude sessions"
     "list_claude_sessions"
     Mcp_formatter.format_list_claude_sessions
     (recent_sessions_response [
       recent_session ~age_minutes:12 ~summary:"fixed tests" "abcd1234";
       recent_session ~age_minutes:125 ~summary:"wrote plan" "efgh5678";
     ]);
-  check_recent_sessions_parity "claude missing summary"
+  check_tool_parity "claude missing summary"
     "list_claude_sessions"
     Mcp_formatter.format_list_claude_sessions
     (recent_sessions_response [
@@ -379,7 +412,7 @@ let test_format_recent_sessions_matches_python () =
         ("age_minutes", `Int 3);
       ];
     ]);
-  check_recent_sessions_parity "codex sessions"
+  check_tool_parity "codex sessions"
     "list_codex_sessions"
     Mcp_formatter.format_list_codex_sessions
     (recent_sessions_response [
@@ -388,7 +421,7 @@ let test_format_recent_sessions_matches_python () =
       recent_session ~working_dir:"/src/beta"
         ~age_minutes:60 ~summary:"reviewed output" "efgh5678";
     ]);
-  check_recent_sessions_parity "codex unknown project"
+  check_tool_parity "codex unknown project"
     "list_codex_sessions"
     Mcp_formatter.format_list_codex_sessions
     (recent_sessions_response [
@@ -400,7 +433,7 @@ let test_format_recent_sessions_matches_python () =
       ];
     ]);
   (* age_minutes absent: both sides default to 0 and render "0m ago". *)
-  check_recent_sessions_parity "claude missing age"
+  check_tool_parity "claude missing age"
     "list_claude_sessions"
     Mcp_formatter.format_list_claude_sessions
     (recent_sessions_response [
@@ -410,7 +443,7 @@ let test_format_recent_sessions_matches_python () =
       ];
     ]);
   (* working_dir null: Python's [or] falls back, so do we. *)
-  check_recent_sessions_parity "codex null working dir"
+  check_tool_parity "codex null working dir"
     "list_codex_sessions"
     Mcp_formatter.format_list_codex_sessions
     (recent_sessions_response [
@@ -423,7 +456,7 @@ let test_format_recent_sessions_matches_python () =
     ]);
   (* Claude's listing ignores working_dir entirely, so a malformed one
      must not fail the listing the way it does for Codex/Gemini. *)
-  check_recent_sessions_parity "claude ignores working dir"
+  check_tool_parity "claude ignores working dir"
     "list_claude_sessions"
     Mcp_formatter.format_list_claude_sessions
     (recent_sessions_response [
@@ -434,18 +467,18 @@ let test_format_recent_sessions_matches_python () =
         ("summary", `String "unrendered wd");
       ];
     ]);
-  check_recent_sessions_parity "gemini sessions"
+  check_tool_parity "gemini sessions"
     "list_gemini_sessions"
     Mcp_formatter.format_list_gemini_sessions
     (recent_sessions_response [
       recent_session ~working_dir:"/src/gamma"
         ~age_minutes:240 ~summary:"added MCP support" "abcd1234";
     ]);
-  check_recent_sessions_parity "null sessions"
+  check_tool_parity "null sessions"
     "list_gemini_sessions"
     Mcp_formatter.format_list_gemini_sessions
     (`Assoc [("ok", `Bool true); ("sessions", `Null)]);
-  check_recent_sessions_parity "missing sessions"
+  check_tool_parity "missing sessions"
     "list_codex_sessions"
     Mcp_formatter.format_list_codex_sessions
     (`Assoc [("ok", `Bool true)])
@@ -631,6 +664,104 @@ let test_format_recent_sessions_documented_divergences () =
          Use resume_session with kind=codex to attach.")
     (Mcp_formatter.format_list_codex_sessions forged)
 
+let test_format_lifecycle_tools_match_python () =
+  check_tool_parity "start session"
+    "start_session"
+    Mcp_formatter.format_start_session
+    (start_session_response ~thread_id:"111" ~working_dir:"/src/alpha"
+       ~project_name:"alpha" ());
+  check_tool_parity "start missing fields"
+    "start_session"
+    Mcp_formatter.format_start_session
+    (`Assoc [("ok", `Bool true)]);
+  check_tool_parity "resume session"
+    "resume_session"
+    Mcp_formatter.format_resume_session
+    (resume_session_response ~thread_id:"222"
+       ~session_id:"abcdef123456" ~agent_kind:"codex" ());
+  check_tool_parity "resume unknown kind"
+    "resume_session"
+    Mcp_formatter.format_resume_session
+    (resume_session_response ~thread_id:"222"
+       ~session_id:"abcdef123456" ~agent_kind:"" ());
+  check_tool_parity "send sent"
+    "send_message"
+    Mcp_formatter.format_send_message
+    (send_message_response ~thread_id:"333" ~remaining_hops:3 ());
+  check_tool_parity "send posted not routed"
+    "send_message"
+    Mcp_formatter.format_send_message
+    (send_message_response ~thread_id:"333" ~remaining_hops:1
+       ~state:"posted_not_routed" ());
+  check_tool_parity "send missing fields"
+    "send_message"
+    Mcp_formatter.format_send_message
+    (`Assoc [("ok", `Bool true)]);
+  check_tool_parity "stop session"
+    "stop_session"
+    Mcp_formatter.format_stop_session
+    (stop_session_response ~message:"Stopping session for repo." ());
+  check_tool_parity "stop missing message"
+    "stop_session"
+    Mcp_formatter.format_stop_session
+    (`Assoc [("ok", `Bool true)])
+
+let test_format_lifecycle_tools_control_error () =
+  let check label formatter =
+    Alcotest.(check (result string string))
+      label
+      (Error "Bot is not running.")
+      (formatter (`Assoc [("error", `String "Bot is not running.")]))
+  in
+  check "start control error" Mcp_formatter.format_start_session;
+  check "resume control error" Mcp_formatter.format_resume_session;
+  check "send control error" Mcp_formatter.format_send_message;
+  check "stop control error" Mcp_formatter.format_stop_session
+
+let test_format_lifecycle_tools_malformed_response () =
+  let check label expected formatter response =
+    Alcotest.(check (result string string))
+      label
+      expected
+      (formatter response)
+  in
+  check "start response object"
+    (Error "Control API response must be an object")
+    Mcp_formatter.format_start_session
+    `Null;
+  check "start thread id"
+    (Error "start_session.thread_id must be a string")
+    Mcp_formatter.format_start_session
+    (`Assoc [("thread_id", `Int 123)]);
+  check "start working dir"
+    (Error "start_session.working_dir must be a string")
+    Mcp_formatter.format_start_session
+    (`Assoc [("working_dir", `Bool true)]);
+  check "start project name"
+    (Error "start_session.project_name must be a string")
+    Mcp_formatter.format_start_session
+    (`Assoc [("project_name", `Bool true)]);
+  check "resume session id"
+    (Error "resume_session.session_id must be a string")
+    Mcp_formatter.format_resume_session
+    (`Assoc [("session_id", `Bool true)]);
+  check "resume agent kind"
+    (Error "resume_session.agent_kind must be a string")
+    Mcp_formatter.format_resume_session
+    (`Assoc [("agent_kind", `Bool true)]);
+  check "send remaining hops"
+    (Error "send_message.remaining_hops must be an integer")
+    Mcp_formatter.format_send_message
+    (`Assoc [("remaining_hops", `String "three")]);
+  check "send state"
+    (Error "send_message.state must be a string")
+    Mcp_formatter.format_send_message
+    (`Assoc [("state", `Bool true)]);
+  check "stop message"
+    (Error "stop_session.message must be a string")
+    Mcp_formatter.format_stop_session
+    (`Assoc [("message", `Bool true)])
+
 let test_handler_list_projects_requests_control_api () =
   let calls = ref [] in
   let response =
@@ -680,10 +811,10 @@ let test_handler_list_sessions_requests_control_api () =
       (Option.is_none request.params)
   | calls -> failf "expected one control request, got %d" (List.length calls)
 
-let check_recent_handler_requests_control_api
-    ~tool_name ~method_name ~response ~expected_output =
+let check_handler_requests_control_api
+    ~timeout_s ~tool_name ~method_name ~arguments
+    ~response ~expected_output =
   let calls = ref [] in
-  let arguments = `Assoc [("hours", `Int 6)] in
   let control_client =
     Control_client.make ~request:(fun request ->
       calls := request :: !calls;
@@ -697,11 +828,19 @@ let check_recent_handler_requests_control_api
   match !calls with
   | [request] ->
     Alcotest.(check string) "method" method_name request.method_name;
-    Alcotest.(check int) "timeout" 60 request.timeout_s;
+    Alcotest.(check int) "timeout" timeout_s request.timeout_s;
     (match request.params with
      | Some params -> check_json "params" arguments params
      | None -> failf "expected params")
   | calls -> failf "expected one control request, got %d" (List.length calls)
+
+let check_recent_handler_requests_control_api
+    ~tool_name ~method_name ~response ~expected_output =
+  check_handler_requests_control_api
+    ~timeout_s:60
+    ~tool_name ~method_name
+    ~arguments:(`Assoc [("hours", `Int 6)])
+    ~response ~expected_output
 
 let test_handler_recent_sessions_request_control_api () =
   check_recent_handler_requests_control_api
@@ -755,15 +894,100 @@ let test_handler_recent_sessions_empty_arguments () =
      | None -> failf "expected params")
   | calls -> failf "expected one control request, got %d" (List.length calls)
 
+let test_handler_lifecycle_tools_request_control_api () =
+  check_handler_requests_control_api
+    ~timeout_s:120
+    ~tool_name:"start_session"
+    ~method_name:"start_session"
+    ~arguments:(`Assoc [
+      ("project", `String "repo");
+      ("agent", `String "codex");
+    ])
+    ~response:(start_session_response ~thread_id:"111"
+       ~working_dir:"/src/repo" ~project_name:"repo" ())
+    ~expected_output:"Started session for **repo** in <#111>.\nWorking in: `/src/repo`";
+  check_handler_requests_control_api
+    ~timeout_s:120
+    ~tool_name:"resume_session"
+    ~method_name:"resume_session"
+    ~arguments:(`Assoc [
+      ("session_id", `String "abcd1234");
+      ("kind", `String "codex");
+    ])
+    ~response:(resume_session_response ~thread_id:"222"
+       ~session_id:"abcd1234efgh5678" ~agent_kind:"codex" ())
+    ~expected_output:"Resumed Codex session `abcd1234` in <#222>.";
+  check_handler_requests_control_api
+    ~timeout_s:60
+    ~tool_name:"send_message"
+    ~method_name:"send_message"
+    ~arguments:(`Assoc [
+      ("thread_id", `String "333");
+      ("message", `String "hello");
+      ("remaining_hops", `Int 2);
+    ])
+    ~response:(send_message_response ~thread_id:"333"
+       ~remaining_hops:2 ())
+    ~expected_output:"Sent message to <#333>. remaining_hops=2.";
+  check_handler_requests_control_api
+    ~timeout_s:60
+    ~tool_name:"stop_session"
+    ~method_name:"stop_session"
+    ~arguments:(`Assoc [("thread_id", `String "444")])
+    ~response:(stop_session_response ~message:"Stopped session for repo." ())
+    ~expected_output:"Stopped session for repo."
+
+let test_handler_start_session_refreshes_missing_project () =
+  let calls = ref [] in
+  let arguments = `Assoc [("project", `String "new-repo")] in
+  let control_client =
+    Control_client.make ~request:(fun request ->
+      calls := request :: !calls;
+      match List.rev !calls with
+      | [{ Control_client.method_name = "start_session"; _ }] ->
+        Ok (`Assoc [("error", `String "No project matching 'new-repo'.")])
+      | [_; { Control_client.method_name = "refresh_projects"; _ }] ->
+        Ok (`Assoc [("ok", `Bool true)])
+      | [_; _; { Control_client.method_name = "start_session"; _ }] ->
+        Ok (start_session_response ~thread_id:"111"
+              ~working_dir:"/src/new-repo" ~project_name:"new-repo" ())
+      | _ -> Ok (`Assoc [("error", `String "unexpected call")]))
+  in
+  let call = { Mcp_server.name = "start_session"; arguments } in
+  Alcotest.(check (result string string))
+    "handler output"
+    (Ok "Started session for **new-repo** in <#111>.\nWorking in: `/src/new-repo`")
+    (Mcp_handler.handle_tool_call ~control_client call);
+  match List.rev !calls with
+  | [start1; refresh; start2] ->
+    Alcotest.(check string) "first method"
+      "start_session" start1.method_name;
+    Alcotest.(check int) "first timeout" 120 start1.timeout_s;
+    (match start1.params with
+     | Some params -> check_json "first params" arguments params
+     | None -> failf "expected first params");
+    Alcotest.(check string) "refresh method"
+      "refresh_projects" refresh.method_name;
+    Alcotest.(check int) "refresh timeout" 60 refresh.timeout_s;
+    Alcotest.(check bool) "refresh params omitted" true
+      (Option.is_none refresh.params);
+    Alcotest.(check string) "second method"
+      "start_session" start2.method_name;
+    Alcotest.(check int) "second timeout" 120 start2.timeout_s;
+    (match start2.params with
+     | Some params -> check_json "second params" arguments params
+     | None -> failf "expected second params")
+  | calls -> failf "expected three control requests, got %d" (List.length calls)
+
 let test_handler_unsupported_tool () =
   let control_client =
     Control_client.make ~request:(fun _request ->
       failf "unsupported tool should not call control API")
   in
-  let call = { Mcp_server.name = "send_message"; arguments = `Assoc [] } in
+  let call = { Mcp_server.name = "not_a_tool"; arguments = `Assoc [] } in
   Alcotest.(check (result string string))
     "unsupported"
-    (Error "OCaml MCP tools/call is not wired yet for tool: send_message")
+    (Error "OCaml MCP tools/call is not wired yet for tool: not_a_tool")
     (Mcp_handler.handle_tool_call ~control_client call)
 
 let test_server_wraps_list_projects_result () =
@@ -891,6 +1115,38 @@ let test_server_wraps_recent_sessions_result () =
             ("type", `String "text");
             ("text",
              `String "- `abcd1234` 7m ago — /src/alpha — ported recent sessions\n\nUse resume_session with kind=codex to attach.");
+          ];
+        ]);
+      ]);
+    ])
+  in
+  match actual, expected with
+  | Some actual, Some expected -> check_json "MCP response" expected actual
+  | _ -> failf "expected MCP response"
+
+let test_server_wraps_lifecycle_result () =
+  let control_client =
+    Control_client.make ~request:(fun _request ->
+      Ok (send_message_response ~thread_id:"123" ~remaining_hops:2 ()))
+  in
+  let line =
+    {|{"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"send_message","arguments":{"thread_id":"123","message":"hello"}}}|}
+  in
+  let actual =
+    Mcp_server.handle_line
+      ~handle_tool_call:(Mcp_handler.handle_tool_call ~control_client)
+      line
+  in
+  let expected =
+    Some (`Assoc [
+      ("jsonrpc", `String "2.0");
+      ("id", `Int 12);
+      ("result", `Assoc [
+        ("content", `List [
+          `Assoc [
+            ("type", `String "text");
+            ("text",
+             `String "Sent message to <#123>. remaining_hops=2.");
           ];
         ]);
       ]);
@@ -1046,6 +1302,12 @@ let () =
         test_format_recent_sessions_malformed_response;
       Alcotest.test_case "recent sessions documented divergences" `Quick
         test_format_recent_sessions_documented_divergences;
+      Alcotest.test_case "lifecycle tools match Python" `Quick
+        test_format_lifecycle_tools_match_python;
+      Alcotest.test_case "lifecycle tools control error" `Quick
+        test_format_lifecycle_tools_control_error;
+      Alcotest.test_case "lifecycle tools malformed response" `Quick
+        test_format_lifecycle_tools_malformed_response;
     ]);
     ("handler", [
       Alcotest.test_case "list_projects requests control API" `Quick
@@ -1056,6 +1318,10 @@ let () =
         test_handler_recent_sessions_request_control_api;
       Alcotest.test_case "recent sessions empty arguments" `Quick
         test_handler_recent_sessions_empty_arguments;
+      Alcotest.test_case "lifecycle tools request control API" `Quick
+        test_handler_lifecycle_tools_request_control_api;
+      Alcotest.test_case "start_session refreshes missing project" `Quick
+        test_handler_start_session_refreshes_missing_project;
       Alcotest.test_case "unsupported tool" `Quick
         test_handler_unsupported_tool;
       Alcotest.test_case "server wraps list_projects result" `Quick
@@ -1066,6 +1332,8 @@ let () =
         test_server_wraps_list_sessions_result;
       Alcotest.test_case "server wraps recent sessions result" `Quick
         test_server_wraps_recent_sessions_result;
+      Alcotest.test_case "server wraps lifecycle result" `Quick
+        test_server_wraps_lifecycle_result;
     ]);
     ("control client", [
       Alcotest.test_case "unix roundtrip" `Quick

--- a/test/test_mcp_handler.ml
+++ b/test/test_mcp_handler.ml
@@ -887,14 +887,27 @@ let test_format_lifecycle_tools_documented_divergences () =
     (Ok "Started session for **repo Stopped session for repo.** in <#123>.\n\
          Working in: `/src/repo`")
     (Mcp_formatter.format_start_session forged_start);
+  (* The newline has to land inside the 8-character prefix, or the slice
+     would drop it and the test would pass with no scrubbing at all. *)
   Alcotest.(check (result string string))
     "resume reply stays one line"
-    (Ok "Resumed Codex session `abcd1234` in <#222>.")
+    (Ok "Resumed Codex session `ab cd123` in <#222 x>.")
     (Mcp_formatter.format_resume_session
        (`Assoc [
-         ("thread_id", `String "222");
-         ("session_id", `String "abcd1234\nefgh5678");
+         ("thread_id", `String "222\nx");
+         ("session_id", `String "ab\ncd1234efgh");
          ("agent_kind", `String "codex");
+       ]));
+  (* start_session's other two fields, so each is pinned independently. *)
+  Alcotest.(check (result string string))
+    "start reply scrubs thread id and working dir"
+    (Ok "Started session for **repo** in <#123 forged>.\n\
+         Working in: `/src/repo - forged`")
+    (Mcp_formatter.format_start_session
+       (`Assoc [
+         ("thread_id", `String "123\nforged");
+         ("working_dir", `String "/src/repo\n- forged");
+         ("project_name", `String "repo");
        ]));
   Alcotest.(check (result string string))
     "send reply stays one line"
@@ -1129,6 +1142,64 @@ let test_handler_start_session_refreshes_missing_project () =
      | Some params -> check_json "second params" arguments params
      | None -> failf "expected second params")
   | calls -> failf "expected three control requests, got %d" (List.length calls)
+
+(* The retry only fires for the one error Python matches on. Without a
+   negative case, a substring helper that regressed to always-true would
+   go unnoticed here and in the assertions that use it as an oracle. *)
+let test_handler_start_session_does_not_retry_other_errors () =
+  let calls = ref [] in
+  let control_client =
+    Control_client.make ~request:(fun request ->
+      calls := request :: !calls;
+      Ok (`Assoc [("error", `String "Disk is read-only; refusing to start.")]))
+  in
+  let call =
+    { Mcp_server.name = "start_session";
+      arguments = `Assoc [("project", `String "repo")] }
+  in
+  Alcotest.(check (result string string))
+    "handler output"
+    (Error "Disk is read-only; refusing to start.")
+    (Mcp_handler.handle_tool_call ~control_client call);
+  match !calls with
+  | [request] ->
+    Alcotest.(check string) "method" "start_session" request.method_name
+  | calls ->
+    failf "expected exactly one control request, got %d" (List.length calls)
+
+(* Direct coverage for the two Resource helpers this port introduced.
+   test_mcp_handler leans on contains_substring as an assertion
+   primitive, so it needs pinning somewhere that doesn't use it. *)
+let test_resource_string_helpers () =
+  let prefix = Discord_agents.Resource.utf8_prefix in
+  Alcotest.(check string) "ascii" "abcd" (prefix ~max_chars:4 "abcdefgh");
+  Alcotest.(check string) "shorter than budget" "ab" (prefix ~max_chars:8 "ab");
+  Alcotest.(check string) "empty" "" (prefix ~max_chars:8 "");
+  Alcotest.(check string) "zero budget" "" (prefix ~max_chars:0 "abc");
+  (* Codepoints, not bytes: 2 characters of a 3-byte-per-character
+     string is 6 bytes, and the cut never lands mid-character. *)
+  Alcotest.(check string) "multibyte" "日本" (prefix ~max_chars:2 "日本語");
+  Alcotest.(check string) "astral" "\xF0\x9F\x98\x80"
+    (prefix ~max_chars:1 "\xF0\x9F\x98\x80\xF0\x9F\x98\x81");
+  (* A lead byte whose continuation bytes are missing must advance one
+     byte, not swallow the ASCII that follows it. *)
+  Alcotest.(check string) "truncated lead" "\xE2" (prefix ~max_chars:1 "\xE2AB");
+  Alcotest.(check string) "truncated lead then ascii" "\xE2A"
+    (prefix ~max_chars:2 "\xE2AB");
+  Alcotest.(check string) "lone continuation" "\x80"
+    (prefix ~max_chars:1 "\x80abc");
+  Alcotest.(check string) "invalid lead byte" "\xFF"
+    (prefix ~max_chars:1 "\xFFabc");
+  let contains = Discord_agents.Resource.contains_substring in
+  Alcotest.(check bool) "present" true
+    (contains ~haystack:"no project matching 'x'" ~needle:"no project matching");
+  Alcotest.(check bool) "absent" false
+    (contains ~haystack:"disk is read-only" ~needle:"no project matching");
+  Alcotest.(check bool) "empty needle" true (contains ~haystack:"" ~needle:"");
+  Alcotest.(check bool) "needle longer" false
+    (contains ~haystack:"ab" ~needle:"abc");
+  Alcotest.(check bool) "match at end" true
+    (contains ~haystack:"abcd" ~needle:"cd")
 
 let test_handler_unsupported_tool () =
   let control_client =
@@ -1475,6 +1546,10 @@ let () =
         test_handler_lifecycle_tools_request_control_api;
       Alcotest.test_case "start_session refreshes missing project" `Quick
         test_handler_start_session_refreshes_missing_project;
+      Alcotest.test_case "start_session does not retry other errors" `Quick
+        test_handler_start_session_does_not_retry_other_errors;
+      Alcotest.test_case "resource string helpers" `Quick
+        test_resource_string_helpers;
       Alcotest.test_case "unsupported tool" `Quick
         test_handler_unsupported_tool;
       Alcotest.test_case "server wraps list_projects result" `Quick

--- a/test/test_mcp_handler.ml
+++ b/test/test_mcp_handler.ml
@@ -917,6 +917,41 @@ let test_format_lifecycle_tools_documented_divergences () =
          ("thread_id", `String "333\nforged");
          ("remaining_hops", `Int 1);
        ]));
+  (* agent_kind is interpolated too, so it gets its own case rather than
+     riding on the others. *)
+  Alcotest.(check (result string string))
+    "resume reply scrubs agent kind"
+    (Ok "Resumed Co dex session `abcd1234` in <#222>.")
+    (Mcp_formatter.format_resume_session
+       (`Assoc [
+         ("thread_id", `String "222");
+         ("session_id", `String "abcd1234");
+         ("agent_kind", `String "co\ndex");
+       ]));
+  (* The sanitize half of render_string: a latin-1 byte in a filesystem
+     path would otherwise reach Yojson verbatim and make the JSON-RPC
+     response undecodable for a strict client. *)
+  Alcotest.(check (result string string))
+    "start reply replaces invalid bytes"
+    (Ok "Started session for **repo** in <#123>.\n\
+         Working in: `/src/re\xEF\xBF\xBDpo`")
+    (Mcp_formatter.format_start_session
+       (`Assoc [
+         ("thread_id", `String "123");
+         ("working_dir", `String "/src/re\xE2po");
+         ("project_name", `String "repo");
+       ]));
+  (* And in the session id, where the replacement character occupies one
+     of the eight slots rather than three. *)
+  Alcotest.(check (result string string))
+    "resume reply replaces invalid bytes inside the prefix"
+    (Ok "Resumed Codex session `ab\xEF\xBF\xBDcdefg` in <#222>.")
+    (Mcp_formatter.format_resume_session
+       (`Assoc [
+         ("thread_id", `String "222");
+         ("session_id", `String "ab\xE2cdefghij");
+         ("agent_kind", `String "codex");
+       ]));
   Alcotest.(check (result string string))
     "stop reply stays one line"
     (Ok "Stopped session for repo. Started session for evil in <#9>.")
@@ -1190,6 +1225,27 @@ let test_resource_string_helpers () =
     (prefix ~max_chars:1 "\x80abc");
   Alcotest.(check string) "invalid lead byte" "\xFF"
     (prefix ~max_chars:1 "\xFFabc");
+  (* The sequences a strict JSON decoder rejects even though their lead
+     byte declares a width: each byte is garbage on its own terms, so it
+     counts as one character — the same accounting sanitize_utf8 uses
+     when it replaces them. *)
+  Alcotest.(check string) "overlong two-byte" "\xC0"
+    (prefix ~max_chars:1 "\xC0\x80");
+  Alcotest.(check string) "surrogate half" "\xED"
+    (prefix ~max_chars:1 "\xED\xA0\x80");
+  Alcotest.(check string) "beyond unicode" "\xF5"
+    (prefix ~max_chars:1 "\xF5\x80\x80\x80");
+  (* sanitize_utf8 shares the decoder, so its notion of a character is
+     the same one; it had no direct coverage before. *)
+  let sanitize = Discord_agents.Resource.sanitize_utf8 in
+  Alcotest.(check string) "sanitize valid" "ok 日本"
+    (sanitize "ok 日本");
+  Alcotest.(check string) "sanitize truncated lead" "\xEF\xBF\xBDAB"
+    (sanitize "\xE2AB");
+  Alcotest.(check string) "sanitize surrogate" "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD"
+    (sanitize "\xED\xA0\x80");
+  Alcotest.(check string) "sanitize overlong" "\xEF\xBF\xBD\xEF\xBF\xBD"
+    (sanitize "\xC0\x80");
   let contains = Discord_agents.Resource.contains_substring in
   Alcotest.(check bool) "present" true
     (contains ~haystack:"no project matching 'x'" ~needle:"no project matching");

--- a/test/test_mcp_handler.ml
+++ b/test/test_mcp_handler.ml
@@ -100,11 +100,7 @@ let python_tool_call_failure ?(arguments=`Assoc []) tool_name response =
   | _, output -> Some output
 
 let contains_substring haystack needle =
-  let n = String.length needle and h = String.length haystack in
-  n = 0 ||
-  (let rec loop i = i + n <= h && (String.sub haystack i n = needle
-                                   || loop (i + 1)) in
-   loop 0)
+  Discord_agents.Resource.contains_substring ~haystack ~needle
 
 let python_list_projects_output response =
   python_tool_output "list_projects" response
@@ -704,7 +700,24 @@ let test_format_lifecycle_tools_match_python () =
   check_tool_parity "stop missing message"
     "stop_session"
     Mcp_formatter.format_stop_session
-    (`Assoc [("ok", `Bool true)])
+    (`Assoc [("ok", `Bool true)]);
+  (* An id longer than the 8-char prefix, and one where the prefix falls
+     mid-character: Python slices codepoints, so this only matches if we
+     do too. *)
+  check_tool_parity "resume long session id"
+    "resume_session"
+    Mcp_formatter.format_resume_session
+    (resume_session_response ~session_id:"0123456789abcdef" ());
+  check_tool_parity "resume multibyte session id"
+    "resume_session"
+    Mcp_formatter.format_resume_session
+    (resume_session_response ~session_id:"日本語テストxyz" ());
+  (* str.capitalize() down-cases the tail, so "CODEX" renders "Codex" —
+     the reason python_capitalize_ascii lowercases before capitalizing. *)
+  check_tool_parity "resume upper case kind"
+    "resume_session"
+    Mcp_formatter.format_resume_session
+    (resume_session_response ~agent_kind:"CODEX" ())
 
 let test_format_lifecycle_tools_control_error () =
   let check label formatter =
@@ -760,7 +773,145 @@ let test_format_lifecycle_tools_malformed_response () =
   check "stop message"
     (Error "stop_session.message must be a string")
     Mcp_formatter.format_stop_session
-    (`Assoc [("message", `Bool true)])
+    (`Assoc [("message", `Bool true)]);
+  check "start error envelope"
+    (Error "Control API error field must be a string")
+    Mcp_formatter.format_start_session
+    (`Assoc [("error", `Int 42)]);
+  check "resume error envelope"
+    (Error "Control API error field must be a string")
+    Mcp_formatter.format_resume_session
+    (`Assoc [("error", `Int 42)]);
+  check "send error envelope"
+    (Error "Control API error field must be a string")
+    Mcp_formatter.format_send_message
+    (`Assoc [("error", `Int 42)]);
+  check "stop error envelope"
+    (Error "Control API error field must be a string")
+    Mcp_formatter.format_stop_session
+    (`Assoc [("error", `Int 42)])
+
+(* Where the lifecycle tools deliberately do not match Python. Each case
+   asserts the oracle's behavior too, so a divergence that closes on the
+   Python side shows up as a failure rather than drifting unnoticed.
+
+   Two classes:
+   (a) fail-closed on malformed fields where Python renders whatever it
+       got — str(True), str(None), a bare non-string return;
+   (b) single-lining interpolated strings, so a newline cannot split one
+       reply into what reads like two. *)
+let test_format_lifecycle_tools_documented_divergences () =
+  let check_fails_closed label expected_python expected_error
+      tool_name formatter response =
+    Alcotest.(check string)
+      (label ^ ": python renders it")
+      expected_python
+      (python_tool_output tool_name response);
+    Alcotest.(check (result string string))
+      (label ^ ": we fail closed")
+      (Error expected_error)
+      (formatter response)
+  in
+  check_fails_closed "null hops"
+    "Sent message to <#1>. remaining_hops=None."
+    "send_message.remaining_hops must be an integer"
+    "send_message" Mcp_formatter.format_send_message
+    (`Assoc [
+      ("thread_id", `String "1");
+      ("remaining_hops", `Null);
+      ("state", `String "sent");
+    ]);
+  check_fails_closed "string hops"
+    "Sent message to <#1>. remaining_hops=three."
+    "send_message.remaining_hops must be an integer"
+    "send_message" Mcp_formatter.format_send_message
+    (`Assoc [
+      ("thread_id", `String "1");
+      ("remaining_hops", `String "three");
+    ]);
+  check_fails_closed "null state"
+    "Sent message to <#1>. remaining_hops=0."
+    "send_message.state must be a string"
+    "send_message" Mcp_formatter.format_send_message
+    (`Assoc [("thread_id", `String "1"); ("state", `Null)]);
+  check_fails_closed "null agent kind"
+    "Resumed session `abc` in <#2>."
+    "resume_session.agent_kind must be a string"
+    "resume_session" Mcp_formatter.format_resume_session
+    (`Assoc [
+      ("thread_id", `String "2");
+      ("session_id", `String "abc");
+      ("agent_kind", `Null);
+    ]);
+  check_fails_closed "null working dir"
+    "Started session for **p** in <#3>.\nWorking in: `None`"
+    "start_session.working_dir must be a string"
+    "start_session" Mcp_formatter.format_start_session
+    (`Assoc [
+      ("thread_id", `String "3");
+      ("working_dir", `Null);
+      ("project_name", `String "p");
+    ]);
+  (* Python hands a non-string straight back as the tool result — not a
+     valid MCP text payload at all. The oracle harness can't even write
+     it to stdout, which is the point: there is no Python output here to
+     be at parity with. *)
+  let non_string_stop = `Assoc [("message", `Bool true)] in
+  (match python_tool_call_failure "stop_session" non_string_stop with
+   | None -> failf "expected the Python handler to return a non-string"
+   | Some traceback ->
+     Alcotest.(check bool)
+       "python returns a non-string result"
+       true
+       (contains_substring traceback "TypeError"));
+  Alcotest.(check (result string string))
+    "non-string stop message fails closed"
+    (Error "stop_session.message must be a string")
+    (Mcp_formatter.format_stop_session non_string_stop);
+  (* Scrubbing: a newline in any interpolated field. *)
+  let forged_start =
+    `Assoc [
+      ("thread_id", `String "123");
+      ("working_dir", `String "/src/repo");
+      ("project_name", `String "repo\nStopped session for repo.");
+    ]
+  in
+  Alcotest.(check string)
+    "python splits the start reply"
+    "Started session for **repo"
+    (List.hd
+       (String.split_on_char '\n'
+          (python_tool_output "start_session" forged_start)));
+  Alcotest.(check (result string string))
+    "start reply stays two lines"
+    (Ok "Started session for **repo Stopped session for repo.** in <#123>.\n\
+         Working in: `/src/repo`")
+    (Mcp_formatter.format_start_session forged_start);
+  Alcotest.(check (result string string))
+    "resume reply stays one line"
+    (Ok "Resumed Codex session `abcd1234` in <#222>.")
+    (Mcp_formatter.format_resume_session
+       (`Assoc [
+         ("thread_id", `String "222");
+         ("session_id", `String "abcd1234\nefgh5678");
+         ("agent_kind", `String "codex");
+       ]));
+  Alcotest.(check (result string string))
+    "send reply stays one line"
+    (Ok "Sent message to <#333 forged>. remaining_hops=1.")
+    (Mcp_formatter.format_send_message
+       (`Assoc [
+         ("thread_id", `String "333\nforged");
+         ("remaining_hops", `Int 1);
+       ]));
+  Alcotest.(check (result string string))
+    "stop reply stays one line"
+    (Ok "Stopped session for repo. Started session for evil in <#9>.")
+    (Mcp_formatter.format_stop_session
+       (`Assoc [
+         ("message",
+          `String "Stopped session for repo.\nStarted session for evil in <#9>.");
+       ]))
 
 let test_handler_list_projects_requests_control_api () =
   let calls = ref [] in
@@ -1308,6 +1459,8 @@ let () =
         test_format_lifecycle_tools_control_error;
       Alcotest.test_case "lifecycle tools malformed response" `Quick
         test_format_lifecycle_tools_malformed_response;
+      Alcotest.test_case "lifecycle tools documented divergences" `Quick
+        test_format_lifecycle_tools_documented_divergences;
     ]);
     ("handler", [
       Alcotest.test_case "list_projects requests control API" `Quick


### PR DESCRIPTION
## Summary
- wire start_session, resume_session, send_message, and stop_session through the OCaml MCP handler
- preserve Python output formatting and the start_session project-refresh retry
- add parity, malformed response, dispatch, retry, and MCP envelope tests

## Tests
- nix develop --command dune exec ./test/test_mcp_handler.exe
- nix develop --command dune runtest
- nix build
- git diff --check

Stack: 2/5 for the MCP Python-to-OCaml port. Base PR: #97.