### PR TITLE
Cut MCP runtime over to OCaml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,13 +150,13 @@ Gemini tool names (`run_shell_command`, `read_file`, `write_file`, `replace`, `s
 
 ## MCP configuration
 
-The bot exposes MCP tools (`start_session`, `stop_session`, `list_sessions`, etc.) via `scripts/mcp-server.py`. All three agents now pick it up — each through a different mechanism:
+The bot exposes MCP tools (`start_session`, `stop_session`, `list_sessions`, etc.) via the `discord-agents-mcp` OCaml stdio server. All three agents pick it up through a different mechanism:
 
 - **Claude** — `--mcp-config <path>` flag; we write the config to `~/.config/discord-agents/mcp-generated.json`.
-- **Codex** — TOML overrides via `-c key=value` per invocation: `mcp_servers.discord_agents.command="python3"` and `mcp_servers.discord_agents.args=["..."]`. Doesn't touch the user's `~/.codex/config.toml`.
+- **Codex** — TOML overrides via `-c key=value` per invocation: `mcp_servers.discord_agents.command="discord-agents-mcp"` and `mcp_servers.discord_agents.args=[]`. Doesn't touch the user's `~/.codex/config.toml`.
 - **Gemini** — has no `--mcp-config` flag; loads `mcpServers` from `<cwd>/.gemini/settings.json`. The bot merges its entry into any existing settings file (preserving the user's other MCP servers and unrelated keys) at session start and appends `.gemini/` to the worktree's `.git/info/exclude`.
 
-For non-default install layouts where the script doesn't live next to the executable, set `DISCORD_AGENTS_MCP_SCRIPT=/path/to/mcp-server.py` to override the heuristic search.
+For non-default install layouts, set `DISCORD_AGENTS_MCP_COMMAND=/path/to/discord-agents-mcp` to override the heuristic search.
 
 ## System prompts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,9 @@ nix develop --command dune build
 ```bash
 # Config at ~/.config/discord-agents/config.json
 # Or use DISCORD_BOT_TOKEN env var
-nix develop --command dune exec discord-agents
+# dune build first: `dune exec discord-agents` builds only the bot,
+# not the sibling MCP server executable the agents connect to.
+nix develop --command dune build && nix develop --command dune exec discord-agents
 
 # Smoke test
 nix develop --command dune exec discord-agents -- --test [CHANNEL_ID]
@@ -153,10 +155,28 @@ Gemini tool names (`run_shell_command`, `read_file`, `write_file`, `replace`, `s
 The bot exposes MCP tools (`start_session`, `stop_session`, `list_sessions`, etc.) via the `discord-agents-mcp` OCaml stdio server. All three agents pick it up through a different mechanism:
 
 - **Claude** — `--mcp-config <path>` flag; we write the config to `~/.config/discord-agents/mcp-generated.json`.
-- **Codex** — TOML overrides via `-c key=value` per invocation: `mcp_servers.discord_agents.command="discord-agents-mcp"` and `mcp_servers.discord_agents.args=[]`. Doesn't touch the user's `~/.codex/config.toml`.
+- **Codex** — TOML overrides via `-c key=value` per invocation: `mcp_servers.discord_agents.command="<resolved absolute path>"` and `mcp_servers.discord_agents.args=[]`. Doesn't touch the user's `~/.codex/config.toml`.
 - **Gemini** — has no `--mcp-config` flag; loads `mcpServers` from `<cwd>/.gemini/settings.json`. The bot merges its entry into any existing settings file (preserving the user's other MCP servers and unrelated keys) at session start and appends `.gemini/` to the worktree's `.git/info/exclude`.
 
-For non-default install layouts, set `DISCORD_AGENTS_MCP_COMMAND=/path/to/discord-agents-mcp` to override the heuristic search.
+All three regenerate their config on every spawn, so a stale `mcp-generated.json` or `.gemini/settings.json` from an older version heals itself on the next session.
+
+### Finding the server
+
+`Agent_process.resolve_mcp_command` looks, in order, at `DISCORD_AGENTS_MCP_COMMAND`, then `discord-agents-mcp` and `mcp_server.exe` beside the running bot, then `_build/default/bin/mcp_server.exe` walking up from the working directory. Each candidate must be an executable regular file, not merely present.
+
+**`dune exec discord-agents` does not build the MCP server** — it builds only the executable you named. Run `dune build` first (the documented run commands and `scripts/run-branch.sh` do). If nothing resolves, the bot logs an error naming every path it tried and starts sessions *without* MCP config rather than pointing an agent at a command that isn't there; the agent then simply has no `discord-agents` tools.
+
+The pre-cutover `DISCORD_AGENTS_MCP_SCRIPT` is no longer read. Setting it logs a warning telling you to use `DISCORD_AGENTS_MCP_COMMAND`.
+
+### Rolling back to the Python server
+
+`scripts/mcp-server.py` is still present, still executable, and still the parity oracle the test suite checks the OCaml implementation against. To fall back at runtime without reverting code:
+
+```bash
+DISCORD_AGENTS_MCP_COMMAND=/path/to/repo/scripts/mcp-server.py
+```
+
+Its shebang makes it work with the empty `args` list the config now emits. Restart the bot for it to take effect.
 
 ## System prompts
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cat > ~/.config/discord-agents/config.json << 'EOF'
 EOF
 
 # Run
-nix develop --command dune exec discord-agents
+nix develop --command dune build && nix develop --command dune exec discord-agents
 ```
 
 Then in Discord:

--- a/SETUP.md
+++ b/SETUP.md
@@ -123,6 +123,7 @@ Create a wrapper script (`nix-run.sh`):
 
 ```bash
 #!/bin/bash
+nix develop --command dune build
 exec nix develop --command dune exec discord-agents
 ```
 

--- a/bin/dune
+++ b/bin/dune
@@ -6,4 +6,6 @@
 
 (executable
  (name mcp_server)
+ (public_name discord-agents-mcp)
+ (package discord_agents)
  (libraries discord_agents yojson))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -126,6 +126,14 @@ let () =
     | _ -> None
   in
   Logs.info (fun m -> m "discord-agents starting%s" (if test_mode then " (test mode)" else ""));
+  (* Resolve the MCP server now rather than lazily at the first session
+     spawn: an operator who launched without building wants to hear it
+     at boot, in the log they are already looking at, not one line
+     buried in a session's output an hour later. Memoized, so the spawn
+     path reuses this. *)
+  (match Discord_agents.Agent_process.mcp_command_opt () with
+   | Some path -> Logs.info (fun m -> m "MCP server: %s" path)
+   | None -> ()  (* resolution already logged the error and why *));
   Random.self_init ();  (* Seed PRNG for heartbeat jitter *)
   let config =
     match Discord_agents.Config.load_result () with

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1420,15 +1420,24 @@ let claude_mcp_config_path () =
        does not degrade when --mcp-config names a missing file, it exits
        1 — so promising a path we didn't write would turn a no-tools
        session into no session at all, exactly when read-only-disk
-       handling is trying to keep sessions alive. *)
-    if Sys.file_exists config_path then Some config_path
-    else begin
+       handling is trying to keep sessions alive.
+
+       Read it back rather than stat it: the write is a rename, so a
+       refused write leaves whatever was there before — a config from
+       another worktree naming an executable that no longer exists,
+       which is the silent-no-tools failure this PR is closing. A
+       directory at that path would also satisfy [Sys.file_exists] and
+       then make Claude exit 1. *)
+    let intended = Lazy.force mcp_json in
+    match read_file_result config_path with
+    | File_contents actual when String.equal actual intended ->
+      Some config_path
+    | _ ->
       Logs.warn (fun m ->
-        m "MCP config %s could not be written; starting Claude without \
-           --mcp-config rather than pointing it at a missing file"
-          config_path);
+        m "MCP config %s does not match what we tried to write; \
+           starting Claude without --mcp-config rather than pointing it \
+           at a stale or missing config" config_path);
       None
-    end
 
 (** Inject our [discord-agents] entry into a Gemini settings JSON
     string (preserving any other [mcpServers] and unrelated
@@ -1476,8 +1485,28 @@ let gemini_settings_with ~our_entry existing =
 let merge_gemini_settings existing =
   gemini_settings_with ~our_entry:(Some (mcp_server_entry ())) existing
 
+(* [None] means "leave the file exactly as it is".
+
+   The register path's "parseable but non-object: discard" reasoning
+   does not transfer here. There we *must* install our entry, so
+   replacing a file that could never have held it costs nothing. Here
+   there is nothing to install, so rewriting a file we can't understand
+   is pure loss — a truncated or hand-commented settings.json, or one
+   whose [mcpServers] isn't an object, would come back as
+   [{"mcpServers": {}}] with the user's keys gone. We only rewrite when
+   we can see our own entry to remove. *)
 let gemini_settings_without_our_entry existing =
-  gemini_settings_with ~our_entry:None existing
+  match existing with
+  | None -> None
+  | Some text ->
+    match Yojson.Safe.from_string text with
+    | exception _ -> None
+    | `Assoc fields ->
+      (match List.assoc_opt "mcpServers" fields with
+       | Some (`Assoc servers) when List.mem_assoc "discord-agents" servers ->
+         Some (gemini_settings_with ~our_entry:None (Some text))
+       | _ -> None)
+    | _ -> None
 
 (** Resolve the [info/exclude] file Git actually reads for
     [working_dir]. Uses [git rev-parse --git-path info/exclude],
@@ -1532,36 +1561,49 @@ let merge_gemini_exclude existing =
     repo's [info/exclude]. Both writes are idempotent — re-running
     against a worktree we've already configured leaves the file and
     the exclude line unchanged in shape. *)
-let setup_gemini_mcp ~working_dir =
-  let resolved = mcp_command_opt () in
+(* [?resolved] exists so the unresolved branch is reachable from a
+   test: the real value is a process-global memoized lazy, so without a
+   seam here nothing could exercise the very path the last two review
+   rounds were about. *)
+let setup_gemini_mcp ?resolved ~working_dir () =
+  let resolved =
+    match resolved with Some r -> r | None -> mcp_command_opt ()
+  in
   if working_dir = "" then ()
     (* Defense-in-depth: the resume handlers reject empty working_dir
        before we get here, but a future caller shouldn't write
        .gemini/ into the bot's own directory by accident. *)
   else
   let gemini_dir = Filename.concat working_dir ".gemini" in
+  let settings_path = Filename.concat gemini_dir "settings.json" in
+  (* Unresolved: withdraw our entry rather than leave one naming a
+     command that is no longer there. Control and project channel
+     sessions run in persistent directories, not throwaway worktrees,
+     so a settings.json written while a build tree existed outlives it.
+     But touch nothing else — no .gemini/ to create, no info/exclude
+     line to add, and no rewrite of a file that doesn't contain our
+     entry. With no server to register, every one of those would be a
+     change made on a user's behalf for no benefit. *)
+  match resolved with
+  | None ->
+    (match read_file_result settings_path with
+     | File_read_error exn -> log_file_read_failure ~path:settings_path exn
+     | File_missing -> ()
+     | File_contents existing ->
+       (match gemini_settings_without_our_entry (Some existing) with
+        | None -> ()
+        | Some updated -> write_file_safely ~path:settings_path updated))
+  | Some _ ->
   (try
      if not (Sys.file_exists gemini_dir) then Unix.mkdir gemini_dir 0o755
    with _ -> ());
-  let settings_path = Filename.concat gemini_dir "settings.json" in
-  let render existing =
-    match resolved with
-    | Some _ -> merge_gemini_settings existing
-    (* Unresolved: withdraw our entry rather than leave one naming a
-       command that is no longer there. Control and project channel
-       sessions run in persistent directories, not throwaway worktrees,
-       so a settings.json written while a build tree existed outlives
-       it. *)
-    | None -> gemini_settings_without_our_entry existing
-  in
   (match read_file_result settings_path with
    | File_read_error exn -> log_file_read_failure ~path:settings_path exn
-   (* Nothing to withdraw from, and nothing to register: don't create a
-      settings.json at all in the unresolved case. *)
-   | File_missing when Option.is_none resolved -> ()
-   | File_missing -> write_file_safely ~path:settings_path (render None)
+   | File_missing ->
+     write_file_safely ~path:settings_path (merge_gemini_settings None)
    | File_contents existing ->
-     write_file_safely ~path:settings_path (render (Some existing)));
+     write_file_safely ~path:settings_path
+       (merge_gemini_settings (Some existing)));
   match resolve_git_info_exclude ~working_dir with
   | None -> ()
   | Some exclude_path ->
@@ -1786,7 +1828,7 @@ let run_streaming ~sw ~env ~working_dir ~kind ~session_id ~message_count
       codex_args ~model ~reasoning_effort
         ~session_id ~session_id_confirmed ~prompt
     | Config.Gemini ->
-      setup_gemini_mcp ~working_dir;
+      setup_gemini_mcp ~working_dir ();
       gemini_args ~model ~session_id ~session_id_confirmed ~prompt
   in
   let args = [setsid_command (); "--wait"] @ args in

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1245,6 +1245,10 @@ let rec find_upwards ~from ~relative =
    no tools.
 
    [Error] carries the candidates tried, for an operator-readable log. *)
+type mcp_resolution_failure =
+  | Override_not_executable of string
+  | No_candidate_found of string list
+
 let resolve_mcp_command ~env_override ~exe_dir ~cwd =
   match env_override with
   | Some path when String.trim path <> "" ->
@@ -1252,7 +1256,7 @@ let resolve_mcp_command ~env_override ~exe_dir ~cwd =
        untrimmed one, so " /usr/bin/foo" passed and then never ran. *)
     let path = String.trim path in
     if is_executable_file path then Ok path
-    else Error [path]
+    else Error (Override_not_executable path)
   | _ ->
     let siblings = [
       Filename.concat exe_dir "discord-agents-mcp";
@@ -1264,7 +1268,17 @@ let resolve_mcp_command ~env_override ~exe_dir ~cwd =
        let relative = "_build/default/bin/mcp_server.exe" in
        (match find_upwards ~from:cwd ~relative with
         | Some path -> Ok path
-        | None -> Error (siblings @ [Filename.concat cwd relative])))
+        | None ->
+          (* Name every directory the walk actually looked in, not just
+             the first: "we tried X" listing one of eight paths sends
+             the operator looking in the wrong place. *)
+          let rec ancestors dir acc =
+            let acc = Filename.concat dir relative :: acc in
+            let parent = Filename.dirname dir in
+            if String.equal parent dir then List.rev acc
+            else ancestors parent acc
+          in
+          Error (No_candidate_found (siblings @ ancestors cwd []))))
 
 let mcp_command_result = lazy (
   let exe_dir =
@@ -1279,7 +1293,13 @@ let mcp_command_result = lazy (
   in
   (match result with
    | Ok _ -> ()
-   | Error candidates ->
+   | Error (Override_not_executable path) ->
+     (* Don't advise `dune build` at someone who told us exactly where
+        to look; the problem is that path, not a missing build. *)
+     Logs.err (fun m ->
+       m "DISCORD_AGENTS_MCP_COMMAND=%s is not an executable file; \
+          agents will start with no discord-agents tools." path)
+   | Error (No_candidate_found candidates) ->
      Logs.err (fun m ->
        m "MCP server executable not found; agents will start with no \
           discord-agents tools. Tried: %s. Build it with `dune build` \
@@ -1395,7 +1415,20 @@ let claude_mcp_config_path () =
     let config_dir = Resource.app_config_dir () in
     let config_path = Filename.concat config_dir "mcp-generated.json" in
     write_file_safely ~path:config_path (Lazy.force mcp_json);
-    Some config_path
+    (* [write_file_safely] swallows both a disk-preflight refusal and a
+       write exception, so "we tried" is not "there is a file". Claude
+       does not degrade when --mcp-config names a missing file, it exits
+       1 — so promising a path we didn't write would turn a no-tools
+       session into no session at all, exactly when read-only-disk
+       handling is trying to keep sessions alive. *)
+    if Sys.file_exists config_path then Some config_path
+    else begin
+      Logs.warn (fun m ->
+        m "MCP config %s could not be written; starting Claude without \
+           --mcp-config rather than pointing it at a missing file"
+          config_path);
+      None
+    end
 
 (** Inject our [discord-agents] entry into a Gemini settings JSON
     string (preserving any other [mcpServers] and unrelated
@@ -1404,11 +1437,24 @@ let claude_mcp_config_path () =
     not an object — in any of those cases the existing content
     couldn't have meaningfully held our entry, so we'd lose nothing
     by replacing it. *)
-let merge_gemini_settings existing =
-  let our_entry = mcp_server_entry () in
+(* [~entry:None] withdraws our server instead of registering it, for the
+   case where no MCP executable resolved. Gemini is the only agent whose
+   config is a file it reads unconditionally on every run — Claude's
+   flag and Codex's overrides simply aren't passed — so for Gemini
+   "don't write the config" is not the same as "run without it". A
+   settings.json written while a build tree existed keeps naming that
+   vanished path afterwards. Removing our entry leaves the user's other
+   servers and unrelated keys exactly where they were. *)
+let gemini_settings_with ~our_entry existing =
+  let set_our_server servers =
+    let others = List.filter (fun (k, _) -> k <> "discord-agents") servers in
+    match our_entry with
+    | Some entry -> ("discord-agents", entry) :: others
+    | None -> others
+  in
   let render_fresh () =
     Yojson.Safe.pretty_to_string
-      (`Assoc [("mcpServers", `Assoc [("discord-agents", our_entry)])])
+      (`Assoc [("mcpServers", `Assoc (set_our_server []))])
   in
   match existing with
   | None -> render_fresh ()
@@ -1419,17 +1465,19 @@ let merge_gemini_settings existing =
         let prior_servers = match List.assoc_opt "mcpServers" fields with
           | Some (`Assoc servers) -> servers
           | _ -> [] in
-        let new_servers =
-          ("discord-agents", our_entry)
-          :: List.filter (fun (k, _) -> k <> "discord-agents") prior_servers
-        in
         let new_fields =
-          ("mcpServers", `Assoc new_servers)
+          ("mcpServers", `Assoc (set_our_server prior_servers))
           :: List.filter (fun (k, _) -> k <> "mcpServers") fields
         in
         Yojson.Safe.pretty_to_string (`Assoc new_fields)
       | _ -> render_fresh ()  (* parseable but non-object: discard *)
     with _ -> render_fresh ()
+
+let merge_gemini_settings existing =
+  gemini_settings_with ~our_entry:(Some (mcp_server_entry ())) existing
+
+let gemini_settings_without_our_entry existing =
+  gemini_settings_with ~our_entry:None existing
 
 (** Resolve the [info/exclude] file Git actually reads for
     [working_dir]. Uses [git rev-parse --git-path info/exclude],
@@ -1485,12 +1533,8 @@ let merge_gemini_exclude existing =
     against a worktree we've already configured leaves the file and
     the exclude line unchanged in shape. *)
 let setup_gemini_mcp ~working_dir =
-  if Option.is_none (mcp_command_opt ()) then ()
-    (* Same call as the other two agents: writing a settings.json that
-       names a missing command would leave the worktree configured for
-       a server that can't start, and Gemini reads that file on every
-       later run. Error already logged at resolution. *)
-  else if working_dir = "" then ()
+  let resolved = mcp_command_opt () in
+  if working_dir = "" then ()
     (* Defense-in-depth: the resume handlers reject empty working_dir
        before we get here, but a future caller shouldn't write
        .gemini/ into the bot's own directory by accident. *)
@@ -1500,14 +1544,24 @@ let setup_gemini_mcp ~working_dir =
      if not (Sys.file_exists gemini_dir) then Unix.mkdir gemini_dir 0o755
    with _ -> ());
   let settings_path = Filename.concat gemini_dir "settings.json" in
+  let render existing =
+    match resolved with
+    | Some _ -> merge_gemini_settings existing
+    (* Unresolved: withdraw our entry rather than leave one naming a
+       command that is no longer there. Control and project channel
+       sessions run in persistent directories, not throwaway worktrees,
+       so a settings.json written while a build tree existed outlives
+       it. *)
+    | None -> gemini_settings_without_our_entry existing
+  in
   (match read_file_result settings_path with
    | File_read_error exn -> log_file_read_failure ~path:settings_path exn
-   | File_missing ->
-     write_file_safely ~path:settings_path
-       (merge_gemini_settings None)
+   (* Nothing to withdraw from, and nothing to register: don't create a
+      settings.json at all in the unresolved case. *)
+   | File_missing when Option.is_none resolved -> ()
+   | File_missing -> write_file_safely ~path:settings_path (render None)
    | File_contents existing ->
-     write_file_safely ~path:settings_path
-       (merge_gemini_settings (Some existing)));
+     write_file_safely ~path:settings_path (render (Some existing)));
   match resolve_git_info_exclude ~working_dir with
   | None -> ()
   | Some exclude_path ->
@@ -1718,6 +1772,13 @@ let run_streaming ~sw ~env ~working_dir ~kind ~session_id ~message_count
         | Some path -> base @ ["--mcp-config"; path]
         | None -> base
       in
+      (* --mcp-config is variadic in the Claude CLI: it keeps eating
+         following arguments as additional config paths until it hits
+         one starting with `-`. That is safe here only because the
+         prompt positional is already in [base] and the sole thing
+         appended after is another flag. Anything non-flag appended
+         below would silently become a second config file, and Claude
+         hard-fails on a config path that doesn't exist. *)
       (match system_prompt with
        | Some sp -> base @ ["--append-system-prompt"; sp]
        | None -> base)

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1216,38 +1216,102 @@ let absolute_path path =
   if Filename.is_relative path then Filename.concat (Sys.getcwd ()) path
   else path
 
-let first_existing paths =
-  List.find_opt Sys.file_exists paths
+(* Executable, not merely present: [Sys.file_exists] is true of
+   directories and of a non-executable file, either of which would be
+   accepted here and then fail at spawn time inside the agent, where we
+   never see it. *)
+let is_executable_file path =
+  match Unix.stat path with
+  | { Unix.st_kind = Unix.S_REG; _ } ->
+    (try Unix.access path [Unix.X_OK]; true with Unix.Unix_error _ -> false)
+  | _ -> false
+  | exception Unix.Unix_error _ -> false
+
+let first_executable paths =
+  List.find_opt is_executable_file paths
 
 let rec find_upwards ~from ~relative =
   let candidate = Filename.concat from relative in
-  if Sys.file_exists candidate then Some candidate
+  if is_executable_file candidate then Some candidate
   else
     let parent = Filename.dirname from in
     if String.equal parent from then None
     else find_upwards ~from:parent ~relative
 
-let mcp_command_path = lazy (
-  match Sys.getenv_opt "DISCORD_AGENTS_MCP_COMMAND" with
-  | Some path when String.trim path <> "" -> path
+(* Resolve the MCP server command, or explain why we couldn't.
+   Parameterized rather than reading the environment directly so the
+   branches are testable: this is the riskiest logic in the cutover and
+   every branch fails in a way nobody sees until an agent silently has
+   no tools.
+
+   [Error] carries the candidates tried, for an operator-readable log. *)
+let resolve_mcp_command ~env_override ~exe_dir ~cwd =
+  match env_override with
+  | Some path when String.trim path <> "" ->
+    (* Trim: the guard used to test the trimmed value and return the
+       untrimmed one, so " /usr/bin/foo" passed and then never ran. *)
+    let path = String.trim path in
+    if is_executable_file path then Ok path
+    else Error [path]
   | _ ->
-    try
-      let exe_dir = Sys.executable_name |> absolute_path |> Filename.dirname in
-      match first_existing [
-        Filename.concat exe_dir "discord-agents-mcp";
-        Filename.concat exe_dir "mcp_server.exe";
-      ] with
-      | Some path -> path
-      | None ->
-        (match find_upwards ~from:(Sys.getcwd ())
-                 ~relative:"_build/default/bin/mcp_server.exe" with
-         | Some path -> path
-         | None -> "discord-agents-mcp")
-    with _ -> "discord-agents-mcp"
+    let siblings = [
+      Filename.concat exe_dir "discord-agents-mcp";
+      Filename.concat exe_dir "mcp_server.exe";
+    ] in
+    (match first_executable siblings with
+     | Some path -> Ok path
+     | None ->
+       let relative = "_build/default/bin/mcp_server.exe" in
+       (match find_upwards ~from:cwd ~relative with
+        | Some path -> Ok path
+        | None -> Error (siblings @ [Filename.concat cwd relative])))
+
+let mcp_command_result = lazy (
+  let exe_dir =
+    try Sys.executable_name |> absolute_path |> Filename.dirname
+    with _ -> Filename.current_dir_name
+  in
+  let cwd = try Sys.getcwd () with _ -> Filename.current_dir_name in
+  let result =
+    resolve_mcp_command
+      ~env_override:(Sys.getenv_opt "DISCORD_AGENTS_MCP_COMMAND")
+      ~exe_dir ~cwd
+  in
+  (match result with
+   | Ok _ -> ()
+   | Error candidates ->
+     Logs.err (fun m ->
+       m "MCP server executable not found; agents will start with no \
+          discord-agents tools. Tried: %s. Build it with `dune build` \
+          (plain `dune exec discord-agents` does not build sibling \
+          executables), or set DISCORD_AGENTS_MCP_COMMAND to its path."
+         (String.concat ", " candidates)));
+  (* The old override named a Python script and was silently ignored
+     after the cutover, which lands the operator in exactly the
+     no-tools state above. Say so rather than let them find out from an
+     agent that quietly has no tools. *)
+  (match Sys.getenv_opt "DISCORD_AGENTS_MCP_SCRIPT" with
+   | Some value when String.trim value <> "" ->
+     Logs.warn (fun m ->
+       m "DISCORD_AGENTS_MCP_SCRIPT=%s is no longer used; the MCP server \
+          is now a native executable. Set DISCORD_AGENTS_MCP_COMMAND \
+          instead — it accepts scripts/mcp-server.py directly if you \
+          need to roll back to the Python server." value)
+   | _ -> ());
+  result
 )
 
+let mcp_command_opt () =
+  match Lazy.force mcp_command_result with
+  | Ok path -> Some path
+  | Error _ -> None
+
+(* Kept for the config writers that already ran the [mcp_command_opt]
+   check; never reached with an unresolved command. *)
 let mcp_command () =
-  Lazy.force mcp_command_path
+  match Lazy.force mcp_command_result with
+  | Ok path -> path
+  | Error _ -> "discord-agents-mcp"
 
 let mcp_server_entry () =
   `Assoc [
@@ -1325,10 +1389,13 @@ let contains_substring text needle =
 (** Claude: write the MCP config to a well-known location and return
     the path for [--mcp-config]. *)
 let claude_mcp_config_path () =
-  let config_dir = Resource.app_config_dir () in
-  let config_path = Filename.concat config_dir "mcp-generated.json" in
-  write_file_safely ~path:config_path (Lazy.force mcp_json);
-  config_path
+  match mcp_command_opt () with
+  | None -> None
+  | Some _ ->
+    let config_dir = Resource.app_config_dir () in
+    let config_path = Filename.concat config_dir "mcp-generated.json" in
+    write_file_safely ~path:config_path (Lazy.force mcp_json);
+    Some config_path
 
 (** Inject our [discord-agents] entry into a Gemini settings JSON
     string (preserving any other [mcpServers] and unrelated
@@ -1418,7 +1485,12 @@ let merge_gemini_exclude existing =
     against a worktree we've already configured leaves the file and
     the exclude line unchanged in shape. *)
 let setup_gemini_mcp ~working_dir =
-  if working_dir = "" then ()
+  if Option.is_none (mcp_command_opt ()) then ()
+    (* Same call as the other two agents: writing a settings.json that
+       names a missing command would leave the worktree configured for
+       a server that can't start, and Gemini reads that file on every
+       later run. Error already logged at resolution. *)
+  else if working_dir = "" then ()
     (* Defense-in-depth: the resume handlers reject empty working_dir
        before we get here, but a future caller shouldn't write
        .gemini/ into the bot's own directory by accident. *)
@@ -1472,10 +1544,13 @@ let escape_toml_string s =
     Codex invocation, without touching the user's ~/.codex/config.toml.
     Two key=value pairs because Codex parses each [-c] independently. *)
 let codex_mcp_overrides () =
-  let command = escape_toml_string (mcp_command ()) in
-  [ "-c"; Printf.sprintf
-      {|mcp_servers.discord_agents.command="%s"|} command;
-    "-c"; {|mcp_servers.discord_agents.args=[]|} ]
+  match mcp_command_opt () with
+  | None -> []
+  | Some path ->
+    let command = escape_toml_string path in
+    [ "-c"; Printf.sprintf
+        {|mcp_servers.discord_agents.command="%s"|} command;
+      "-c"; {|mcp_servers.discord_agents.args=[]|} ]
 
 (** Codex allocates its session id server-side in the thread.started
     event, so the UUID the bot pre-generated is invalid for resume on
@@ -1635,7 +1710,14 @@ let run_streaming ~sw ~env ~working_dir ~kind ~session_id ~message_count
       let base = claude_args ~model ~reasoning_effort
           ~fork_from_session_id ~session_id ~message_count ~prompt
       in
-      let base = base @ ["--mcp-config"; claude_mcp_config_path ()] in
+      let base =
+        (* No resolvable server: start without the flag rather than
+           point Claude at a config naming a command that isn't there.
+           The error is already logged once at resolution. *)
+        match claude_mcp_config_path () with
+        | Some path -> base @ ["--mcp-config"; path]
+        | None -> base
+      in
       (match system_prompt with
        | Some sp -> base @ ["--append-system-prompt"; sp]
        | None -> base)

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1524,8 +1524,8 @@ let gemini_settings_without_our_entry existing =
          Some (gemini_settings_with ~our_entry:None (Some text))
        | _ :: _ :: _ ->
          Logs.warn (fun m ->
-           m "Gemini settings has duplicate mcpServers keys; leaving the \
-              stale discord-agents entry rather than collapsing them");
+           m "Gemini settings has duplicate mcpServers keys; declining to \
+              rewrite rather than collapsing them");
          None
        | _ -> None)
     | _ -> None

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1199,7 +1199,8 @@ let claude_args ~model ~reasoning_effort
 (* ── MCP server config (shared by all three agents) ──────────────
 
    All three agents expose the bot's MCP tools (start_session,
-   list_*, etc.) by pointing at scripts/mcp-server.py. They each
+   list_*, etc.) by pointing at the OCaml discord-agents-mcp
+   executable. They each
    accept the pointer through a different mechanism:
 
    - Claude takes a [--mcp-config <path>] flag; we write the JSON to
@@ -1211,34 +1212,56 @@ let claude_args ~model ~reasoning_effort
      [<cwd>/.gemini/settings.json]. We write the file into the
      worktree and add [.gemini/] to [.git/info/exclude]. *)
 
-let mcp_script_path = lazy (
-  (* Allow an explicit override for installs where the script doesn't
-     live next to the executable (e.g. a standalone binary, or a
-     packaged install). Falls through to the heuristic search if
-     unset. *)
-  match Sys.getenv_opt "DISCORD_AGENTS_MCP_SCRIPT" with
-  | Some path when path <> "" -> path
+let absolute_path path =
+  if Filename.is_relative path then Filename.concat (Sys.getcwd ()) path
+  else path
+
+let first_existing paths =
+  List.find_opt Sys.file_exists paths
+
+let rec find_upwards ~from ~relative =
+  let candidate = Filename.concat from relative in
+  if Sys.file_exists candidate then Some candidate
+  else
+    let parent = Filename.dirname from in
+    if String.equal parent from then None
+    else find_upwards ~from:parent ~relative
+
+let mcp_command_path = lazy (
+  match Sys.getenv_opt "DISCORD_AGENTS_MCP_COMMAND" with
+  | Some path when String.trim path <> "" -> path
   | _ ->
     try
-      let exe = Sys.executable_name in
-      let exe = if Filename.is_relative exe
-        then Filename.concat (Sys.getcwd ()) exe else exe in
-      let rec find_root path =
-        let candidate = Filename.concat path "scripts/mcp-server.py" in
-        if Sys.file_exists candidate then candidate
-        else
-          let parent = Filename.dirname path in
-          if parent = path then "scripts/mcp-server.py"
-          else find_root parent
-      in
-      find_root (Filename.dirname exe)
-    with _ -> "scripts/mcp-server.py"
+      let exe_dir = Sys.executable_name |> absolute_path |> Filename.dirname in
+      match first_existing [
+        Filename.concat exe_dir "discord-agents-mcp";
+        Filename.concat exe_dir "mcp_server.exe";
+      ] with
+      | Some path -> path
+      | None ->
+        (match find_upwards ~from:(Sys.getcwd ())
+                 ~relative:"_build/default/bin/mcp_server.exe" with
+         | Some path -> path
+         | None -> "discord-agents-mcp")
+    with _ -> "discord-agents-mcp"
 )
 
+let mcp_command () =
+  Lazy.force mcp_command_path
+
+let mcp_server_entry () =
+  `Assoc [
+    ("command", `String (mcp_command ()));
+    ("args", `List []);
+  ]
+
 let mcp_json = lazy (
-  Printf.sprintf
-    {|{"mcpServers":{"discord-agents":{"command":"python3","args":["%s"]}}}|}
-    (Lazy.force mcp_script_path)
+  Yojson.Safe.to_string
+    (`Assoc [
+      ("mcpServers", `Assoc [
+        ("discord-agents", mcp_server_entry ());
+      ]);
+    ])
 )
 
 let write_file_safely ~path contents =
@@ -1315,10 +1338,7 @@ let claude_mcp_config_path () =
     couldn't have meaningfully held our entry, so we'd lose nothing
     by replacing it. *)
 let merge_gemini_settings existing =
-  let our_entry = `Assoc [
-    ("command", `String "python3");
-    ("args", `List [`String (Lazy.force mcp_script_path)]);
-  ] in
+  let our_entry = mcp_server_entry () in
   let render_fresh () =
     Yojson.Safe.pretty_to_string
       (`Assoc [("mcpServers", `Assoc [("discord-agents", our_entry)])])
@@ -1452,10 +1472,10 @@ let escape_toml_string s =
     Codex invocation, without touching the user's ~/.codex/config.toml.
     Two key=value pairs because Codex parses each [-c] independently. *)
 let codex_mcp_overrides () =
-  let path = escape_toml_string (Lazy.force mcp_script_path) in
-  [ "-c"; {|mcp_servers.discord_agents.command="python3"|};
-    "-c"; Printf.sprintf
-      {|mcp_servers.discord_agents.args=["%s"]|} path ]
+  let command = escape_toml_string (mcp_command ()) in
+  [ "-c"; Printf.sprintf
+      {|mcp_servers.discord_agents.command="%s"|} command;
+    "-c"; {|mcp_servers.discord_agents.args=[]|} ]
 
 (** Codex allocates its session id server-side in the thread.started
     event, so the UUID the bot pre-generated is invalid for resume on

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1430,7 +1430,14 @@ let claude_mcp_config_path () =
        then make Claude exit 1. *)
     let intended = Lazy.force mcp_json in
     match read_file_result config_path with
-    | File_contents actual when String.equal actual intended ->
+    (* Trimmed, because the comparison is with the file the writer
+       produced, not with the string handed to it: write_file_atomic
+       appends a newline of its own (lib/resource.ml). Comparing
+       untrimmed made this reject every healthy write — the config was
+       written correctly and then declared stale, so Claude ran with no
+       MCP tools at all. Trim rather than [intended ^ "\n"] so this
+       doesn't silently re-break if the writer's framing changes. *)
+    | File_contents actual when String.equal (String.trim actual) intended ->
       Some config_path
     | _ ->
       Logs.warn (fun m ->
@@ -1491,10 +1498,14 @@ let merge_gemini_settings existing =
    does not transfer here. There we *must* install our entry, so
    replacing a file that could never have held it costs nothing. Here
    there is nothing to install, so rewriting a file we can't understand
-   is pure loss — a truncated or hand-commented settings.json, or one
-   whose [mcpServers] isn't an object, would come back as
-   [{"mcpServers": {}}] with the user's keys gone. We only rewrite when
-   we can see our own entry to remove. *)
+   is pure loss — a truncated settings.json, one whose [mcpServers]
+   isn't an object, or one that simply never held our entry would come
+   back as [{"mcpServers": {}}] with the user's keys gone. We only
+   rewrite when we can see our own entry to remove.
+
+   Note Yojson does accept [//] comments, so a hand-commented file that
+   *does* hold our entry is rewritten (and its comments dropped) rather
+   than left alone. That is the register path's behavior too. *)
 let gemini_settings_without_our_entry existing =
   match existing with
   | None -> None
@@ -1502,9 +1513,20 @@ let gemini_settings_without_our_entry existing =
     match Yojson.Safe.from_string text with
     | exception _ -> None
     | `Assoc fields ->
-      (match List.assoc_opt "mcpServers" fields with
-       | Some (`Assoc servers) when List.mem_assoc "discord-agents" servers ->
+      (match List.filter (fun (key, _) -> key = "mcpServers") fields with
+       (* Exactly one [mcpServers], and it holds our entry. Duplicate
+          top-level keys are legal JSON that Yojson keeps and that
+          different readers resolve differently — Gemini's parser takes
+          the last, [List.assoc_opt] the first — and rewriting collapses
+          them to one, dropping whichever block we didn't act on. There
+          is no rewrite here that can't lose something, so decline. *)
+       | [(_, `Assoc servers)] when List.mem_assoc "discord-agents" servers ->
          Some (gemini_settings_with ~our_entry:None (Some text))
+       | _ :: _ :: _ ->
+         Logs.warn (fun m ->
+           m "Gemini settings has duplicate mcpServers keys; leaving the \
+              stale discord-agents entry rather than collapsing them");
+         None
        | _ -> None)
     | _ -> None
 

--- a/lib/control_api.ml
+++ b/lib/control_api.ml
@@ -322,10 +322,9 @@ let handle_list_sessions (bot : Bot.t) =
   let entries = Session_store.bindings bot.sessions in
   let sessions = List.map (fun (_tid, (s : Session_store.session)) ->
     (* single_line on project_name: MCP clients format this back into
-       Discord markdown bullets (scripts/mcp-server.py list_sessions and
-       Mcp_formatter.session_line), so a literal newline in a project name
-       would split the bullet just like it did for session summaries before
-       25d3546. *)
+       Discord markdown bullets (Mcp_formatter.session_line), so a literal
+       newline in a project name would split the bullet just like it did for
+       session summaries before 25d3546. *)
     `Assoc [
       ("project_name", `String (Resource.single_line s.project_name));
       ("agent_kind", `String (Config.string_of_agent_kind s.agent_kind));

--- a/lib/mcp_handler.ml
+++ b/lib/mcp_handler.ml
@@ -7,7 +7,21 @@ let unsupported_tool name =
       name
   )
 
+(* An empty arguments object is dropped rather than forwarded, matching
+   Python's [if params:] in control_request. This is not cosmetic: the
+   handlers for get_agent_config, set_model, set_effort, set_goal,
+   stop_session, rename_thread and resume_session read required fields
+   with [to_string], so [{}] reaches them as a present-but-empty object
+   and Yojson raises Type_error — the agent gets
+   `Type_error("Expected string, got null", 870828711)` where Python
+   returns the actionable `missing params`. An LLM that forgot an
+   argument should be told which one, not handed a hash. *)
+let drop_empty_params = function
+  | Some (`Assoc []) -> None
+  | params -> params
+
 let request_and_format ?params control_client method_id formatter =
+  let params = drop_empty_params params in
   match Control_client.request_method ?params control_client method_id with
   | Error _ as error -> error
   | Ok response -> formatter response
@@ -35,12 +49,10 @@ let handle_list_sessions control_client =
     Control_api.List_sessions_id
     Mcp_formatter.format_list_sessions
 
-(* Wire-format note: Python's [control_request] drops falsy params, so a
-   no-argument call goes out with no "params" key at all, while we always
-   forward the arguments object — [{}] for the common no-argument case.
-   [Control_api.hours_param] maps absent, empty and non-integer alike to
-   the 24h default, so the two are equivalent; pinned by
-   test_control_api's hours_param cases. *)
+(* The recent-session tools take an optional [hours]; with none given,
+   [drop_empty_params] makes the request identical to Python's, and
+   [Control_api.hours_param] defaults to 24 either way (pinned by
+   test_control_api's hours_param cases). *)
 let handle_list_claude_sessions control_client params =
   request_and_format ~params control_client
     Control_api.List_claude_sessions_id
@@ -57,8 +69,9 @@ let handle_list_gemini_sessions control_client params =
     Mcp_formatter.format_list_gemini_sessions
 
 let handle_start_session control_client params =
+  let params = drop_empty_params (Some params) in
   let request_start () =
-    Control_client.request_method ~params control_client
+    Control_client.request_method ?params control_client
       Control_api.Start_session_id
   in
   match request_start () with

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -1,8 +1,4 @@
-(** Minimal MCP JSON-RPC protocol handling.
-
-    The Python MCP server remains the runtime entrypoint for tool calls while
-    formatting is ported. This module owns the protocol surface that can be
-    tested against the typed OCaml tool descriptors. *)
+(** Minimal MCP JSON-RPC protocol handling for the OCaml stdio server. *)
 
 type tool_call = {
   name : string;
@@ -19,8 +15,6 @@ let protocol_version = "2024-11-05"
 
 let server_name = "discord-agents-mcp"
 
-(* Keep aligned with scripts/mcp-server.py while Python remains the runtime
-   MCP entrypoint. *)
 let server_version = "0.2.0"
 
 let raise_if_fatal exn =

--- a/lib/mcp_tool.ml
+++ b/lib/mcp_tool.ml
@@ -1,7 +1,7 @@
 (** MCP tool descriptors for the discord-agents control surface.
 
-    The Python MCP shim is still the runtime entrypoint. This module is
-    the typed OCaml source of truth we can migrate that runtime toward. *)
+    This module is the typed OCaml source of truth for the MCP tools
+    exposed by the discord-agents-mcp stdio server. *)
 
 type id =
   | Start_session

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
-"""MCP server for discord-agents bot control.
+"""Compatibility MCP server for discord-agents bot control.
 
 Thin stdio-to-UDS proxy: receives MCP tool calls via JSON-RPC over stdin,
 forwards them to the bot's control API over a Unix domain socket, and
 returns the formatted response.
+
+The production runtime uses the OCaml discord-agents-mcp executable. This
+script remains as a parity oracle and fallback shim.
 
 All session state, Discord REST calls, and worktree management are owned
 by the bot process. This server never touches sessions.json or Discord

--- a/scripts/mcp.json
+++ b/scripts/mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "discord-agents": {
-      "command": "python3",
-      "args": ["scripts/mcp-server.py"]
+      "command": "discord-agents-mcp",
+      "args": []
     }
   }
 }

--- a/scripts/mcp.json
+++ b/scripts/mcp.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Sample for registering the bot's MCP server with an agent by hand — the bot generates its own config per session, so you only need this to attach an agent the bot didn't spawn. Replace the command with an absolute path: nothing installs discord-agents-mcp onto PATH, so the bare name below resolves only if you put it there yourself. `dune build` leaves the executable at _build/default/bin/mcp_server.exe.",
   "mcpServers": {
     "discord-agents": {
       "command": "discord-agents-mcp",

--- a/test/dune
+++ b/test/dune
@@ -2,6 +2,12 @@
  (names test_command test_control_api test_mcp_tool test_mcp_server test_mcp_handler test_formatting test_project test_agent_contracts test_discord_rest test_gateway
  test_runtime_settings test_bot_defaults test_session_store test_disk_health test_config
   test_runtime_limits test_stream_interrupt)
- (deps ../scripts/mcp-server.py)
+ ; mcp-server.py is the parity oracle the MCP tests shell out to.
+ ; mcp_server.exe is what the agent-wiring tests resolve to: `dune
+ ; runtest` does not build sibling executables, so without this dep a
+ ; fresh clone runs the suite against an unbuilt path and the codex /
+ ; gemini MCP-config tests fail for a reason that has nothing to do with
+ ; the code under test.
+ (deps ../scripts/mcp-server.py %{exe:../bin/mcp_server.exe})
  (libraries discord_agents alcotest str unix yojson eio.mock eio_main cohttp-eio
   uri mirage-crypto-rng.unix))

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -2338,7 +2338,17 @@ let test_gemini_settings_withdraw_our_entry () =
     (Some {|{"theme":"dark","mcpServers":[{"user":1}]}|});
   untouched "no entry of ours"
     (Some {|{"theme":"dark","mcpServers":{"user-tool":{"command":"x"}}}|});
-  untouched "no mcpServers at all" (Some {|{"theme":"dark"}|})
+  untouched "no mcpServers at all" (Some {|{"theme":"dark"}|});
+  (* Duplicate top-level keys are legal JSON that readers disagree
+     about — Gemini's parser takes the last, List.assoc the first — and
+     any rewrite collapses them, dropping one block. Declining leaves a
+     stale entry, which is the lesser harm. *)
+  untouched "duplicate mcpServers, ours first"
+    (Some {|{"mcpServers":{"discord-agents":{"command":"/gone"}},
+             "mcpServers":{"user-tool":{"command":"x"}}}|});
+  untouched "duplicate mcpServers, ours second"
+    (Some {|{"mcpServers":{"user-tool":{"command":"x"}},
+             "mcpServers":{"discord-agents":{"command":"/gone"}}}|})
 
 let test_merge_gemini_settings_creates_when_absent () =
   let merged = Discord_agents.Agent_process.merge_gemini_settings None in
@@ -2922,6 +2932,47 @@ let test_setup_gemini_mcp_idempotent () =
         1 (List.length gemini_lines);
       ignore (count_substr exclude ".gemini/"))
 
+(* The healthy Claude path, end to end. A read-back check with no test
+   is how the last round shipped a comparison that rejected every
+   correctly-written config: write_file_atomic appends a newline the
+   compared string doesn't have, so the bot silently ran every Claude
+   session with no MCP tools while the suite stayed green. *)
+let test_claude_mcp_config_path_round_trips () =
+  with_temp_dir (fun dir ->
+    let fake_mcp = Filename.concat dir "fake-mcp" in
+    let oc = open_out fake_mcp in
+    close_out oc;
+    Unix.chmod fake_mcp 0o755;
+    let config_home = Filename.concat dir "config" in
+    Unix.mkdir config_home 0o755;
+    let saved_xdg = Sys.getenv_opt "XDG_CONFIG_HOME" in
+    let saved_home = Sys.getenv_opt "HOME" in
+    Unix.putenv "XDG_CONFIG_HOME" config_home;
+    (* HOME too: app_config_dir prefers a legacy ~/.discord-agents when
+       the XDG one holds no state yet. *)
+    Unix.putenv "HOME" (Filename.concat dir "home");
+    Fun.protect
+      ~finally:(fun () ->
+        (match saved_xdg with
+         | Some v -> Unix.putenv "XDG_CONFIG_HOME" v
+         | None -> Unix.putenv "XDG_CONFIG_HOME" "");
+        match saved_home with
+        | Some v -> Unix.putenv "HOME" v
+        | None -> Unix.putenv "HOME" "")
+      (fun () ->
+        match Discord_agents.Agent_process.claude_mcp_config_path () with
+        | None ->
+          Alcotest.fail
+            "a writable config dir and a resolvable server must yield a              --mcp-config path"
+        | Some path ->
+          Alcotest.(check bool) "config file exists" true (Sys.file_exists path);
+          let json = Yojson.Safe.from_string (read_all path) in
+          let open Yojson.Safe.Util in
+          Alcotest.(check bool) "names our server"
+            true
+            (List.mem_assoc "discord-agents"
+               (json |> member "mcpServers" |> to_assoc))))
+
 (* The caller, not just the helper. Both prior rounds were about
    setup_gemini_mcp's behavior when no MCP server resolved, and neither
    round's test could reach it — the real value is a memoized global, so
@@ -3185,6 +3236,8 @@ let resume_helpers_tests = [
     test_setup_gemini_mcp_unresolved_withdraws_our_entry;
   Alcotest.test_case "setup_gemini_mcp unresolved touches nothing else" `Quick
     test_setup_gemini_mcp_unresolved_touches_nothing_else;
+  Alcotest.test_case "claude_mcp_config_path round trips" `Quick
+    test_claude_mcp_config_path_round_trips;
   Alcotest.test_case "merge_gemini_settings invalid input falls back" `Quick
     test_merge_gemini_settings_invalid_input_falls_back;
   Alcotest.test_case "merge_gemini_settings non-object falls back" `Quick

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -2166,6 +2166,108 @@ let test_merge_gemini_settings_overwrites_our_entry () =
   Alcotest.(check int) "OCaml MCP server has no wrapper args"
     0 (List.length our_args)
 
+(* The resolver decides where all three agents look for the MCP server,
+   and every wrong answer fails the same silent way: the agent starts
+   with no discord-agents tools and nothing says so. The assertions
+   above compare generated config against [mcp_command ()] itself, so
+   they'd pass just as well if it returned nonsense — these don't. *)
+let with_temp_dir name f =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "mcp-resolve-%s-%d" name (Unix.getpid ()))
+  in
+  let rec rm path =
+    match Unix.stat path with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+      Sys.readdir path
+      |> Array.iter (fun entry -> rm (Filename.concat path entry));
+      Unix.rmdir path
+    | _ -> Sys.remove path
+    | exception Unix.Unix_error _ -> ()
+  in
+  rm dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> rm dir) (fun () -> f dir)
+
+let touch ?(perms=0o755) path =
+  let oc = open_out path in
+  close_out oc;
+  Unix.chmod path perms
+
+let check_resolves label expected actual =
+  match actual with
+  | Ok path -> Alcotest.(check string) label expected path
+  | Error candidates ->
+    Alcotest.failf "%s: expected %s, got Error [%s]"
+      label expected (String.concat "; " candidates)
+
+let check_unresolved label = function
+  | Ok path -> Alcotest.failf "%s: expected Error, resolved to %s" label path
+  | Error _ -> ()
+
+let test_mcp_command_resolution () =
+  let resolve = Discord_agents.Agent_process.resolve_mcp_command in
+  with_temp_dir "env" (fun dir ->
+    let exe = Filename.concat dir "custom-mcp" in
+    touch exe;
+    check_resolves "env override wins"
+      exe
+      (resolve ~env_override:(Some exe) ~exe_dir:dir ~cwd:dir);
+    (* The guard used to trim while the value returned did not, so a
+       stray space produced a command that could never run. *)
+    check_resolves "env override is trimmed"
+      exe
+      (resolve ~env_override:(Some ("  " ^ exe ^ "  ")) ~exe_dir:dir ~cwd:dir);
+    check_unresolved "env override pointing nowhere"
+      (resolve ~env_override:(Some (Filename.concat dir "missing"))
+         ~exe_dir:dir ~cwd:dir);
+    let not_exec = Filename.concat dir "not-exec" in
+    touch ~perms:0o644 not_exec;
+    check_unresolved "env override not executable"
+      (resolve ~env_override:(Some not_exec) ~exe_dir:dir ~cwd:dir);
+    check_unresolved "env override is a directory"
+      (resolve ~env_override:(Some dir) ~exe_dir:dir ~cwd:dir));
+  with_temp_dir "installed" (fun dir ->
+    let installed = Filename.concat dir "discord-agents-mcp" in
+    touch installed;
+    check_resolves "installed name beside the bot"
+      installed
+      (resolve ~env_override:None ~exe_dir:dir ~cwd:dir);
+    check_resolves "empty override falls through to the search"
+      installed
+      (resolve ~env_override:(Some "   ") ~exe_dir:dir ~cwd:dir));
+  with_temp_dir "dune" (fun dir ->
+    let built = Filename.concat dir "mcp_server.exe" in
+    touch built;
+    check_resolves "dune executable name beside the bot"
+      built
+      (resolve ~env_override:None ~exe_dir:dir ~cwd:dir));
+  with_temp_dir "upwards" (fun dir ->
+    let nested = Filename.concat dir "a/b/c" in
+    let build_bin = Filename.concat dir "_build/default/bin" in
+    List.iter (fun path ->
+      let rec mkdirs p =
+        if not (Sys.file_exists p) then begin
+          mkdirs (Filename.dirname p);
+          Unix.mkdir p 0o755
+        end
+      in
+      mkdirs path)
+      [nested; build_bin];
+    let built = Filename.concat build_bin "mcp_server.exe" in
+    touch built;
+    let empty = Filename.concat dir "empty-exe-dir" in
+    Unix.mkdir empty 0o755;
+    check_resolves "found by walking up from the working directory"
+      built
+      (resolve ~env_override:None ~exe_dir:empty ~cwd:nested);
+    (* A build tree that was never built: the file exists nowhere, and
+       the old resolver answered with a bare name that is on nobody's
+       PATH — the silent-no-tools case. *)
+    Sys.remove built;
+    check_unresolved "nothing built anywhere"
+      (resolve ~env_override:None ~exe_dir:empty ~cwd:nested))
+
 let test_merge_gemini_settings_creates_when_absent () =
   let merged = Discord_agents.Agent_process.merge_gemini_settings None in
   let json = Yojson.Safe.from_string merged in
@@ -2942,6 +3044,8 @@ let resume_helpers_tests = [
     test_merge_gemini_settings_overwrites_our_entry;
   Alcotest.test_case "merge_gemini_settings creates when absent" `Quick
     test_merge_gemini_settings_creates_when_absent;
+  Alcotest.test_case "MCP command resolution" `Quick
+    test_mcp_command_resolution;
   Alcotest.test_case "merge_gemini_settings invalid input falls back" `Quick
     test_merge_gemini_settings_invalid_input_falls_back;
   Alcotest.test_case "merge_gemini_settings non-object falls back" `Quick

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -2939,10 +2939,8 @@ let test_setup_gemini_mcp_idempotent () =
    session with no MCP tools while the suite stayed green. *)
 let test_claude_mcp_config_path_round_trips () =
   with_temp_dir (fun dir ->
-    let fake_mcp = Filename.concat dir "fake-mcp" in
-    let oc = open_out fake_mcp in
-    close_out oc;
-    Unix.chmod fake_mcp 0o755;
+    (* Resolution comes from test/dune's %{exe:../bin/mcp_server.exe}
+       dep, not from anything set up here. *)
     let config_home = Filename.concat dir "config" in
     Unix.mkdir config_home 0o755;
     let saved_xdg = Sys.getenv_opt "XDG_CONFIG_HOME" in
@@ -2963,7 +2961,7 @@ let test_claude_mcp_config_path_round_trips () =
         match Discord_agents.Agent_process.claude_mcp_config_path () with
         | None ->
           Alcotest.fail
-            "a writable config dir and a resolvable server must yield a              --mcp-config path"
+            "a writable config dir and a resolvable server must yield an MCP config path"
         | Some path ->
           Alcotest.(check bool) "config file exists" true (Sys.file_exists path);
           let json = Yojson.Safe.from_string (read_all path) in

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -2159,8 +2159,12 @@ let test_merge_gemini_settings_overwrites_our_entry () =
   let open Yojson.Safe.Util in
   let our_cmd = json |> member "mcpServers" |> member "discord-agents"
                 |> member "command" |> to_string in
-  Alcotest.(check string) "stale entry replaced with current python3"
-    "python3" our_cmd
+  let our_args = json |> member "mcpServers" |> member "discord-agents"
+                 |> member "args" |> to_list in
+  Alcotest.(check string) "stale entry replaced with current MCP command"
+    (Discord_agents.Agent_process.mcp_command ()) our_cmd;
+  Alcotest.(check int) "OCaml MCP server has no wrapper args"
+    0 (List.length our_args)
 
 let test_merge_gemini_settings_creates_when_absent () =
   let merged = Discord_agents.Agent_process.merge_gemini_settings None in
@@ -3062,22 +3066,27 @@ let test_codex_args_includes_mcp_overrides () =
      Two -c overrides register the discord-agents server. *)
   let args = codex_args ~session_id:"x" ~session_id_confirmed:false
     ~prompt:"hi" in
+  let command_override =
+    Printf.sprintf {|mcp_servers.discord_agents.command="%s"|}
+      (Discord_agents.Agent_process.escape_toml_string
+         (Discord_agents.Agent_process.mcp_command ()))
+  in
   Alcotest.(check bool) "registers discord_agents.command"
-    true (contains_pair args "-c"
-            {|mcp_servers.discord_agents.command="python3"|});
+    true (contains_pair args "-c" command_override);
   Alcotest.(check bool) "registers discord_agents.args" true
-    (List.exists (fun s ->
-      try ignore (Str.search_forward
-        (Str.regexp_string "mcp_servers.discord_agents.args=[") s 0); true
-      with Not_found -> false) args)
+    (contains_pair args "-c" {|mcp_servers.discord_agents.args=[]|})
 
 let test_codex_args_resume_keeps_mcp () =
   (* Resuming a Codex session should still expose MCP tools. *)
   let args = codex_args ~session_id:"x" ~session_id_confirmed:true
     ~prompt:"hi" in
+  let command_override =
+    Printf.sprintf {|mcp_servers.discord_agents.command="%s"|}
+      (Discord_agents.Agent_process.escape_toml_string
+         (Discord_agents.Agent_process.mcp_command ()))
+  in
   Alcotest.(check bool) "MCP override present on resume too"
-    true (contains_pair args "-c"
-            {|mcp_servers.discord_agents.command="python3"|})
+    true (contains_pair args "-c" command_override)
 
 let test_codex_args_model_and_effort_overrides () =
   let args = Discord_agents.Agent_process.codex_args

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -2297,8 +2297,15 @@ let test_mcp_command_resolution () =
 (* Gemini is the only agent whose MCP config is a file it reads on
    every run, so "start without MCP" has to mean removing our entry, not
    just declining to write one — a settings.json written while a build
-   tree existed keeps naming that path after the tree is gone. *)
+   tree existed keeps naming that path after the tree is gone.
+
+   Withdrawal only ever rewrites a file we can prove holds our entry.
+   The register path may discard a file it can't parse (it has to
+   install something, so a file that could never have held our entry
+   costs nothing to replace); withdrawal has nothing to install, so the
+   same clobber would be pure loss. *)
 let test_gemini_settings_withdraw_our_entry () =
+  let withdraw = Discord_agents.Agent_process.gemini_settings_without_our_entry in
   let existing = {|{
     "mcpServers": {
       "discord-agents": { "command": "/gone/mcp_server.exe", "args": [] },
@@ -2306,28 +2313,32 @@ let test_gemini_settings_withdraw_our_entry () =
     },
     "theme": "dark"
   }|} in
-  let withdrawn =
-    Discord_agents.Agent_process.gemini_settings_without_our_entry
-      (Some existing)
+  (match withdraw (Some existing) with
+   | None -> Alcotest.fail "expected our stale entry to be withdrawn"
+   | Some updated ->
+     let json = Yojson.Safe.from_string updated in
+     let open Yojson.Safe.Util in
+     let servers = json |> member "mcpServers" |> to_assoc in
+     Alcotest.(check bool) "our stale entry is gone"
+       false (List.mem_assoc "discord-agents" servers);
+     Alcotest.(check bool) "the user's server survives"
+       true (List.mem_assoc "user-tool" servers);
+     Alcotest.(check bool) "unrelated keys survive"
+       true (List.mem_assoc "theme" (json |> to_assoc)));
+  (* Every shape we can't prove holds our entry is left alone. Each of
+     these previously came back as {"mcpServers": {}}. *)
+  let untouched label input =
+    Alcotest.(check bool) label true (Option.is_none (withdraw input))
   in
-  let json = Yojson.Safe.from_string withdrawn in
-  let open Yojson.Safe.Util in
-  let servers = json |> member "mcpServers" |> to_assoc in
-  Alcotest.(check bool) "our stale entry is gone"
-    false (List.mem_assoc "discord-agents" servers);
-  Alcotest.(check bool) "the user's server survives"
-    true (List.mem_assoc "user-tool" servers);
-  Alcotest.(check bool) "unrelated keys survive"
-    true (List.mem_assoc "theme" (json |> to_assoc));
-  (* Withdrawing from a file that never had our entry is a no-op, and
-     from nothing at all leaves an empty server map rather than an
-     entry pointing nowhere. *)
-  let fresh =
-    Discord_agents.Agent_process.gemini_settings_without_our_entry None
-  in
-  Alcotest.(check int) "nothing registered when starting from nothing"
-    0 (List.length
-         (Yojson.Safe.from_string fresh |> member "mcpServers" |> to_assoc))
+  untouched "no file" None;
+  untouched "unparseable" (Some "not valid json {");
+  untouched "truncated" (Some {|{"theme":"dark","contextFileName":"GEM|});
+  untouched "not an object" (Some "[1, 2, 3]");
+  untouched "mcpServers is not an object"
+    (Some {|{"theme":"dark","mcpServers":[{"user":1}]}|});
+  untouched "no entry of ours"
+    (Some {|{"theme":"dark","mcpServers":{"user-tool":{"command":"x"}}}|});
+  untouched "no mcpServers at all" (Some {|{"theme":"dark"}|})
 
 let test_merge_gemini_settings_creates_when_absent () =
   let merged = Discord_agents.Agent_process.merge_gemini_settings None in
@@ -2865,7 +2876,7 @@ let test_setup_gemini_mcp_writes_settings_in_regular_repo () =
       "git init -q -b main %s 2>&1 >/dev/null"
       (Filename.quote dir)) in
     Alcotest.(check int) "git init succeeded" 0 rc;
-    Discord_agents.Agent_process.setup_gemini_mcp ~working_dir:dir;
+    Discord_agents.Agent_process.setup_gemini_mcp ~working_dir:dir ();
     let settings_path = Filename.concat dir ".gemini/settings.json" in
     Alcotest.(check bool) "settings.json created"
       true (Sys.file_exists settings_path);
@@ -2889,8 +2900,8 @@ let test_setup_gemini_mcp_idempotent () =
     (* Run twice. Second invocation must be a no-op shape: settings
        still has our entry, and the exclude has exactly one .gemini/
        line (not two). *)
-    Discord_agents.Agent_process.setup_gemini_mcp ~working_dir:dir;
-    Discord_agents.Agent_process.setup_gemini_mcp ~working_dir:dir;
+    Discord_agents.Agent_process.setup_gemini_mcp ~working_dir:dir ();
+    Discord_agents.Agent_process.setup_gemini_mcp ~working_dir:dir ();
     let settings = read_all (Filename.concat dir ".gemini/settings.json") in
     let json = Yojson.Safe.from_string settings in
     let open Yojson.Safe.Util in
@@ -2911,6 +2922,67 @@ let test_setup_gemini_mcp_idempotent () =
         1 (List.length gemini_lines);
       ignore (count_substr exclude ".gemini/"))
 
+(* The caller, not just the helper. Both prior rounds were about
+   setup_gemini_mcp's behavior when no MCP server resolved, and neither
+   round's test could reach it — the real value is a memoized global, so
+   reverting the fix left the suite green. ?resolved is the seam. *)
+let test_setup_gemini_mcp_unresolved_withdraws_our_entry () =
+  with_temp_dir (fun dir ->
+    let rc = Sys.command (Printf.sprintf
+      "git init -q -b main %s 2>&1 >/dev/null" (Filename.quote dir)) in
+    Alcotest.(check int) "git init succeeded" 0 rc;
+    let gemini_dir = Filename.concat dir ".gemini" in
+    Unix.mkdir gemini_dir 0o755;
+    let settings_path = Filename.concat gemini_dir "settings.json" in
+    let write path contents =
+      let oc = open_out path in
+      output_string oc contents;
+      close_out oc
+    in
+    write settings_path {|{
+      "mcpServers": {
+        "discord-agents": { "command": "/gone/mcp_server.exe", "args": [] },
+        "user-tool": { "command": "their-cmd", "args": [] }
+      },
+      "theme": "dark"
+    }|};
+    Discord_agents.Agent_process.setup_gemini_mcp
+      ~resolved:None ~working_dir:dir ();
+    let json = Yojson.Safe.from_string (read_all settings_path) in
+    let open Yojson.Safe.Util in
+    let servers = json |> member "mcpServers" |> to_assoc in
+    Alcotest.(check bool) "stale entry removed by the caller"
+      false (List.mem_assoc "discord-agents" servers);
+    Alcotest.(check bool) "user's server survives"
+      true (List.mem_assoc "user-tool" servers);
+    (* A file we can't prove holds our entry is left byte-for-byte. *)
+    let garbage = "not valid json {" in
+    write settings_path garbage;
+    Discord_agents.Agent_process.setup_gemini_mcp
+      ~resolved:None ~working_dir:dir ();
+    Alcotest.(check string) "unparseable settings left untouched"
+      garbage (read_all settings_path))
+
+let test_setup_gemini_mcp_unresolved_touches_nothing_else () =
+  with_temp_dir (fun dir ->
+    let rc = Sys.command (Printf.sprintf
+      "git init -q -b main %s 2>&1 >/dev/null" (Filename.quote dir)) in
+    Alcotest.(check int) "git init succeeded" 0 rc;
+    Discord_agents.Agent_process.setup_gemini_mcp
+      ~resolved:None ~working_dir:dir ();
+    (* With no server to register, creating .gemini/ and adding a
+       .gemini/ line to the user's info/exclude are changes made on
+       their behalf for no benefit — the exclude line would hide their
+       own .gemini/ from git status. *)
+    Alcotest.(check bool) "no .gemini directory created"
+      false (Sys.file_exists (Filename.concat dir ".gemini"));
+    let exclude_path = Filename.concat dir ".git/info/exclude" in
+    let exclude =
+      if Sys.file_exists exclude_path then read_all exclude_path else ""
+    in
+    Alcotest.(check bool) "info/exclude not touched"
+      false (count_substr exclude ".gemini/" > 0))
+
 let test_setup_gemini_mcp_preserves_user_settings () =
   with_temp_dir (fun dir ->
     let rc = Sys.command (Printf.sprintf
@@ -2929,7 +3001,7 @@ let test_setup_gemini_mcp_preserves_user_settings () =
     let oc = open_out settings_path in
     output_string oc user_config;
     close_out oc;
-    Discord_agents.Agent_process.setup_gemini_mcp ~working_dir:dir;
+    Discord_agents.Agent_process.setup_gemini_mcp ~working_dir:dir ();
     let json = Yojson.Safe.from_string (read_all settings_path) in
     let open Yojson.Safe.Util in
     let servers = json |> member "mcpServers" |> to_assoc in
@@ -2953,7 +3025,7 @@ let test_setup_gemini_mcp_fails_closed_on_read_errors () =
     let exclude_path = Filename.concat dir ".git/info/exclude" in
     Sys.remove exclude_path;
     Unix.mkdir exclude_path 0o755;
-    Discord_agents.Agent_process.setup_gemini_mcp ~working_dir:dir;
+    Discord_agents.Agent_process.setup_gemini_mcp ~working_dir:dir ();
     Alcotest.(check bool) "settings path left untouched"
       true (Sys.is_directory settings_path);
     Alcotest.(check bool) "exclude path left untouched"
@@ -3109,6 +3181,10 @@ let resume_helpers_tests = [
     test_mcp_command_resolution;
   Alcotest.test_case "gemini settings withdraw our entry" `Quick
     test_gemini_settings_withdraw_our_entry;
+  Alcotest.test_case "setup_gemini_mcp unresolved withdraws our entry" `Quick
+    test_setup_gemini_mcp_unresolved_withdraws_our_entry;
+  Alcotest.test_case "setup_gemini_mcp unresolved touches nothing else" `Quick
+    test_setup_gemini_mcp_unresolved_touches_nothing_else;
   Alcotest.test_case "merge_gemini_settings invalid input falls back" `Quick
     test_merge_gemini_settings_invalid_input_falls_back;
   Alcotest.test_case "merge_gemini_settings non-object falls back" `Quick

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -2171,43 +2171,69 @@ let test_merge_gemini_settings_overwrites_our_entry () =
    with no discord-agents tools and nothing says so. The assertions
    above compare generated config against [mcp_command ()] itself, so
    they'd pass just as well if it returned nonsense — these don't. *)
-let with_temp_dir name f =
-  let dir =
-    Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "mcp-resolve-%s-%d" name (Unix.getpid ()))
+let with_resolver_temp_dir f =
+  (* Filename.temp_file for the same reason the gemini helper below uses
+     it: a predictable /tmp/<name>-<pid> path is guessable, and a
+     pre-planted symlink there would send the cleanup walk somewhere
+     else entirely. *)
+  let tmp = Filename.temp_file "test_mcp_resolve" "" in
+  Sys.remove tmp;
+  Unix.mkdir tmp 0o755;
+  let rec rm_rf path =
+    if (try Sys.is_directory path with Sys_error _ -> false) then begin
+      (try
+         Array.iter (fun entry -> rm_rf (Filename.concat path entry))
+           (Sys.readdir path)
+       with Sys_error _ -> ());
+      (try Unix.rmdir path with _ -> ())
+    end else (try Sys.remove path with _ -> ())
   in
-  let rec rm path =
-    match Unix.stat path with
-    | { Unix.st_kind = Unix.S_DIR; _ } ->
-      Sys.readdir path
-      |> Array.iter (fun entry -> rm (Filename.concat path entry));
-      Unix.rmdir path
-    | _ -> Sys.remove path
-    | exception Unix.Unix_error _ -> ()
-  in
-  rm dir;
-  Unix.mkdir dir 0o755;
-  Fun.protect ~finally:(fun () -> rm dir) (fun () -> f dir)
+  Fun.protect ~finally:(fun () -> rm_rf tmp) (fun () -> f tmp)
 
 let touch ?(perms=0o755) path =
   let oc = open_out path in
   close_out oc;
   Unix.chmod path perms
 
+let describe_resolution_failure = function
+  | Discord_agents.Agent_process.Override_not_executable path ->
+    Printf.sprintf "override %s not executable" path
+  | Discord_agents.Agent_process.No_candidate_found candidates ->
+    Printf.sprintf "no candidate among [%s]" (String.concat "; " candidates)
+
 let check_resolves label expected actual =
   match actual with
   | Ok path -> Alcotest.(check string) label expected path
-  | Error candidates ->
-    Alcotest.failf "%s: expected %s, got Error [%s]"
-      label expected (String.concat "; " candidates)
+  | Error failure ->
+    Alcotest.failf "%s: expected %s, got Error (%s)"
+      label expected (describe_resolution_failure failure)
 
-let check_unresolved label = function
+(* The two failures are reported differently — one advises `dune build`,
+   the other names the operator's own override — so which one comes back
+   is part of the contract. *)
+let check_override_failure label = function
   | Ok path -> Alcotest.failf "%s: expected Error, resolved to %s" label path
-  | Error _ -> ()
+  | Error (Discord_agents.Agent_process.Override_not_executable _) -> ()
+  | Error other ->
+    Alcotest.failf "%s: expected an override failure, got %s"
+      label (describe_resolution_failure other)
+
+let check_search_failure label = function
+  | Ok path -> Alcotest.failf "%s: expected Error, resolved to %s" label path
+  | Error (Discord_agents.Agent_process.No_candidate_found candidates) ->
+    (* Every ancestor the walk visited must be named, not just the
+       first: a diagnostic listing one of eight paths sends the reader
+       looking in the wrong place. *)
+    Alcotest.(check bool)
+      (label ^ ": names more than the starting directory")
+      true (List.length candidates > 3)
+  | Error other ->
+    Alcotest.failf "%s: expected a search failure, got %s"
+      label (describe_resolution_failure other)
 
 let test_mcp_command_resolution () =
   let resolve = Discord_agents.Agent_process.resolve_mcp_command in
-  with_temp_dir "env" (fun dir ->
+  with_resolver_temp_dir (fun dir ->
     let exe = Filename.concat dir "custom-mcp" in
     touch exe;
     check_resolves "env override wins"
@@ -2218,16 +2244,16 @@ let test_mcp_command_resolution () =
     check_resolves "env override is trimmed"
       exe
       (resolve ~env_override:(Some ("  " ^ exe ^ "  ")) ~exe_dir:dir ~cwd:dir);
-    check_unresolved "env override pointing nowhere"
+    check_override_failure "env override pointing nowhere"
       (resolve ~env_override:(Some (Filename.concat dir "missing"))
          ~exe_dir:dir ~cwd:dir);
     let not_exec = Filename.concat dir "not-exec" in
     touch ~perms:0o644 not_exec;
-    check_unresolved "env override not executable"
+    check_override_failure "env override not executable"
       (resolve ~env_override:(Some not_exec) ~exe_dir:dir ~cwd:dir);
-    check_unresolved "env override is a directory"
+    check_override_failure "env override is a directory"
       (resolve ~env_override:(Some dir) ~exe_dir:dir ~cwd:dir));
-  with_temp_dir "installed" (fun dir ->
+  with_resolver_temp_dir (fun dir ->
     let installed = Filename.concat dir "discord-agents-mcp" in
     touch installed;
     check_resolves "installed name beside the bot"
@@ -2236,13 +2262,13 @@ let test_mcp_command_resolution () =
     check_resolves "empty override falls through to the search"
       installed
       (resolve ~env_override:(Some "   ") ~exe_dir:dir ~cwd:dir));
-  with_temp_dir "dune" (fun dir ->
+  with_resolver_temp_dir (fun dir ->
     let built = Filename.concat dir "mcp_server.exe" in
     touch built;
     check_resolves "dune executable name beside the bot"
       built
       (resolve ~env_override:None ~exe_dir:dir ~cwd:dir));
-  with_temp_dir "upwards" (fun dir ->
+  with_resolver_temp_dir (fun dir ->
     let nested = Filename.concat dir "a/b/c" in
     let build_bin = Filename.concat dir "_build/default/bin" in
     List.iter (fun path ->
@@ -2265,8 +2291,43 @@ let test_mcp_command_resolution () =
        the old resolver answered with a bare name that is on nobody's
        PATH — the silent-no-tools case. *)
     Sys.remove built;
-    check_unresolved "nothing built anywhere"
+    check_search_failure "nothing built anywhere"
       (resolve ~env_override:None ~exe_dir:empty ~cwd:nested))
+
+(* Gemini is the only agent whose MCP config is a file it reads on
+   every run, so "start without MCP" has to mean removing our entry, not
+   just declining to write one — a settings.json written while a build
+   tree existed keeps naming that path after the tree is gone. *)
+let test_gemini_settings_withdraw_our_entry () =
+  let existing = {|{
+    "mcpServers": {
+      "discord-agents": { "command": "/gone/mcp_server.exe", "args": [] },
+      "user-tool": { "command": "their-cmd", "args": [] }
+    },
+    "theme": "dark"
+  }|} in
+  let withdrawn =
+    Discord_agents.Agent_process.gemini_settings_without_our_entry
+      (Some existing)
+  in
+  let json = Yojson.Safe.from_string withdrawn in
+  let open Yojson.Safe.Util in
+  let servers = json |> member "mcpServers" |> to_assoc in
+  Alcotest.(check bool) "our stale entry is gone"
+    false (List.mem_assoc "discord-agents" servers);
+  Alcotest.(check bool) "the user's server survives"
+    true (List.mem_assoc "user-tool" servers);
+  Alcotest.(check bool) "unrelated keys survive"
+    true (List.mem_assoc "theme" (json |> to_assoc));
+  (* Withdrawing from a file that never had our entry is a no-op, and
+     from nothing at all leaves an empty server map rather than an
+     entry pointing nowhere. *)
+  let fresh =
+    Discord_agents.Agent_process.gemini_settings_without_our_entry None
+  in
+  Alcotest.(check int) "nothing registered when starting from nothing"
+    0 (List.length
+         (Yojson.Safe.from_string fresh |> member "mcpServers" |> to_assoc))
 
 let test_merge_gemini_settings_creates_when_absent () =
   let merged = Discord_agents.Agent_process.merge_gemini_settings None in
@@ -3046,6 +3107,8 @@ let resume_helpers_tests = [
     test_merge_gemini_settings_creates_when_absent;
   Alcotest.test_case "MCP command resolution" `Quick
     test_mcp_command_resolution;
+  Alcotest.test_case "gemini settings withdraw our entry" `Quick
+    test_gemini_settings_withdraw_our_entry;
   Alcotest.test_case "merge_gemini_settings invalid input falls back" `Quick
     test_merge_gemini_settings_invalid_input_falls_back;
   Alcotest.test_case "merge_gemini_settings non-object falls back" `Quick

--- a/test/test_mcp_handler.ml
+++ b/test/test_mcp_handler.ml
@@ -77,7 +77,14 @@ let python_tool_command ?(arguments=`Assoc []) ?(merge_stderr=false)
     ^ "lambda method, params=None, timeout=60: response; "
     ^ "sys.stdout.write(ns['handle_tool_call'](sys.argv[3], arguments))"
   in
-  Printf.sprintf "python3 -c %s %s %s %s %s%s"
+  (* PYTHONIOENCODING pins the oracle's stdout codec to strict UTF-8.
+     Without it the ambient environment decides: under PYTHONUTF8=1 (or
+     no locale vars at all) CPython uses the surrogateescape error
+     handler, which round-trips raw invalid bytes back out instead of
+     refusing them — so a test asserting "Python cannot encode this"
+     passes in one shell and fails in another. Strict is also what a
+     real JSON-RPC peer does. *)
+  Printf.sprintf "PYTHONIOENCODING=utf-8 python3 -c %s %s %s %s %s%s"
     (Filename.quote program)
     (Filename.quote script)
     (Filename.quote (Yojson.Safe.to_string response))
@@ -1837,10 +1844,12 @@ let test_handler_recent_sessions_request_control_api () =
     ])
     ~expected_output:"- `abcd1234` 2h ago — /src/repo — checked stack\n\nUse resume_session with kind=gemini to attach."
 
-(* The no-argument call is the common case, and the one place our wire
-   format differs from Python's: we forward an empty params object where
-   [control_request] omits "params" entirely. [Control_api.hours_param]
-   collapses both to the 24h default (pinned in test_control_api). *)
+(* The no-argument call is the common case. We drop the empty arguments
+   object rather than forwarding it, exactly as Python's control_request
+   drops falsy params — the runtime cutover made that difference matter:
+   handlers that read a required field with [to_string] see [{}] as a
+   present-but-empty object and raise a Yojson Type_error instead of
+   returning "missing params". *)
 let test_handler_recent_sessions_empty_arguments () =
   let calls = ref [] in
   let control_client =
@@ -1859,9 +1868,8 @@ let test_handler_recent_sessions_empty_arguments () =
   | [request] ->
     Alcotest.(check string) "method"
       "list_codex_sessions" request.method_name;
-    (match request.params with
-     | Some params -> check_json "params" (`Assoc []) params
-     | None -> failf "expected params")
+    Alcotest.(check bool) "params omitted like Python" true
+      (Option.is_none request.params)
   | calls -> failf "expected one control request, got %d" (List.length calls)
 
 let test_handler_lifecycle_tools_request_control_api () =

--- a/test/test_mcp_handler.ml
+++ b/test/test_mcp_handler.ml
@@ -3,6 +3,7 @@ module Control_client = Discord_agents.Control_client
 module Mcp_formatter = Discord_agents.Mcp_formatter
 module Mcp_handler = Discord_agents.Mcp_handler
 module Mcp_server = Discord_agents.Mcp_server
+module Mcp_tool = Discord_agents.Mcp_tool
 
 let failf fmt = Format.kasprintf (fun message -> Alcotest.fail message) fmt
 
@@ -2194,6 +2195,25 @@ let test_handler_unsupported_tool () =
     (Error "OCaml MCP tools/call is not wired yet for tool: not_a_tool")
     (Mcp_handler.handle_tool_call ~control_client call)
 
+let test_all_mcp_tools_are_wired () =
+  Mcp_tool.all_specs
+  |> List.iter (fun spec ->
+    let tool_name = Mcp_tool.tool_name spec in
+    let calls = ref 0 in
+    let control_client =
+      Control_client.make ~request:(fun _request ->
+        incr calls;
+        Error "wired")
+    in
+    let call = { Mcp_server.name = tool_name; arguments = `Assoc [] } in
+    Alcotest.(check (result string string))
+      (tool_name ^ " dispatch")
+      (Error "wired")
+      (Mcp_handler.handle_tool_call ~control_client call);
+    Alcotest.(check bool)
+      (tool_name ^ " called control API")
+      true (!calls > 0))
+
 let test_server_wraps_list_projects_result () =
   let control_client =
     Control_client.make ~request:(fun _request ->
@@ -2620,6 +2640,8 @@ let () =
         test_handler_covers_every_advertised_tool;
       Alcotest.test_case "unsupported tool" `Quick
         test_handler_unsupported_tool;
+      Alcotest.test_case "all MCP tools are wired" `Quick
+        test_all_mcp_tools_are_wired;
       Alcotest.test_case "server wraps list_projects result" `Quick
         test_server_wraps_list_projects_result;
       Alcotest.test_case "server wraps list_projects control error" `Quick


### PR DESCRIPTION
## Summary
- install the OCaml MCP stdio server as discord-agents-mcp and point generated Claude/Codex/Gemini MCP configs at it
- add all-tools-wired coverage for MCP handler dispatch
- update repo docs/sample config and mark the Python shim as compatibility/parity only

## Tests
- nix develop --command dune exec ./test/test_mcp_handler.exe
- nix develop --command dune runtest
- nix build
- git diff --check
- printf initialize | nix develop --command dune exec discord-agents-mcp

Stack: 5/5 for the MCP Python-to-OCaml port. Base PR: #100.