### PR TITLE
Re-resolve the MCP command per spawn instead of once at boot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,8 @@ All three regenerate their config on every spawn, so a stale `mcp-generated.json
 
 `Agent_process.resolve_mcp_command` looks, in order, at `DISCORD_AGENTS_MCP_COMMAND`, then `discord-agents-mcp` and `mcp_server.exe` beside the running bot, then `_build/default/bin/mcp_server.exe` walking up from the working directory. Each candidate must be an executable regular file, not merely present.
 
+Resolution runs on every session spawn, not once at startup, so building the server under a running bot takes effect on the next session — and deleting it (a `dune clean`, a removed worktree) is noticed rather than cached. The log stays quiet unless the answer changes.
+
 **`dune exec discord-agents` does not build the MCP server** — it builds only the executable you named. Run `dune build` first (the documented run commands and `scripts/run-branch.sh` do). If nothing resolves, the bot logs an error naming every path it tried and starts sessions *without* MCP config rather than pointing an agent at a command that isn't there; the agent then simply has no `discord-agents` tools.
 
 The pre-cutover `DISCORD_AGENTS_MCP_SCRIPT` is no longer read. Setting it logs a warning telling you to use `DISCORD_AGENTS_MCP_COMMAND`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ All three regenerate their config on every spawn, so a stale `mcp-generated.json
 
 `Agent_process.resolve_mcp_command` looks, in order, at `DISCORD_AGENTS_MCP_COMMAND`, then `discord-agents-mcp` and `mcp_server.exe` beside the running bot, then `_build/default/bin/mcp_server.exe` walking up from the working directory. Each candidate must be an executable regular file, not merely present.
 
-Resolution runs on every session spawn, not once at startup, so building the server under a running bot takes effect on the next session — and deleting it (a `dune clean`, a removed worktree) is noticed rather than cached. The log stays quiet unless the answer changes.
+Resolution runs on every agent spawn — which is every message, not every session — rather than once at startup, so building the server under a running bot takes effect on the next turn — and deleting it (a `dune clean`, a removed worktree) is noticed rather than cached. The log stays quiet unless the answer changes.
 
 **`dune exec discord-agents` does not build the MCP server** — it builds only the executable you named. Run `dune build` first (the documented run commands and `scripts/run-branch.sh` do). If nothing resolves, the bot logs an error naming every path it tried and starts sessions *without* MCP config rather than pointing an agent at a command that isn't there; the agent then simply has no `discord-agents` tools.
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -126,14 +126,14 @@ let () =
     | _ -> None
   in
   Logs.info (fun m -> m "discord-agents starting%s" (if test_mode then " (test mode)" else ""));
-  (* Resolve the MCP server now rather than lazily at the first session
-     spawn: an operator who launched without building wants to hear it
-     at boot, in the log they are already looking at, not one line
-     buried in a session's output an hour later. Memoized, so the spawn
-     path reuses this. *)
-  (match Discord_agents.Agent_process.mcp_command_opt () with
-   | Some path -> Logs.info (fun m -> m "MCP server: %s" path)
-   | None -> ()  (* resolution already logged the error and why *));
+  (* Resolve once at boot so an operator who launched without building
+     hears it in the log they are already looking at, rather than one
+     line buried in a session's output an hour later. Resolution is
+     repeated per spawn, so this is a report, not a decision — and it
+     primes the change-detection that keeps the per-spawn logging quiet
+     while the answer stays the same. *)
+  ignore (Discord_agents.Agent_process.mcp_command_opt ());
+  Discord_agents.Agent_process.warn_if_deprecated_mcp_script_env ();
   Random.self_init ();  (* Seed PRNG for heartbeat jitter *)
   let config =
     match Discord_agents.Config.load_result () with

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1325,8 +1325,8 @@ let log_mcp_resolution result =
 
    Cost is a handful of [stat] calls per agent spawn — which is per
    turn, not per session, since every message spawns a fresh agent
-   process. Still a few syscalls against the local disk, next to a
-   [git] subprocess already forked on the same path. Logging is
+   process. Still a few local-disk syscalls beside the PATH walk and
+   process spawn every turn already pays for. Logging is
    suppressed unless the answer changed, so steady state is silent and
    each transition gets exactly one line. *)
 let current_mcp_command () =

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1280,7 +1280,53 @@ let resolve_mcp_command ~env_override ~exe_dir ~cwd =
           in
           Error (No_candidate_found (siblings @ ancestors cwd []))))
 
-let mcp_command_result = lazy (
+(* Last resolution we logged about, so steady state stays quiet while
+   every transition gets one line. [None] before the first resolve. *)
+let last_logged_mcp_resolution :
+  (string, mcp_resolution_failure) result option ref = ref None
+
+let log_mcp_resolution result =
+  let same =
+    match !last_logged_mcp_resolution, result with
+    | Some (Ok previous), Ok current -> String.equal previous current
+    | Some (Error (Override_not_executable a)),
+      Error (Override_not_executable b) -> String.equal a b
+    | Some (Error (No_candidate_found _)), Error (No_candidate_found _) -> true
+    | _ -> false
+  in
+  if not same then begin
+    last_logged_mcp_resolution := Some result;
+    match result with
+    | Ok path -> Logs.info (fun m -> m "MCP server: %s" path)
+    | Error (Override_not_executable path) ->
+      (* Don't advise `dune build` at someone who told us exactly where
+         to look; the problem is that path, not a missing build. *)
+      Logs.err (fun m ->
+        m "DISCORD_AGENTS_MCP_COMMAND=%s is not an executable file; \
+           agents will start with no discord-agents tools." path)
+    | Error (No_candidate_found candidates) ->
+      Logs.err (fun m ->
+        m "MCP server executable not found; agents will start with no \
+           discord-agents tools. Tried: %s. Build it with `dune build` \
+           (plain `dune exec discord-agents` does not build sibling \
+           executables), or set DISCORD_AGENTS_MCP_COMMAND to its path."
+          (String.concat ", " candidates))
+  end
+
+(* Resolved fresh on every session spawn rather than memoized at boot.
+   The path normally lives in _build, so a `dune clean`, a removed
+   worktree, or a deleted _build under a running bot would otherwise
+   leave a cached [Ok path] naming a command that no longer exists —
+   agents spawn with a config pointing at nothing, the failure happens
+   inside the agent where we never see it, and none of the degrade
+   paths below can fire. It reads the other way too: build the server
+   after starting the bot and the next session picks it up, instead of
+   the boot-time failure persisting until restart.
+
+   Cost is a handful of [stat] calls per session start. Logging is
+   suppressed unless the answer changed, so steady state is silent and
+   each transition gets exactly one line. *)
+let current_mcp_command () =
   let exe_dir =
     try Sys.executable_name |> absolute_path |> Filename.dirname
     with _ -> Filename.current_dir_name
@@ -1291,62 +1337,45 @@ let mcp_command_result = lazy (
       ~env_override:(Sys.getenv_opt "DISCORD_AGENTS_MCP_COMMAND")
       ~exe_dir ~cwd
   in
-  (match result with
-   | Ok _ -> ()
-   | Error (Override_not_executable path) ->
-     (* Don't advise `dune build` at someone who told us exactly where
-        to look; the problem is that path, not a missing build. *)
-     Logs.err (fun m ->
-       m "DISCORD_AGENTS_MCP_COMMAND=%s is not an executable file; \
-          agents will start with no discord-agents tools." path)
-   | Error (No_candidate_found candidates) ->
-     Logs.err (fun m ->
-       m "MCP server executable not found; agents will start with no \
-          discord-agents tools. Tried: %s. Build it with `dune build` \
-          (plain `dune exec discord-agents` does not build sibling \
-          executables), or set DISCORD_AGENTS_MCP_COMMAND to its path."
-         (String.concat ", " candidates)));
-  (* The old override named a Python script and was silently ignored
-     after the cutover, which lands the operator in exactly the
-     no-tools state above. Say so rather than let them find out from an
-     agent that quietly has no tools. *)
-  (match Sys.getenv_opt "DISCORD_AGENTS_MCP_SCRIPT" with
-   | Some value when String.trim value <> "" ->
-     Logs.warn (fun m ->
-       m "DISCORD_AGENTS_MCP_SCRIPT=%s is no longer used; the MCP server \
-          is now a native executable. Set DISCORD_AGENTS_MCP_COMMAND \
-          instead — it accepts scripts/mcp-server.py directly if you \
-          need to roll back to the Python server." value)
-   | _ -> ());
+  log_mcp_resolution result;
   result
-)
 
 let mcp_command_opt () =
-  match Lazy.force mcp_command_result with
+  match current_mcp_command () with
   | Ok path -> Some path
   | Error _ -> None
 
-(* Kept for the config writers that already ran the [mcp_command_opt]
-   check; never reached with an unresolved command. *)
-let mcp_command () =
-  match Lazy.force mcp_command_result with
-  | Ok path -> path
-  | Error _ -> "discord-agents-mcp"
+(* The old override named a Python script and is silently ignored after
+   the cutover, which lands the operator in the no-tools state above.
+   Startup-only: it describes the environment, not the build, so
+   repeating it per spawn would be noise. *)
+let warn_if_deprecated_mcp_script_env () =
+  match Sys.getenv_opt "DISCORD_AGENTS_MCP_SCRIPT" with
+  | Some value when String.trim value <> "" ->
+    Logs.warn (fun m ->
+      m "DISCORD_AGENTS_MCP_SCRIPT=%s is no longer used; the MCP server \
+         is now a native executable. Set DISCORD_AGENTS_MCP_COMMAND \
+         instead — it accepts scripts/mcp-server.py directly if you \
+         need to roll back to the Python server." value)
+  | _ -> ()
 
-let mcp_server_entry () =
+(* [~command] rather than a second lookup: with resolution no longer
+   memoized, a writer that re-resolved could disagree with the check
+   that let it run, and the disagreement would be written into a
+   config file. Passing the resolved path makes that unrepresentable. *)
+let mcp_server_entry ~command =
   `Assoc [
-    ("command", `String (mcp_command ()));
+    ("command", `String command);
     ("args", `List []);
   ]
 
-let mcp_json = lazy (
+let mcp_json ~command =
   Yojson.Safe.to_string
     (`Assoc [
       ("mcpServers", `Assoc [
-        ("discord-agents", mcp_server_entry ());
+        ("discord-agents", mcp_server_entry ~command);
       ]);
     ])
-)
 
 let write_file_safely ~path contents =
   match Disk_health.preflight_write path with
@@ -1411,10 +1440,10 @@ let contains_substring text needle =
 let claude_mcp_config_path () =
   match mcp_command_opt () with
   | None -> None
-  | Some _ ->
+  | Some command ->
     let config_dir = Resource.app_config_dir () in
     let config_path = Filename.concat config_dir "mcp-generated.json" in
-    write_file_safely ~path:config_path (Lazy.force mcp_json);
+    write_file_safely ~path:config_path (mcp_json ~command);
     (* [write_file_safely] swallows both a disk-preflight refusal and a
        write exception, so "we tried" is not "there is a file". Claude
        does not degrade when --mcp-config names a missing file, it exits
@@ -1428,7 +1457,7 @@ let claude_mcp_config_path () =
        which is the silent-no-tools failure this PR is closing. A
        directory at that path would also satisfy [Sys.file_exists] and
        then make Claude exit 1. *)
-    let intended = Lazy.force mcp_json in
+    let intended = mcp_json ~command in
     match read_file_result config_path with
     (* Trimmed, because the comparison is with the file the writer
        produced, not with the string handed to it: write_file_atomic
@@ -1489,8 +1518,8 @@ let gemini_settings_with ~our_entry existing =
       | _ -> render_fresh ()  (* parseable but non-object: discard *)
     with _ -> render_fresh ()
 
-let merge_gemini_settings existing =
-  gemini_settings_with ~our_entry:(Some (mcp_server_entry ())) existing
+let merge_gemini_settings ~command existing =
+  gemini_settings_with ~our_entry:(Some (mcp_server_entry ~command)) existing
 
 (* [None] means "leave the file exactly as it is".
 
@@ -1583,10 +1612,11 @@ let merge_gemini_exclude existing =
     repo's [info/exclude]. Both writes are idempotent — re-running
     against a worktree we've already configured leaves the file and
     the exclude line unchanged in shape. *)
-(* [?resolved] exists so the unresolved branch is reachable from a
-   test: the real value is a process-global memoized lazy, so without a
-   seam here nothing could exercise the very path the last two review
-   rounds were about. *)
+(* [?resolved] exists so the unresolved branch is reachable from a test
+   without arranging for the real resolution to fail. It also pins the
+   answer for the duration of one call: resolving once here and using
+   that value throughout means the withdraw/register decision and the
+   command written into the file can't come from two different lookups. *)
 let setup_gemini_mcp ?resolved ~working_dir () =
   let resolved =
     match resolved with Some r -> r | None -> mcp_command_opt ()
@@ -1615,17 +1645,18 @@ let setup_gemini_mcp ?resolved ~working_dir () =
        (match gemini_settings_without_our_entry (Some existing) with
         | None -> ()
         | Some updated -> write_file_safely ~path:settings_path updated))
-  | Some _ ->
+  | Some command ->
   (try
      if not (Sys.file_exists gemini_dir) then Unix.mkdir gemini_dir 0o755
    with _ -> ());
   (match read_file_result settings_path with
    | File_read_error exn -> log_file_read_failure ~path:settings_path exn
    | File_missing ->
-     write_file_safely ~path:settings_path (merge_gemini_settings None)
+     write_file_safely ~path:settings_path
+       (merge_gemini_settings ~command None)
    | File_contents existing ->
      write_file_safely ~path:settings_path
-       (merge_gemini_settings (Some existing)));
+       (merge_gemini_settings ~command (Some existing)));
   match resolve_git_info_exclude ~working_dir with
   | None -> ()
   | Some exclude_path ->

--- a/lib/agent_process.ml
+++ b/lib/agent_process.ml
@@ -1323,7 +1323,10 @@ let log_mcp_resolution result =
    after starting the bot and the next session picks it up, instead of
    the boot-time failure persisting until restart.
 
-   Cost is a handful of [stat] calls per session start. Logging is
+   Cost is a handful of [stat] calls per agent spawn — which is per
+   turn, not per session, since every message spawns a fresh agent
+   process. Still a few syscalls against the local disk, next to a
+   [git] subprocess already forked on the same path. Logging is
    suppressed unless the answer changed, so steady state is silent and
    each transition gets exactly one line. *)
 let current_mcp_command () =

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -2353,18 +2353,23 @@ let test_gemini_settings_withdraw_our_entry () =
     (Some {|{"mcpServers":{"user-tool":{"command":"x"}},
              "mcpServers":{"discord-agents":{"command":"/gone"}}}|})
 
-(* Two properties, both needed. That the command is a real executable —
-   comparing it against the same function that produced it would pass
-   even if that function returned nonsense. And that it is preceded by
-   its own -c: Codex parses each -c independently, so an override that
-   loses its flag becomes a stray positional Codex ignores, and the
-   session starts with no discord-agents tools with nothing failing. *)
+(* Extract the MCP command Codex is actually told, insisting it is
+   preceded by its own -c. Codex parses each -c independently, so an
+   override that loses its flag becomes a stray positional it ignores,
+   and the session starts with no discord-agents tools with nothing
+   failing. [check_codex_mcp_command_is_real] below adds the other half
+   — that the extracted path is a real executable. *)
 let codex_mcp_command_override args =
   let prefix = {|mcp_servers.discord_agents.command="|} in
   let rec scan = function
     | "-c" :: value :: rest when String.starts_with ~prefix value ->
       let start = String.length prefix in
-      String.sub value start (String.length value - start - 1) :: scan rest
+      (* A value that is the bare prefix with no closing quote would
+         make String.sub raise; say what happened instead. *)
+      if String.length value <= start then
+        Alcotest.failf "malformed MCP command override: %s" value
+      else
+        String.sub value start (String.length value - start - 1) :: scan rest
     | value :: _ when String.starts_with ~prefix value ->
       Alcotest.failf "MCP command override is not preceded by -c: %s" value
     | _ :: rest -> scan rest

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -2173,9 +2173,7 @@ let test_merge_gemini_settings_overwrites_our_entry () =
 
 (* The resolver decides where all three agents look for the MCP server,
    and every wrong answer fails the same silent way: the agent starts
-   with no discord-agents tools and nothing says so. The assertions
-   above compare generated config against [mcp_command ()] itself, so
-   they'd pass just as well if it returned nonsense — these don't. *)
+   with no discord-agents tools and nothing says so. *)
 let with_resolver_temp_dir f =
   (* Filename.temp_file for the same reason the gemini helper below uses
      it: a predictable /tmp/<name>-<pid> path is guessable, and a
@@ -2355,6 +2353,25 @@ let test_gemini_settings_withdraw_our_entry () =
     (Some {|{"mcpServers":{"user-tool":{"command":"x"}},
              "mcpServers":{"discord-agents":{"command":"/gone"}}}|})
 
+(* Two properties, both needed. That the command is a real executable —
+   comparing it against the same function that produced it would pass
+   even if that function returned nonsense. And that it is preceded by
+   its own -c: Codex parses each -c independently, so an override that
+   loses its flag becomes a stray positional Codex ignores, and the
+   session starts with no discord-agents tools with nothing failing. *)
+let codex_mcp_command_override args =
+  let prefix = {|mcp_servers.discord_agents.command="|} in
+  let rec scan = function
+    | "-c" :: value :: rest when String.starts_with ~prefix value ->
+      let start = String.length prefix in
+      String.sub value start (String.length value - start - 1) :: scan rest
+    | value :: _ when String.starts_with ~prefix value ->
+      Alcotest.failf "MCP command override is not preceded by -c: %s" value
+    | _ :: rest -> scan rest
+    | [] -> []
+  in
+  scan args
+
 (* The point of #112: resolution is re-run per spawn, not memoized at
    boot. A `dune clean` or a removed worktree under a running bot used
    to leave a cached Ok path naming a command that no longer exists,
@@ -2369,6 +2386,12 @@ let test_mcp_command_is_not_memoized () =
     let restore () =
       match saved with
       | Some v -> Unix.putenv "DISCORD_AGENTS_MCP_COMMAND" v
+      (* OCaml has no unsetenv, so an originally-unset variable comes
+         back blank rather than absent. Safe only because
+         resolve_mcp_command trims and falls through on a blank
+         override — the later setup_gemini_mcp_e2e cases do real
+         resolution and would resolve nothing if that changed. If blank
+         ever becomes an Error, those break, and this is why. *)
       | None -> Unix.putenv "DISCORD_AGENTS_MCP_COMMAND" ""
     in
     Unix.putenv "DISCORD_AGENTS_MCP_COMMAND" exe;
@@ -2390,7 +2413,23 @@ let test_mcp_command_is_not_memoized () =
       Alcotest.(check (option string))
         "resolves again once it is rebuilt"
         (Some exe)
-        (Discord_agents.Agent_process.mcp_command_opt ())))
+        (Discord_agents.Agent_process.mcp_command_opt ());
+      (* And at a spawn path, not only at the entry point: a cache
+         reintroduced at any individual call site would be invisible to
+         the assertions above. *)
+      let overrides_now () =
+        codex_mcp_command_override
+          (Discord_agents.Agent_process.codex_args
+             ~model:None ~reasoning_effort:None
+             ~session_id:"x" ~session_id_confirmed:false ~prompt:"hi")
+      in
+      Alcotest.(check (list string))
+        "codex is told the command while it exists"
+        [exe] (overrides_now ());
+      Sys.remove exe;
+      Alcotest.(check (list string))
+        "codex is told nothing once it is gone"
+        [] (overrides_now ())))
 
 let test_merge_gemini_settings_creates_when_absent () =
   let merged = Discord_agents.Agent_process.merge_gemini_settings ~command:test_mcp_command None in
@@ -3398,24 +3437,18 @@ let test_codex_args_dash_prompt_safe () =
   Alcotest.(check (option (pair string string)))
     "prompt sits after --" (Some ("--", "--help me")) (last_two args)
 
-(* Assert Codex is pointed at a command that actually exists, rather
-   than at whatever the resolver just returned — comparing the argument
-   against the same function that produced it would pass even if that
-   function returned nonsense. *)
 let check_codex_mcp_command_is_real args =
-  let prefix = {|mcp_servers.discord_agents.command="|} in
-  let overrides =
-    List.filter (fun arg -> String.starts_with ~prefix arg) args
-  in
-  match overrides with
-  | [override] ->
-    let start = String.length prefix in
-    let path =
-      String.sub override start (String.length override - start - 1)
-    in
+  match codex_mcp_command_override args with
+  | [path] ->
     Alcotest.(check bool)
-      (Printf.sprintf "codex MCP command exists: %s" path)
-      true (Sys.file_exists path)
+      (Printf.sprintf "codex MCP command is executable: %s" path)
+      true
+      (match Unix.stat path with
+       | { Unix.st_kind = Unix.S_REG; _ } ->
+         (try Unix.access path [Unix.X_OK]; true
+          with Unix.Unix_error _ -> false)
+       | _ -> false
+       | exception Unix.Unix_error _ -> false)
   | overrides ->
     Alcotest.failf "expected exactly one MCP command override, got %d"
       (List.length overrides)

--- a/test/test_formatting.ml
+++ b/test/test_formatting.ml
@@ -2134,12 +2134,17 @@ let test_resume_not_found_codex_uniform () =
 let test_resume_not_found_gemini_includes_sid () =
   test_resume_not_found_names_kind_and_sid Discord_agents.Config.Gemini "gemini"
 
+(* A command the test supplies rather than one it looks up: these
+   assertions are about the merge, not about where the executable
+   happens to live in this build. *)
+let test_mcp_command = "/opt/discord-agents/bin/discord-agents-mcp"
+
 let test_merge_gemini_settings_preserves_other_servers () =
   let existing = Some {|{
     "mcpServers": { "user-tool": { "command": "foo", "args": [] } },
     "theme": "dark"
   }|} in
-  let merged = Discord_agents.Agent_process.merge_gemini_settings existing in
+  let merged = Discord_agents.Agent_process.merge_gemini_settings ~command:test_mcp_command existing in
   let json = Yojson.Safe.from_string merged in
   let open Yojson.Safe.Util in
   let servers = json |> member "mcpServers" |> to_assoc in
@@ -2154,7 +2159,7 @@ let test_merge_gemini_settings_overwrites_our_entry () =
   let existing = Some {|{
     "mcpServers": { "discord-agents": { "command": "stale", "args": [] } }
   }|} in
-  let merged = Discord_agents.Agent_process.merge_gemini_settings existing in
+  let merged = Discord_agents.Agent_process.merge_gemini_settings ~command:test_mcp_command existing in
   let json = Yojson.Safe.from_string merged in
   let open Yojson.Safe.Util in
   let our_cmd = json |> member "mcpServers" |> member "discord-agents"
@@ -2162,7 +2167,7 @@ let test_merge_gemini_settings_overwrites_our_entry () =
   let our_args = json |> member "mcpServers" |> member "discord-agents"
                  |> member "args" |> to_list in
   Alcotest.(check string) "stale entry replaced with current MCP command"
-    (Discord_agents.Agent_process.mcp_command ()) our_cmd;
+    test_mcp_command our_cmd;
   Alcotest.(check int) "OCaml MCP server has no wrapper args"
     0 (List.length our_args)
 
@@ -2350,8 +2355,45 @@ let test_gemini_settings_withdraw_our_entry () =
     (Some {|{"mcpServers":{"user-tool":{"command":"x"}},
              "mcpServers":{"discord-agents":{"command":"/gone"}}}|})
 
+(* The point of #112: resolution is re-run per spawn, not memoized at
+   boot. A `dune clean` or a removed worktree under a running bot used
+   to leave a cached Ok path naming a command that no longer exists,
+   with every degrade path unreachable because nothing re-checked. This
+   drives the real entry point (mcp_command_opt) through the
+   DISCORD_AGENTS_MCP_COMMAND override, which is the one branch a test
+   can control. *)
+let test_mcp_command_is_not_memoized () =
+  with_resolver_temp_dir (fun dir ->
+    let exe = Filename.concat dir "mcp-probe" in
+    let saved = Sys.getenv_opt "DISCORD_AGENTS_MCP_COMMAND" in
+    let restore () =
+      match saved with
+      | Some v -> Unix.putenv "DISCORD_AGENTS_MCP_COMMAND" v
+      | None -> Unix.putenv "DISCORD_AGENTS_MCP_COMMAND" ""
+    in
+    Unix.putenv "DISCORD_AGENTS_MCP_COMMAND" exe;
+    Fun.protect ~finally:restore (fun () ->
+      touch exe;
+      Alcotest.(check (option string))
+        "resolves while the executable is there"
+        (Some exe)
+        (Discord_agents.Agent_process.mcp_command_opt ());
+      (* The dune clean case. *)
+      Sys.remove exe;
+      Alcotest.(check (option string))
+        "stops resolving once it is gone"
+        None
+        (Discord_agents.Agent_process.mcp_command_opt ());
+      (* And back again — building the server after the bot started
+         should not require a restart. *)
+      touch exe;
+      Alcotest.(check (option string))
+        "resolves again once it is rebuilt"
+        (Some exe)
+        (Discord_agents.Agent_process.mcp_command_opt ())))
+
 let test_merge_gemini_settings_creates_when_absent () =
-  let merged = Discord_agents.Agent_process.merge_gemini_settings None in
+  let merged = Discord_agents.Agent_process.merge_gemini_settings ~command:test_mcp_command None in
   let json = Yojson.Safe.from_string merged in
   let open Yojson.Safe.Util in
   Alcotest.(check bool) "creates mcpServers with our entry"
@@ -2359,7 +2401,7 @@ let test_merge_gemini_settings_creates_when_absent () =
             (json |> member "mcpServers" |> to_assoc))
 
 let test_merge_gemini_settings_invalid_input_falls_back () =
-  let merged = Discord_agents.Agent_process.merge_gemini_settings
+  let merged = Discord_agents.Agent_process.merge_gemini_settings ~command:test_mcp_command
     (Some "not valid json {") in
   let json = Yojson.Safe.from_string merged in
   let open Yojson.Safe.Util in
@@ -3205,7 +3247,7 @@ let test_merge_gemini_settings_non_object_falls_back () =
   (* Parseable JSON that isn't an object — list, scalar — would
      round-trip unchanged under naive logic, dropping our MCP entry. *)
   List.iter (fun text ->
-    let merged = Discord_agents.Agent_process.merge_gemini_settings
+    let merged = Discord_agents.Agent_process.merge_gemini_settings ~command:test_mcp_command
       (Some text) in
     let json = Yojson.Safe.from_string merged in
     let open Yojson.Safe.Util in
@@ -3228,6 +3270,8 @@ let resume_helpers_tests = [
     test_merge_gemini_settings_creates_when_absent;
   Alcotest.test_case "MCP command resolution" `Quick
     test_mcp_command_resolution;
+  Alcotest.test_case "MCP command is not memoized" `Quick
+    test_mcp_command_is_not_memoized;
   Alcotest.test_case "gemini settings withdraw our entry" `Quick
     test_gemini_settings_withdraw_our_entry;
   Alcotest.test_case "setup_gemini_mcp unresolved withdraws our entry" `Quick
@@ -3354,19 +3398,35 @@ let test_codex_args_dash_prompt_safe () =
   Alcotest.(check (option (pair string string)))
     "prompt sits after --" (Some ("--", "--help me")) (last_two args)
 
+(* Assert Codex is pointed at a command that actually exists, rather
+   than at whatever the resolver just returned — comparing the argument
+   against the same function that produced it would pass even if that
+   function returned nonsense. *)
+let check_codex_mcp_command_is_real args =
+  let prefix = {|mcp_servers.discord_agents.command="|} in
+  let overrides =
+    List.filter (fun arg -> String.starts_with ~prefix arg) args
+  in
+  match overrides with
+  | [override] ->
+    let start = String.length prefix in
+    let path =
+      String.sub override start (String.length override - start - 1)
+    in
+    Alcotest.(check bool)
+      (Printf.sprintf "codex MCP command exists: %s" path)
+      true (Sys.file_exists path)
+  | overrides ->
+    Alcotest.failf "expected exactly one MCP command override, got %d"
+      (List.length overrides)
+
 let test_codex_args_includes_mcp_overrides () =
   (* Codex sessions should expose the bot's MCP tools the same way
      Claude (--mcp-config) and Gemini (.gemini/settings.json) do.
      Two -c overrides register the discord-agents server. *)
   let args = codex_args ~session_id:"x" ~session_id_confirmed:false
     ~prompt:"hi" in
-  let command_override =
-    Printf.sprintf {|mcp_servers.discord_agents.command="%s"|}
-      (Discord_agents.Agent_process.escape_toml_string
-         (Discord_agents.Agent_process.mcp_command ()))
-  in
-  Alcotest.(check bool) "registers discord_agents.command"
-    true (contains_pair args "-c" command_override);
+  check_codex_mcp_command_is_real args;
   Alcotest.(check bool) "registers discord_agents.args" true
     (contains_pair args "-c" {|mcp_servers.discord_agents.args=[]|})
 
@@ -3374,13 +3434,7 @@ let test_codex_args_resume_keeps_mcp () =
   (* Resuming a Codex session should still expose MCP tools. *)
   let args = codex_args ~session_id:"x" ~session_id_confirmed:true
     ~prompt:"hi" in
-  let command_override =
-    Printf.sprintf {|mcp_servers.discord_agents.command="%s"|}
-      (Discord_agents.Agent_process.escape_toml_string
-         (Discord_agents.Agent_process.mcp_command ()))
-  in
-  Alcotest.(check bool) "MCP override present on resume too"
-    true (contains_pair args "-c" command_override)
+  check_codex_mcp_command_is_real args
 
 let test_codex_args_model_and_effort_overrides () =
   let args = Discord_agents.Agent_process.codex_args


### PR DESCRIPTION
Fixes https://github.com/tedks/discord-agents/issues/112, found by the full-stack council pass over the completed MCP port.

`mcp_command_result` was a memoized `lazy` forced at startup — `is_executable_file` ran exactly once per process. The resolved path normally lives in `_build`, so **`dune clean`, a removed worktree, or a deleted `_build` under a running bot left a cached `Ok path` naming a command that no longer exists.** Every later spawn handed all three agents a config pointing at nothing, the failure happened inside the agent where the bot never sees it, and none of the degrade paths #101 built could fire because nothing re-checked.

That's the same silent-no-tools state #101 spent four review rounds closing, relocated from "never resolved" to "resolved, then vanished" — and `dune clean` in the worktree you're running from is a normal thing to do mid-development.

It reads the other way too: build the server *after* starting the bot and the next session picks it up, where before the boot-time failure persisted until restart.

## What changed

Resolution runs per session spawn. Cost is a handful of `stat` calls at session start. Logging is suppressed unless the answer changed, so steady state is silent and each transition — resolved, vanished, different path, rebuilt — gets exactly one line. `bin/main.ml` still resolves at boot, but as a *report* rather than a decision; it primes the change detection so the first spawn doesn't repeat what startup already said.

**Threading the resolved command through the writers is no longer optional.** With resolution memoized, `mcp_server_entry` could look it up again and be guaranteed the same answer. Without memoization, a writer that re-resolved could disagree with the check that let it run — and the disagreement would be *written into a config file*, including the bare `discord-agents-mcp` fallback that nothing installs on PATH. So `mcp_server_entry`, `mcp_json` and `merge_gemini_settings` take `~command`, and each caller resolves once and passes it down. Round 5 of #101 deferred this refactor as unnecessary; this change is what makes it necessary.

## Tests

The new case drives the real entry point through the env override — present, deleted, restored — and **fails if memoization is reintroduced** (verified by doing exactly that).

Two pre-existing codex assertions compared the generated override against the same function that produced it, so they'd have passed had it returned nonsense; they now assert the command is a path that exists. The gemini merge tests take a fixture command instead of asking the resolver, which also makes them independent of the build layout.

`dune build`, `dune runtest` green — 537 assertions.